### PR TITLE
[Bugfix]GoDoc can not found correct package path when package name has ext

### DIFF
--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -32,7 +32,7 @@ function! go#tool#Imports()
     endif
 
     for package_path in split(out, '\n')
-        let package_name = fnamemodify(package_path, ":t")
+        let package_name = fnamemodify(package_path, ":t:r")
         let imports[package_name] = package_path
     endfor
 


### PR DESCRIPTION
https://github.com/fatih/vim-go/issues/281

To reproduce the problem in following code:

put cursor on "yaml.Unmarshal", and run `:GoDoc`


```
package main

import (
	"io/ioutil"

	"gopkg.in/yaml.v2"
)

type config struct {
}

func test() {
	if content, err := ioutil.ReadFile("nothing"); err == nil {
		c := config{}
		err = yaml.Unmarshal(content, &c)
	}
}
```

