### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ $ git clone https://github.com/fatih/vim-go.git
 ```
 
 For the first Vim start it will try to download and install all necessary go
-binaries. To disable this behabeviour please check out
+binaries. To disable this behaviour please check out
 [settings](#settings).
 
 Autocompletion is enabled by default via `<C-x><C-o>`, to get real-time

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -52,7 +52,7 @@ If you use pathogen, just clone it into your bundle directory: >
 	$ git clone https://github.com/fatih/vim-go.git
 <
 For the first Vim start it will try to download and install all necessary go
-binaries. To disable this behabeviour please check out |go-settings|.
+binaries. To disable this behaviour please check out |go-settings|.
 
 Autocompletion is enabled by default via `<C-x><C-o>`, to get real-time
 completion (completion by type) install YCM: >


### PR DESCRIPTION
Just a typo I found while reading the docs.

In the README there is a _seperate different_. There's a typo there too but I'd go for removing the seperate completely as it feels redundant. If you want I can add a commit (or amend this one) to remove it.
