### PR TITLE
fix GoDoc if package name differs from import path

### DIFF
--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -32,7 +32,8 @@ function! go#tool#Imports()
     endif
 
     for package_path in split(out, '\n')
-        let package_name = fnamemodify(package_path, ":t:r")
+        let cmd = "go list -f {{.Name}} " . package_path
+        let package_name = substitute(go#tool#ExecuteInDir(cmd), '\n$', '', '')
         let imports[package_name] = package_path
     endfor
 


### PR DESCRIPTION
When package with "import path" e.g. `"github.com/bitly/go-simplejson"` is accessible by default with other name (in this case `simplejson`),
GoDoc cannot find this because it cannot dereference "package name" to "import path" because of how go#tool#Imports creates mapping between "package_name" and "import path".

this merge tries to infer real "package name" that if GoDoc is placed on  eg. simplejson.NewJson which is located in "github.com/bitly/go-simplejson" - it correctly finds out the correct path

example of non-working code, before path
```go
import "github.com/bitly/go-simplejson"

func main(){
    json, err := simplejson.NewJson()
}
```

I am aware that this is problem with library that not sticks with convention of giving the same name to package and last folder in import path - but it looks it is quite common.