### PR TITLE
improve syntax highlighting for godoc

### DIFF
--- a/syntax/godoc.vim
+++ b/syntax/godoc.vim
@@ -7,13 +7,40 @@ if exists("b:current_syntax")
 endif
 
 syn case match
-syn match  godocTitle "^\([A-Z][A-Z ]*\)$"
 
-command -nargs=+ HiLink hi def link <args>
+syn match   godocTitle        "^\([A-Z][A-Z ]*\)$"
+hi def link godocTitle        Title
 
-HiLink godocTitle Title
+" Single Line Definitions
+syn match   godocMethodRec    /\i\+\ze)/ contained
+syn match   godocMethodName   /) \zs\i\+\ze(/ contained
+syn match   godocMethod       /^func \((\i\+ [^)]*)\) \i\+(/ contains=godocMethodRec,godocMethodName
+syn match   godocFunction     /^func \zs\i\+\ze(/
 
-delcommand HiLink
+syn match   godocType         /^type \zs\i\+\ze.*/
+syn match   godocVar          /^var \zs\i\+\ze.*/
+syn match   godocConst        /^const \zs\i\+\ze.*/
+
+hi def link godocMethodRec    Type
+hi def link godocType         Type
+hi def link godocMethodName   Function
+hi def link godocFunction     Function
+hi def link godocVar          Identifier
+hi def link godocConst        Identifier
+
+" Definition Blocks
+syn region  godocComment      start="/\*" end="\*/" contained
+syn region  godocComment      start="//" end="$" contained
+syn match   godocDefinition   /^\s\+\i\+/ contained
+
+syn region  godocVarBlock     start=/^var (/ end=/^)/ contains=godocComment,godocDefinition
+syn region  godocConstBlock   start=/^const (/ end=/^)/ contains=godocComment,godocDefinition
+syn region  godocTypeBlock    start=/^type \i\+ \(interface\|struct\) {/ end=/^}/ matchgroup=godocType contains=godocComment,godocType
+
+hi def link godocComment      Comment
+hi def link godocDefinition   Identifier
+
+syn sync minlines=500
 
 let b:current_syntax = "godoc"
 


### PR DESCRIPTION
With these changes, the godoc view highlights variable, constant, function and type names, as well as method receiver types. Go comments are also highlighted when they appear inside a definition block.

![The syntax in action...](https://cloud.githubusercontent.com/assets/6915/2625235/78292e1a-bd87-11e3-8849-23068db74f4c.png)
