### PR TITLE
Note dependency on mercurial

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ and execute `:PluginInstall`
 
 
 For the first Vim start it will try to download and install all necessary go
-binaries. It requires `hg`, so [install mercurial](https://developer.mozilla.org/en-US/docs/Installing_Mercurial)
-in advance. This can take some time. To disable this behaviour add `let g:go_disable_autoinstall = 1`
+binaries. It requires `git` and `hg` for fetching the individual Go packages.
+This can take some time. To disable this behaviour add `let g:go_disable_autoinstall = 1`
 
 ### Optional
 


### PR DESCRIPTION
First time Go user here, just tried this plugin out on a fairly fresh box. :heart: it. I didn't have mercurial so it errored out during startup. Easy fix, but I figured I'd note it in the README.
