### PR TITLE
Custom text objects

### DIFF
--- a/autoload/go/textobj.vim
+++ b/autoload/go/textobj.vim
@@ -1,0 +1,15 @@
+if !exists("g:go_textobj_enabled")
+    let g:go_textobj_enabled = 1
+endif
+
+function! go#textobj#Function(mode)
+  if search('^\s*func .*{$', 'Wce', line('.')) <= 0
+        \ && search('^\s*func .*{$', 'bWce') <= 0
+    return
+  endif
+  if a:mode == 'a'
+    normal! Va{V
+  else " a:mode == 'i'
+    normal! Vi{V
+  endif
+endfunction

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -19,6 +19,7 @@ CONTENTS                                                          *go-contents*
 	3. Commands.....................................|go-commands|
 	4. Settings.....................................|go-settings|
 	5. Mappings.....................................|go-mappings|
+	5. Text Objects.................................|go-text-objects|
 	6. Troubleshooting..............................|go-troubleshooting|
 	7. Credits......................................|go-credits|
 
@@ -371,6 +372,20 @@ Rename the identifier under the cursor to the desired new name
 
 Show the call targets for the type under the cursor
 
+===============================================================================
+TEXT OBJECTS                                                 *go-text-objects*
+
+vim-go comes with several custom |text-objects| that can be used to operate
+upon regions of text. vim-go currently defines the following text objects:
+
+                                               *go-v_am* *go-am*
+am			      "a function", select contents from a function definition to the
+               closing bracket.
+
+                                               *go-v_im* *go-im*
+im			      "inside a function", select contents of a function,
+			        excluding the fuction definition and the closing bracket.
+
 
 ===============================================================================
 SETTINGS                                                        *go-settings*
@@ -544,6 +559,12 @@ Highlights struct names. By default it's disabled. >
 
 	let g:go_highlight_structs = 0
 <
+                                                  *'g:go_textobj_enabled'*
+
+Adds custom text objects. By default it's enabled. >
+
+	let g:go_textobj_enabled = 1
+
 ===============================================================================
 TROUBLESHOOTING                                         *go-troubleshooting*
 

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -32,6 +32,13 @@ if get(g:, "go_def_mapping_enabled", 1)
    nnoremap <buffer> <silent> gd :GoDef<cr>
 endif
 
+if get(g:, "go_textobj_enabled", 1)
+    onoremap <buffer> af :<c-u>call go#textobj#Function('a')<cr>
+    xnoremap <buffer> af :<c-u>call go#textobj#Function('a')<cr>
+    onoremap <buffer> if :<c-u>call go#textobj#Function('i')<cr>
+    xnoremap <buffer> if :<c-u>call go#textobj#Function('i')<cr>
+endif
+
 if get(g:, "go_auto_type_info", 0)
     setlocal updatetime=800
 endif


### PR DESCRIPTION
As per commit message, I consider this a draft as it comes without documentation. I don't like to open issues to discuss features request, I find politer to open a PR and start a discussion with a few questions:
- Are you interested in adding custom text-objects to vim-go? I find the addition very neat as the feature is fundamental to the way vim users think about text. For example, vim-ruby does the very same (actually I've _stolen_ this implementation from @AndrewRadev , one of the vim-ruby mantainers, [here](https://github.com/AndrewRadev/vim-golang/commit/d442aaedbf531159307f97539da7b2183ed33388))
- Would you have the feature enabled by default?
- Are you ok with the way I've organised the files?

Thank you very much for this awesome plugin and for all the time and effort you put in it.

P.S. Of course @AndrewRadev did the job here and I want to thank him, I've just put the things together for a small PR. 
