### PR TITLE
Support autocompletion of path in GoImportAs

### DIFF
--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -116,7 +116,7 @@ endfunction
 
 function! go#package#Complete(ArgLead, CmdLine, CursorPos)
     let words = split(a:CmdLine, '\s\+', 1)
-    if len(words) > 2
+    if len(words) > 2 && words[0] != "GoImportAs"
         " Complete package members
         return go#package#CompleteMembers(words[1], words[2])
     endif


### PR DESCRIPTION
Currently the second argument of any command is treated as package member. This fails in the case of `:GoImportAs` as the second argument there is the package path.

This change treats the second argument as package path if the command is `:GoImportAs`.
