### PR TITLE
Open GoDef window silently

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -96,7 +96,7 @@ function! s:godefJump(out, mode)
 		endif
 
 		" jump to file now
-		ll 1
+		sil ll 1
 		normal zz
 
 		let &switchbuf = old_switchbuf


### PR DESCRIPTION
Follows #234. This patch mutes the `:ll` command. This prevents the pollution of the message history (`:h message-history`) with the (quite useless) message: 

```
(file 1 of 1):
```
