### PR TITLE
Fix go#fmt#Format for using GoImports

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -186,7 +186,11 @@ augroup vim-go
 
     " code formatting on save
     if get(g:, "go_fmt_autosave", 1)
-        autocmd BufWritePre *.go call go#fmt#Format(1)
+        if exists("g:go_fmt_command")
+            autocmd BufWritePre *.go call go#fmt#Format(1)
+        else
+            autocmd BufWritePre *.go call go#fmt#Format(-1)
+        endif
     endif
 
 augroup END

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -186,7 +186,7 @@ augroup vim-go
 
     " code formatting on save
     if get(g:, "go_fmt_autosave", 1)
-        autocmd BufWritePre *.go call go#fmt#Format(-1)
+        autocmd BufWritePre *.go call go#fmt#Format(1)
     endif
 
 augroup END


### PR DESCRIPTION
Pull request to fix the [Issue 217](https://github.com/fatih/vim-go/issues/217). 1 needs to be passed to [here](https://github.com/fatih/vim-go/blob/master/autoload/go/fmt.vim#L76).