### PR TITLE
Proposed fix for fatih/vim-go#93

### DIFF
--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -1,18 +1,30 @@
 function! go#tool#Files()
-    let command = "go list -f $'{{range $f := .GoFiles}}{{$.Dir}}/{{$f}}\n{{end}}'"
+    if has ("win32")
+        let command = 'go list -f "{{range $f := .GoFiles}}{{$.Dir}}/{{$f}}{{printf \"\n\"}}{{end}}"'
+    else
+        let command = "go list -f $'{{range $f := .GoFiles}}{{$.Dir}}/{{$f}}\n{{end}}'"
+    endif
     let out = go#tool#ExecuteInDir(command)
     return split(out, '\n')
 endfunction
 
 function! go#tool#Deps()
-    let command = "go list -f $'{{range $f := .Deps}}{{$f}}\n{{end}}'"
+    if has ("win32")
+        let command = 'go list -f "{{range $f := .Deps}}{{$f}}{{printf \"\n\"}}{{end}}"'
+    else
+        let command = "go list -f $'{{range $f := .Deps}}{{$f}}\n{{end}}'"
+    endif
     let out = go#tool#ExecuteInDir(command)
     return split(out, '\n')
 endfunction
 
 function! go#tool#Imports()
     let imports = {}
-    let command = "go list -f $'{{range $f := .Imports}}{{$f}}\n{{end}}'"
+    if has ("win32")
+        let command = 'go list -f "{{range $f := .Imports}}{{$f}}{{printf \"\n\"}}{{end}}"'
+    else
+        let command = "go list -f $'{{range $f := .Imports}}{{$f}}\n{{end}}'"
+    endif
     let out = go#tool#ExecuteInDir(command)
     if v:shell_error
         echo out


### PR DESCRIPTION
This is a proposal for a fix for fatih/vim-go#93.

It distinguishes for windows and other systems when setting up the relevant go list commands. The difference is in the shell escaping and the explicit printf-template-call for the newline.

With this fix, pressing 'K' and calling :GoBuild works for Vim for Windows.
