### PR TITLE
check import before :GoImport

### DIFF
--- a/ftplugin/go/import.vim
+++ b/ftplugin/go/import.vim
@@ -76,6 +76,13 @@ function! GoSwitchImport(enabled, localname, path)
         return
     endif
 
+    if !isdirectory($GOROOT . "/src/pkg/" . path)
+        if !isdirectory($GOPATH . "/src/". path)
+            call s:Error("Can't find import: " . path)
+            return
+        endif
+    endif
+
     " Extract any site prefix (e.g. github.com/).
     " If other imports with the same prefix are grouped separately,
     " we will add this new import with them.


### PR DESCRIPTION
This is the fastest way I could think of to check if a :GoImport import is not mistyped. Another solution is checking via godoc, but I think it will do the same thing and its just slower.

Its my understanding that both environmental variables and / are changed properly by vim to work for windows.
