### PR TITLE
Added support for passing build flags to GoBuild

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -41,13 +41,13 @@ function! go#cmd#Install(...)
     endif
 endfunction
 
-function! go#cmd#Build(bang)
+function! go#cmd#Build(bang, ...)
     let default_makeprg = &makeprg
     let gofiles = join(go#tool#Files(), ' ')
     if v:shell_error
         let &makeprg = "go build . errors"
     else
-        let &makeprg = "go build -o /dev/null " . gofiles
+        let &makeprg = "go build -o /dev/null " . join(a:000, ' ') . " " . gofiles
     endif
 
     echon "vim-go: " | echohl Identifier | echon "building ..."| echohl None
@@ -60,7 +60,7 @@ function! go#cmd#Build(bang)
             if g:go_jump_to_error
                 cc 1 "jump to first error if there is any
             endif
-        else 
+        else
             redraws! | echon "vim-go: " | echohl Function | echon "[build] SUCCESS"| echohl None
         endif
     endif

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -172,11 +172,14 @@ COMMANDS                                                          *go-commands*
     If [!] is not given the first error is jumped to.
 
                                                                    *:GoBuild*
-:GoBuild[!]
+:GoBuild[!] [options]
 
     Build your package with `go build`. It automatically builds only the files
     that depends on the current file. GoBuild doesn't produce a result file.
     Use 'make' to create a result file.
+
+    You may optionally pass any valid go build flags/options. For a full list
+    please see `go help build`.
 
     If [!] is not given the first error is jumped to.
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -45,7 +45,7 @@ command! -nargs=* GoInfo call go#complete#Info()
 
 " cmd
 command! -nargs=* -bang GoRun call go#cmd#Run(<bang>0,<f-args>)
-command! -nargs=? -bang GoBuild call go#cmd#Build(<bang>0)
+command! -nargs=* -bang GoBuild call go#cmd#Build(<bang>0,<f-args>)
 command! -nargs=* GoInstall call go#cmd#Install(<f-args>)
 command! -nargs=* GoTest call go#cmd#Test(<f-args>)
 command! -nargs=* GoCoverage call go#cmd#Coverage(<f-args>)


### PR DESCRIPTION
This is to address the https://github.com/fatih/vim-go/issues/231 feature request.

Works just fine for `-gcflags=-m` but for `-gcflags=-s` it only works if `g:go_jump_to_error` is set to 0. That is due to the "funny" output from that flag (on my end it generates absolute paths but prefixes them with ./ thus making them invalid - an attempt to jump at such an invalid file, will clear out the buffer).

Cheers!
