### PR TITLE
Parse and add 'fatal errors' to quickfix list

### DIFF
--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -42,8 +42,12 @@ endfunction
 function! go#tool#ShowErrors(out)
     let errors = []
     for line in split(a:out, '\n')
+        let fatalerrors = matchlist(line, '^\(fatal error:.*\)$')
         let tokens = matchlist(line, '^\s*\(.\{-}\):\(\d\+\):\s*\(.*\)')
-        if !empty(tokens)
+
+        if !empty(fatalerrors)
+            call add(errors, {"text": fatalerrors[1]})
+        elseif !empty(tokens)
             call add(errors, {"filename" : expand("%:p:h:") . "/" . tokens[1],
                         \"lnum":     tokens[2],
                         \"text":     tokens[3]})


### PR DESCRIPTION
This fixes two existing problems:

1.) If `ShowErrors` was run with the quickfix list already populated it would not update the quickfix list if the new output contained a fatal error. e.g. test is fixed, new run results in fatal error, the now-fixed test is still shown in the quickfix list.

2.) It shows stacktraces without the context of the `fatal error`. Before this changed, `ShowErrors` parsed stacktraces (by accident, I assume) and added them to the quickfix list. But without the `fatal
error:` line, it seemed like these stacktraces belonged to a failing test.

This change adds parsing of "fatal error" lines to `ShowErrors`. It checks if a line contains `fatal error:` and if so, it handles the line like a error and adds it to the quickfix list.

The result is that now fatal errors are handled like regular failing test: they update the quickfix list.

I know that this is a really simple solution, since it doesn't even attempt to parse the stacktraces correctly (which is hard!). And I wanted to get feedback about this change before even thinking about it.

Also, this is the first solution I proposed at the end in #270. The quickfix list now gets updated and passing tests disappear correctly. And the stacktraces have more context in the quickfix list. 

_But_ the "print the output as it is" (if we can't recognise anything in the output of the cmd) functionality of ShowErrors doesn't work anymore, since we now recognise fatal errors.

The other solution in #270, which was "always reset the quickfix list, even if we didn't recognise anything" would keep the quickfix list updated too and keep the "print the output as it is" functionality, but it would not show "fatal errors" in the quickfix list.

What do you think?