### PR TITLE
Ultisnips: fix automatic parentheses insertion with function types

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -97,19 +97,23 @@ endsnippet
 
 global !p
 
-# Automatically wrap return types with parentheses if
-# return types are more than one.
+import re
+
+# Automatically wrap return types with parentheses
+
+def return_values(s):
+	# remove everything wrapped in parentheses
+	s = re.sub("\(.*?\)|\([^)]*$", "", s)
+	return len(s.split(","))
 
 def opening_par(snip, pos):
-	value = t[pos]
-	if len(value.split(",")) > 1 and not value.startswith("("):
+	if return_values(t[pos]) > 1 and not t[pos].startswith("("):
 		snip.rv = "("
 	else:
 		snip.rv = ""
 
 def closing_par(snip, pos):
-	value = t[pos]
-	if len(value.split(",")) > 1 and not value.endswith(")"):
+	if return_values(t[pos]) > 1:
 		snip.rv = ")"
 	else:
 		snip.rv = ""


### PR DESCRIPTION
I didn't test #229 thoroughly. When among return types there are functions that accept many arguments, return types are not wrapped correctly with parentheses. This patch takes care of that. 
