### PR TITLE
fixed unnecessary buffer creation

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -85,7 +85,7 @@ function! go#doc#OpenBrowser(...)
     call go#tool#OpenBrowser(godoc_url)
 endfunction
 
-function! go#doc#Open(mode, ...)
+function! go#doc#Open(newmode, mode, ...)
     let pkgs = s:godocWord(a:000)
     if empty(pkgs)
         return
@@ -102,7 +102,7 @@ function! go#doc#Open(mode, ...)
         return -1
     endif
 
-    call s:GodocView(a:mode, content)
+    call s:GodocView(a:newmode, a:mode, content)
 
     if exported_name == ''
         silent! normal gg
@@ -129,10 +129,10 @@ function! go#doc#Open(mode, ...)
     silent! normal gg
 endfunction
 
-function! s:GodocView(position, content)
+function! s:GodocView(newposition, position, content)
     " reuse existing buffer window if it exists otherwise create a new one
     if !bufexists(s:buf_nr)
-        execute a:position
+        execute a:newposition
         sil file `="[Godoc]"`
         let s:buf_nr = bufnr('%')
     elseif bufwinnr(s:buf_nr) == -1

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -25,10 +25,10 @@ nnoremap <silent> <Plug>(go-def-vertical) :<C-u>call go#def#JumpMode("vsplit")<C
 nnoremap <silent> <Plug>(go-def-split) :<C-u>call go#def#JumpMode("split")<CR>
 nnoremap <silent> <Plug>(go-def-tab) :<C-u>call go#def#JumpMode("tab")<CR>
 
-nnoremap <silent> <Plug>(go-doc) :<C-u>call go#doc#Open("leftabove new")<CR>
-nnoremap <silent> <Plug>(go-doc-tab) :<C-u>call go#doc#Open("tabnew")<CR>
-nnoremap <silent> <Plug>(go-doc-vertical) :<C-u>call go#doc#Open("vnew")<CR>
-nnoremap <silent> <Plug>(go-doc-split) :<C-u>call go#doc#Open("split")<CR>
+nnoremap <silent> <Plug>(go-doc) :<C-u>call go#doc#Open("new", "split")<CR>
+nnoremap <silent> <Plug>(go-doc-tab) :<C-u>call go#doc#Open("tabnew", "tabe")<CR>
+nnoremap <silent> <Plug>(go-doc-vertical) :<C-u>call go#doc#Open("vnew", "vsplit")<CR>
+nnoremap <silent> <Plug>(go-doc-split) :<C-u>call go#doc#Open("new", "split")<CR>
 nnoremap <silent> <Plug>(go-doc-browser) :<C-u>call go#doc#OpenBrowser()<CR>
 
 
@@ -58,7 +58,7 @@ command! -nargs=0 -range=% GoPlay call go#play#Share(<count>, <line1>, <line2>)
 command! -nargs=* -range GoDef :call go#def#Jump(<f-args>)
 
 " -- doc
-command! -nargs=* -range -complete=customlist,go#package#Complete GoDoc call go#doc#Open('leftabove new', <f-args>)
+command! -nargs=* -range -complete=customlist,go#package#Complete GoDoc call go#doc#Open('new', 'split', <f-args>)
 command! -nargs=* -range -complete=customlist,go#package#Complete GoDocBrowser call go#doc#OpenBrowser(<f-args>)
 
 " -- fmt


### PR DESCRIPTION
GoDoc keeps creating new buffers even when the buffer to reuse is already in place. This should fix this problem.
