### PR TITLE
Ultisnips: automatic parentheses insertion with multiple return values

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -94,6 +94,28 @@ default:
 endsnippet
 
 # functions
+
+global !p
+
+# Automatically wrap return types with parentheses if
+# return types are more than one.
+
+def opening_par(snip, pos):
+	value = t[pos]
+	if len(value.split(",")) > 1 and not value.startswith("("):
+		snip.rv = "("
+	else:
+		snip.rv = ""
+
+def closing_par(snip, pos):
+	value = t[pos]
+	if len(value.split(",")) > 1 and not value.endswith(")"):
+		snip.rv = ")"
+	else:
+		snip.rv = ""
+
+endglobal
+
 snippet /^main/ "Main function" r
 func main() {
 	${0:${VISUAL}}
@@ -101,13 +123,13 @@ func main() {
 endsnippet
 
 snippet /^meth/ "Method" r
-func (${1:receiver} ${2:type}) ${3:name}(${4:params})${5/(.+)/ /}${5:type} {
+func (${1:receiver} ${2:type}) ${3:name}(${4:params})${5/(.+)/ /}`!p opening_par(snip, 5)`$5`!p closing_par(snip, 5)` {
 	${0:${VISUAL}}
 }
 endsnippet
 
 snippet func "Function" b
-func ${1:name}(${2:params})${3/(.+)/ /}${3:type} {
+func ${1:name}(${2:params})${3/(.+)/ /}`!p opening_par(snip, 3)`$3`!p closing_par(snip, 3)` {
 	${0:${VISUAL}}
 }
 endsnippet


### PR DESCRIPTION
When you type return types, as soon as you insert a separation comma, those get wrapped with parentheses. However, this patch may not be compatible with #220 because it relies on Ultisnips python interpolation features.
