### PR TITLE
Support :GoDoc with only package name

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -104,8 +104,12 @@ function! go#doc#Open(mode, ...)
 
     call s:GodocView(a:mode, content)
 
-    " jump to the specified name
+    if exported_name == ''
+        silent! normal gg
+        return -1
+    endif
 
+    " jump to the specified name
     if search('^func ' . exported_name . '(')
         silent! normal zt
         return -1


### PR DESCRIPTION
This change jumps to the top of the help pane when :GoDoc is run with only a package name.

Currently, `:GoDoc os` will scroll to `func (f *File) Chdir() error`, because the first search clause expands to `func (` (i.e., the first method definition). The proposed change always displays the top-level package documentation when only given a package name. This also maintains parity with `misc/vim`'s Godoc command.
