### PR TITLE
Close quickfix window on successful fmt

### DIFF
--- a/ftplugin/go/fmt.vim
+++ b/ftplugin/go/fmt.vim
@@ -90,6 +90,7 @@ function! s:GoFormat()
         if s:got_fmt_error 
             let s:got_fmt_error = 0
             call setqflist([])
+            cwindow
         endif
     elseif g:go_fmt_fail_silently == 0 
         "otherwise get the errors and put them to quickfix window


### PR DESCRIPTION
Prior to 674bdbf40bc3a4ea6beb1ac44feff02d4d05695b, fixing `go fmt`
errors would cause the quickfix window to be closed. This commit
restores that functionality for cases in which we think we control the
contents of the quickfix window.
