### PR TITLE
Stay silent if type info isn't found for the word under cursor

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -96,7 +96,7 @@ function! go#complete#GetInfo()
 
     " no candidates are found
     if len(out) == 1
-        return
+        return ""
     endif
 
     " only one candiate is found
@@ -119,6 +119,8 @@ function! go#complete#GetInfo()
     if len(filtered) == 1
         return filtered[0]
     endif
+
+    return ""
 endfunction
 
 function! go#complete#Info()


### PR DESCRIPTION
As of now, the function `go#complete#GetInfo` returns the value `0` when no type info is found. Since `len(0) == 1`, in `go#complete#Info` we end up showing to the user the message `vim-go: 0`. This is quite annoying, especially when `go_auto_type_info` is turned on. 
