### PR TITLE
Open GoDoc window silently

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -129,7 +129,7 @@ function! s:GodocView(position, content)
     " reuse existing buffer window if it exists otherwise create a new one
     if !bufexists(s:buf_nr)
         execute a:position
-        file `="[Godoc]"`
+        sil file `="[Godoc]"`
         let s:buf_nr = bufnr('%')
     elseif bufwinnr(s:buf_nr) == -1
         execute a:position
@@ -151,7 +151,7 @@ function! s:GodocView(position, content)
     setlocal modifiable
     %delete _
     call append(0, split(a:content, "\n"))
-    $delete _
+    sil $delete _
     setlocal nomodifiable
 endfunction
 


### PR DESCRIPTION
These two lines appear when I execute `:GoDoc` and I'm forced to press enter when `cmdheight=1` before I can view the content of the GoDoc window:

```
"[Godoc]" [Not edited] --No lines in buffer--
1 line less
```

This patch aims to silent commands that presumably cause those messages.
