### PR TITLE
doc: replace godoc to  g:go_doc_command and g:go_doc_options

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -25,6 +25,13 @@ let g:loaded_godoc = 1
 
 let s:buf_nr = -1
 
+if !exists("g:go_doc_command")
+    let g:go_doc_command = "godoc"
+endif
+
+if !exists("g:go_doc_options")
+    let g:go_doc_options = ""
+endif
 
 " returns the package and exported name. exported name might be empty.
 " ie: fmt and Println
@@ -92,7 +99,7 @@ function! go#doc#Open(mode, ...)
     let pkg = pkgs[0]
     let exported_name = pkgs[1]
 
-    let command = 'godoc ' . pkg
+    let command = g:go_doc_command . ' ' . g:go_doc_options . ' ' . pkg
 
     silent! let content = system(command)
     if v:shell_error || !len(content)

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -405,6 +405,20 @@ use the program man. However in go using godoc is more idiomatic. Default is
 enabled. >
 
   let g:go_doc_keywordprg_enabled = 1
+<
+                                                         *'g:go_doc_command'*
+
+Use this option to define which tool is used to godoc. By default `godoc` is
+used >
+
+  let g:go_doc_command = "godoc"
+<
+                                                         *'g:go_doc_options'*
+
+Use this option to add additional options to the |g:go_doc_command|. Default
+is empty. >
+
+  let g:go_doc_options = ''
 
 <                                                            *'g:go_bin_path'*
 


### PR DESCRIPTION
I propose to add g:go_doc_options to set '-ex' option to godoc.
