### PR TITLE
Don't shellescape our oracle scope file; enables multiple packages in scope

### DIFF
--- a/plugin/oracle.vim
+++ b/plugin/oracle.vim
@@ -59,7 +59,7 @@ func! s:RunOracle(mode, selected) range abort
   elseif pkg != -1
      let sname = pkg
   else
-    let sname = fname
+    let sname = shellescape(fname)
   endif
 
   if a:selected != -1
@@ -67,12 +67,12 @@ func! s:RunOracle(mode, selected) range abort
     let pos2 = s:getpos(line("'>"), col("'>"))
     let cmd = printf('%s -pos=%s:#%d,#%d %s %s',
       \  g:go_oracle_bin,
-      \  shellescape(fname), pos1, pos2, a:mode, shellescape(sname))
+      \  shellescape(fname), pos1, pos2, a:mode, sname)
   else
     let pos = s:getpos(line('.'), col('.'))
     let cmd = printf('%s -pos=%s:#%d %s %s',
       \  g:go_oracle_bin,
-      \  shellescape(fname), pos, a:mode, shellescape(sname))
+      \  shellescape(fname), pos, a:mode, sname)
   endif
 
   let out = system(cmd)


### PR DESCRIPTION
Without this, if you specify multiple packages like so: 

```
let g:go_oracle_scope_file="jello/integrations/echub jello/sfe jello/vfe"
```

the string gets quoted and oracle gives an error message about not being able to find the package with three spaces.
