### PR TITLE
improve GoOracle automatic scope handling

### DIFF
--- a/plugin/oracle.vim
+++ b/plugin/oracle.vim
@@ -52,11 +52,14 @@ endfun
 
 func! s:RunOracle(mode, selected) range abort
   let fname = expand('%:p')
-  let pkg = go#package#ImportPath(getcwd())
-  if pkg != -1
-    let sname = pkg
+  let dname = expand('%:p:h')
+  let pkg = go#package#ImportPath(dname)
+  if exists('g:go_oracle_scope_file')
+    let sname = get(g:, 'go_oracle_scope_file')
+  elseif pkg != -1
+     let sname = pkg
   else
-    let sname = get(g:, 'go_oracle_scope_file', fname)
+    let sname = fname
   endif
 
   if a:selected != -1


### PR DESCRIPTION
1) if g:go_oracle_scope_file is defined use it 
2) otherwise use package import path from currently opened file (won't work if file is not under $GOROOT or $GOPATH)
3) fallback to currently opened file

1) is handy when used with vim-localvimrc to setup scope for each go project
2) would work better if it was finding all packages of the currently opened file's workspace as there can be more than one package in the scope, and there must be at least one main function (my nascent vim-scripts skills are reaching their limit there!)
