### PR TITLE
Move autocommands to plugin/go.vim.

### DIFF
--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -32,20 +32,8 @@ if get(g:, "go_def_mapping_enabled", 1)
    nnoremap <buffer> <silent> gd :GoDef<cr>
 endif
 
-augroup vim-go
-    autocmd!
-
-    " GoInfo automatic update
-    if get(g:, "go_auto_type_info", 0)
-        setlocal updatetime=300
-        autocmd CursorHold *.go nested call go#complete#Info()
-    endif
-
-    " code formatting on save
-    if get(g:, "go_fmt_autosave", 1)
-        autocmd BufWritePre <buffer> call go#fmt#Format(-1)
-    endif
-
-augroup END
+if get(g:, "go_auto_type_info", 0)
+    setlocal updatetime=300
+endif
 
 " vim:ts=4:sw=4:et

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -146,4 +146,23 @@ function! s:CheckBinaries()
     endif
 endfunction
 
+" Autocommands
+" ============================================================================
+
+augroup vim-go
+    autocmd!
+
+    " GoInfo automatic update
+    if get(g:, "go_auto_type_info", 0)
+        autocmd CursorHold *.go nested call go#complete#Info()
+    endif
+
+    " code formatting on save
+    if get(g:, "go_fmt_autosave", 1)
+        autocmd BufWritePre *.go call go#fmt#Format(-1)
+    endif
+
+augroup END
+
+
 " vim:ts=4:sw=4:et


### PR DESCRIPTION
Beside having fixed some issues, #232 introduced a new one (my bad...). Every time a go file gets edited, `ftplugin/go.vim` is sourced. The autocommands are cleared and defined again. The problem is that now the autocommand that execute `go#fmt#Format` works only for the last go file edited. To fix that, this patch moves autocommands to `plugin/go.vim`. Fixes #238.
