### PR TITLE
Include cgo files in go#tool#Files listings

### DIFF
--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -1,6 +1,6 @@
 function! go#tool#Files()
     if IsWin()
-        let command = "go list -f '{{range $f := .GoFiles}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}{{range $f := .CgoFiles}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}'"
+        let command = 'go list -f "{{range $f := .GoFiles}}{{$.Dir}}\{{$f}}{{printf \"\n\"}}{{end}}{{range $f := .CgoFiles}}{{$.Dir}}\{{$f}}{{printf \"\n\"}}{{end}}"'
     else
         " let command = "go list -f $'{{range $f := .GoFiles}}{{$.Dir}}/{{$f}}\n{{end}}'"
         let command = "go list -f '{{range $f := .GoFiles}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}{{range $f := .CgoFiles}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}'"


### PR DESCRIPTION
The current behaviour (list only pure go files) breaks commands such as go-build for packages mixing both go and cgo.

example:

```
$ go list -f '{{range $f := .GoFiles}}{{$.Dir}}/{{$f}}{{printf "\n"}}{{end}}'
/Users/aam/../dat.go
/Users/aam/../kexttest.go
$ go list -f '{{range $f := .GoFiles}}{{$.Dir}}/{{$f}}{{printf "\n"}}{{end}}{{range $f := .CgoFiles}}{{$.Dir}}/{{$f}}{{printf "\n"}}{{end}}'
/Users/aam/../dat.go
/Users/aam/../kexttest.go
/Users/aam/../kext.go
```
