### PR TITLE
Fix an error in complete.vim

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -112,6 +112,8 @@ function! go#complete#GetInfo()
     endfor
 
     let wordMatch = '\<' . expand("<cword>") . '\>'
+    " escape single quotes in wordMatch before passing it to filter
+    let wordMatch = substitute(wordMatch, "'", "''", "g")
     let filtered =  filter(infos, "v:val =~ '".wordMatch."'")
 
     if len(filtered) == 1


### PR DESCRIPTION
Prior to this change, placing a cursor over the string `"'"` with completion enabled caused vim to report the following error:

```
Error detected while processing function go#complete#Info..go#complete#GetInfo:
line   29:
E15: Invalid expression: "\>'
```

This is because `<cword>` expanded to `"'"`, which caused the filter expression to evaluate to `v:val =~ '\<"'"\>'`. The unescaped single-quote in the middle terminated the string, and left the characters `"\>'` dangling as an invalid expression. This commit fixes that problem by escaping any single quotes in `<cword>`.
