### PR TITLE
fix tool.vim::go#tool#BinExists()

### DIFF
--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -100,7 +100,7 @@ function! go#tool#BinExists(binpath)
 
     let basename = fnamemodify(a:binpath, ":t")
 
-    if !executable(a:binpath) 
+    if !executable(substitute(substitute(a:binpath, '\s\+$', '', 'g'), '^\s\+', '', 'g'))
         echo "vim-go: could not find '" . basename . "'. Run :GoInstallBinaries to fix it."
         return -1
     endif


### PR DESCRIPTION
see vim manual about executable(): This function checks if an executable with the name {expr} exists.  {expr} must be the name of the program without any arguments. If there are some blank chars around a:binpath, the called result will be -1, that's incorrect.
