### PR TITLE
Disable expandtab

### DIFF
--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -12,6 +12,8 @@ let b:did_ftplugin = 1
 setlocal comments=s1:/*,mb:*,ex:*/,://
 setlocal commentstring=//\ %s
 
+setlocal noexpandtab
+
 let b:undo_ftplugin = "setl com< cms<"
 
 " Set gocode completion


### PR DESCRIPTION
Since `go fmt` uses tabs might as well make sure `expandtab` is off.

Edit: I don't know if this is _all_ that is needed, e.g. `tabstop`, `softtabstop`, `shiftwidth`.  For instance, `ftplugin/make.vim` that comes with `vim` does `setlocal noexpandtab softtabstop=0`.
