### PR TITLE
Only show tests passed if test cmd was successful

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -102,6 +102,7 @@ function! go#cmd#Test(...)
         echon "vim-go: " | echohl ErrorMsg | echon "[test] FAIL" | echohl None
     else
         call setqflist([])
+        cwindow
         echon "vim-go: " | echohl Function | echon "[test] PASS" | echohl None
     endif
 endfunction


### PR DESCRIPTION
Before this change tests were shown as "passing" even if running `go test` resulted in a "fatal error".

The reason was that `go#cmd#Test` determined whether to show "PASS" or not depending on the output of `go test`. If `go test` contained parseable error lines `go#tool#ShowErrors` would fill the quickfix list
with these lines. But if it couldn't parse the output of the test command (as it the case when a "fatal error" occurs) it would just print the output.

But since `go#cmd#Test` only checked the quickfix list for entries and not the exit status of the test command, it called `redraw` and the output was only visible for a fraction of a second.

This commit changes the behaviour of `go#cmd#Test` to the following:
1. Run the test command
2. Redraw the screen
3. If the test command exited successfully, show that the tests passed
4. If it didn't, parse the output and add it to the quickfix list. If it's not parseable, just print it (this is the use case here). Then print that the tests failed.

This change relates to my comment in #248. But it's a small change: it does not try to parse Go stacktraces (I'm not sure whether vim-go should even try to do this), it only shows the output of the test command if it failed. I think this is really important, since otherwise vim-go would tell me that the tests have passed, when they have in fact crashed.

What do you think about this? Feedback very welcome! :)
