### PR TITLE
Load snippets with neosnippet.vim dynamically for .go file opened in new window.

### DIFF
--- a/ftplugin/go/snippet.vim
+++ b/ftplugin/go/snippet.vim
@@ -14,8 +14,8 @@ function! s:GoNeosnippet()
 		return
 	endif
 
-	let g:neosnippet#snippets_directory = globpath(&rtp, 'gosnippets/snippets')
 	let g:neosnippet#enable_snipmate_compatibility = 1
+	execute 'NeoSnippetSource' globpath(&rtp, 'gosnippets/snippets/go.snip')
 endfunction
 
 function! s:GoUltiSnips()


### PR DESCRIPTION
The go.snip is not loaded when .go files are opened in the new window of Vim.
A variable g:neosnippet#snippets_directory seems to be checked on initialization of neosnippet.vim.

This commit makes Vim load go.snip dynamically when a .go file is opened in the new window.
