### PR TITLE
This should fix fatih/vim-go#251 (GoDef and non unix line endings).

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -21,7 +21,7 @@ function! go#def#Jump(...)
 	let command = bin_path . " -f=" . expand("%:p") . " -i " . shellescape(arg)
 
 	" get output of godef
-	let out=system(command, join(getbufline(bufnr('%'), 1, '$'), "\n"))
+	let out=system(command, join(getbufline(bufnr('%'), 1, '$'), LineEnding()))
 
 	" jump to it
 	call s:godefJump(out, "")
@@ -39,7 +39,7 @@ function! go#def#JumpMode(mode)
 	let command = bin_path . " -f=" . expand("%:p") . " -i " . shellescape(arg)
 
 	" get output of godef
-	let out=system(command, join(getbufline(bufnr('%'), 1, '$'), "\n"))
+	let out=system(command, join(getbufline(bufnr('%'), 1, '$'), LineEnding()))
 
 	call s:godefJump(out, a:mode)
 endfunction
@@ -51,7 +51,7 @@ function! s:getOffset()
 		let offs = line2byte(pos[0]) + pos[1] - 2
 	else
 		let c = pos[1]
-		let buf = line('.') == 1 ? "" : (join(getline(1, pos[0] - 1), "\n") . "\n")
+		let buf = line('.') == 1 ? "" : (join(getline(1, pos[0] - 1), LineEnding()) . LineEnding())
 		let buf .= c == 1 ? "" : getline(pos[0])[:c-2]
 		let offs = len(iconv(buf, &encoding, "utf-8"))
 	endif
@@ -66,7 +66,7 @@ function! s:godefJump(out, mode)
 	let &errorformat = "%f:%l:%c"
 
 	if a:out =~ 'godef: '
-		let out=substitute(a:out, '\n$', '', '')
+		let out=substitute(a:out, LineEnding() . '$', '', '')
 		echom out
 	else
 		let parts = split(a:out, ':')
@@ -103,4 +103,3 @@ function! s:godefJump(out, mode)
 	end
 	let &errorformat = old_errorformat
 endfunction
-

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -23,6 +23,17 @@ command! GoErrCheck call go#errcheck#Run()
 command! GoInstallBinaries call s:GoInstallBinaries(-1)
 command! GoUpdateBinaries call s:GoInstallBinaries(1)
 
+" LineEnding returns the correct line ending, based on the current fileformat
+function! LineEnding()
+    if &fileformat == 'dos'
+        return "\r\n"
+    elseif &fileformat == 'mac'
+        return "\r"
+    endif
+
+    return "\n"
+endfunction
+
 " IsWin returns 1 if current OS is Windows or 0 otherwise
 function! IsWin()
     let win = ['win16', 'win32', 'win32unix', 'win64', 'win95']


### PR DESCRIPTION
It does that by taking the current fileformat into account.
