### PR TITLE
Update docs for function text objects.

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -378,12 +378,12 @@ TEXT OBJECTS                                                 *go-text-objects*
 vim-go comes with several custom |text-objects| that can be used to operate
 upon regions of text. vim-go currently defines the following text objects:
 
-                                               *go-v_am* *go-am*
-am			      "a function", select contents from a function definition to the
+                                               *go-v_af* *go-af*
+af			      "a function", select contents from a function definition to the
                closing bracket.
 
-                                               *go-v_im* *go-im*
-im			      "inside a function", select contents of a function,
+                                               *go-v_if* *go-if*
+if			      "inside a function", select contents of a function,
 			        excluding the function definition and the closing bracket.
 
 


### PR DESCRIPTION
It looks like the docs aren't quite right in https://github.com/fatih/vim-go/pull/272. They show `am`/`im` when the implementation is `af`/`if`. I'm somewhat awful at vimscript so maybe I'm missing something, but only the `f` variant works for me in vim.