### PR TITLE
Basic CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: go
+go:
+  - 1.0
+  - 1.1
+  - 1.2
+  - tip
+before_install:
+  - echo "set nocompatible" > ~/.vimrc
+  - echo "filetype off" >> ~/.vimrc
+  - echo "set rtp+=~/.vim/bundle/Vundle.vim" >> ~/.vimrc
+  - echo "call vundle#begin()" >> ~/.vimrc
+  - echo "Plugin 'fatih/vim-go'" >> ~/.vimrc
+  - echo "call vundle#end()" >> ~/.vimrc
+  - echo "filetype plugin indent on" >> ~/.vimrc
+  - echo "let g:go_disable_autoinstall = 1"
+install:
+  - sudo apt-get install vim mercurial git -qq
+  - mkdir -p ~/.vim/bundle/
+  - git clone git://github.com/gmarik/Vundle.vim.git ~/.vim/bundle/Vundle.vim
+  - touch error-tree
+script:
+  - yes '' | vim +PluginInstall +qall 2>&1 | tee -a error-file
+  - cat error-tree | grep -q 'Error installing'; test "1" = $?


### PR DESCRIPTION
Hi, I have been experiencing problems with your plugin, and I have made a travis config file to allow you to test that with CI. It's dependencies depend on go >= 1.2, so you should preferably state that in the README.

For the moment, I am not obtaining the result I expected, as haven't achieved to have the CI script fail when it fails. It's quite hacky the thing I did because I saw no way of asserting that the binaries have been correctly installed.

Hope this gives you an starting point.
