### PR TITLE
Set 'makeprg' variable as 'make' when Makefile exists

### DIFF
--- a/compiler/go.vim
+++ b/compiler/go.vim
@@ -15,8 +15,12 @@ endif
 
 let s:save_cpo = &cpo
 set cpo-=C
+if filereadable("makefile") || filereadable("Makefile")
+    CompilerSet makeprg=make
+else
+    CompilerSet makeprg=go\ build
+endif
 
-CompilerSet makeprg=go\ build
 CompilerSet errorformat=
       \%-G#\ %.%#,
       \%-G%.%#panic:\ %m,


### PR DESCRIPTION
vim-go will change 'makeprg' variable to 'go build' by default,
but it's not what we want when user has created his own Makefile
for golang project.

Let's set 'makeprg' variable as 'make' when Makefile exists in
current directory.

Signed-off-by: Yunkai Zhang qiushu.zyk@taobao.com
