### PR TITLE
add minimal addon-info.json file

### DIFF
--- a/addon-info.json
+++ b/addon-info.json
@@ -1,0 +1,6 @@
+{
+  "name": "vim-go",
+  "description": "Full featured Go (golang) support for Vim. Contains official misc/vim files.",
+  "author": "Fatih Arslan <fatih@arslan.io>",
+  "repository" : {"type": "git", "url": "https://github.com/fatih/vim-go.git"}
+}


### PR DESCRIPTION
This is needed at Google to prevent vim-go from conflicting with our internal vim plugin for go syntax (basically the misc/vim files).  I'm not super familiar with addon-info.json files myself, but a number of vim plugin managers seem to be supporting this format, so it seems like a good thing to add.

I debated whether to name it "vim-go" or "go", and landed on the latter since it is really intended to be a complete replacement for the vim files that ship with Go.  I don't have strong feelings about that though, and can switch it back to "vim-go" if you'd like.
