### PR TITLE
Add vimproc support for vim-go.

### DIFF
--- a/autoload/go.vim
+++ b/autoload/go.vim
@@ -1,0 +1,17 @@
+"Check if has vimproc
+function! go#has_vimproc()
+    if !exists('g:vimgo#use_vimproc')
+    try
+      call vimproc#version()
+      let exists_vimproc = 1
+    catch
+      let exists_vimproc = 0
+    endtry
+
+    let g:vimgo#use_vimproc = exists_vimproc
+  endif
+
+  return g:vimgo#use_vimproc
+endfunction
+
+" vim:ts=4:sw=4:et

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -19,10 +19,15 @@ fu! s:gocodeCurrentBuffer()
     return file
 endf
 
-let s:vim_system = get(g:, 'gocomplete#system_function', 'system')
-
 fu! s:system(str, ...)
-    return call(s:vim_system, [a:str] + a:000)
+
+    if go#has_vimproc()
+        let l:vim_system = get(g:, 'gocomplete#system_function', 'vimproc#system2')
+    else
+        let l:vim_system = get(g:, 'gocomplete#system_function', 'system')
+    endif
+
+    return call(l:vim_system, [a:str] + a:000)
 endf
 
 fu! s:gocodeShellescape(arg)

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -20,8 +20,12 @@ function! go#def#Jump(...)
 
 	let command = bin_path . " -f=" . expand("%:p") . " -i " . shellescape(arg)
 
-	" get output of godef
-	let out=system(command, join(getbufline(bufnr('%'), 1, '$'), LineEnding()))
+  " get output of godef
+  if go#has_vimproc()
+    let out=vimproc#system2(command, join(getbufline(bufnr('%'), 1, '$'), LineEnding()))
+  else
+    let out=system(command, join(getbufline(bufnr('%'), 1, '$'), LineEnding()))
+  endif
 
 	" jump to it
 	call s:godefJump(out, "")
@@ -39,7 +43,11 @@ function! go#def#JumpMode(mode)
 	let command = bin_path . " -f=" . expand("%:p") . " -i " . shellescape(arg)
 
 	" get output of godef
-	let out=system(command, join(getbufline(bufnr('%'), 1, '$'), LineEnding()))
+  if go#has_vimproc()
+    let out=vimproc#system2(command, join(getbufline(bufnr('%'), 1, '$'), LineEnding()))
+  else
+    let out=system(command, join(getbufline(bufnr('%'), 1, '$'), LineEnding()))
+  endif
 
 	call s:godefJump(out, a:mode)
 endfunction

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -96,7 +96,11 @@ function! go#doc#Open(newmode, mode, ...)
 
     let command = g:go_doc_command . ' ' . g:go_doc_options . ' ' . pkg
 
-    silent! let content = system(command)
+    if go#has_vimproc()
+        silent! let content = vimproc#system2(command)
+    else
+        silent! let content = system(command)
+    endif
     if v:shell_error || !len(content)
         echo 'No documentation found for "' . pkg . '".'
         return -1

--- a/autoload/go/errcheck.vim
+++ b/autoload/go/errcheck.vim
@@ -14,7 +14,12 @@ function! go#errcheck#Run(...) abort
         return
     endif
 
-    let out = system(bin_path . ' ' . package)
+    if go#has_vimproc()
+      let out = vimproc#system2(bin_path . ' ' . package)
+    else
+      let out = system(bin_path . ' ' . package)
+    endif
+
     if v:shell_error
         let errors = []
         let mx = '^\(.\{-}\):\(\d\+\):\(\d\+\)\s*\(.*\)'

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -87,7 +87,11 @@ function! go#fmt#Format(withGoimport)
     let command = fmt_command . ' ' . g:go_fmt_options
 
     " execute our command...
-    let out = system(command . " " . l:tmpname)
+    if go#has_vimproc()
+        let out = vimproc#system2(command . " " . l:tmpname)
+    else
+        let out = system(command . " " . l:tmpname)
+    endif
 
     "if there is no error on the temp file, gofmt again our original file
     if v:shell_error == 0

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -17,12 +17,16 @@ if !exists("g:go_golint_bin")
 endif
 
 function! go#lint#Run() abort
-	let bin_path = go#tool#BinPath(g:go_golint_bin) 
-	if empty(bin_path) 
-		return 
+	let bin_path = go#tool#BinPath(g:go_golint_bin)
+	if empty(bin_path)
+		return
 	endif
 
-    silent cexpr system(bin_path . " " . shellescape(expand('%')))
+    if go#has_vimproc()
+        silent cexpr vimproc#system2(bin_path . " " . shellescape(expand('%')))
+    else
+        silent cexpr system(bin_path . " " . shellescape(expand('%')))
+    endif
     cwindow
 endfunction
 

--- a/autoload/go/oracle.vim
+++ b/autoload/go/oracle.vim
@@ -83,7 +83,11 @@ func! s:RunOracle(mode, selected) range abort
 
     echon "vim-go: " | echohl Identifier | echon "analysing ..." | echohl None
 
-    let out = system(cmd)
+    if go#has_vimproc()
+        let out = vimproc#system2(cmd)
+    else
+        let out = system(cmd)
+    endif
     if v:shell_error
         " unfortunaly oracle outputs a very long stack trace that is not
         " parsable to show the real error. But the main issue is usually the

--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -32,7 +32,12 @@ function! go#package#Paths()
     let dirs = []
 
     if executable('go')
-        let goroot = substitute(system('go env GOROOT'), '\n', '', 'g')
+        if go#has_vimproc()
+            let goroot = substitute(vimproc#system2('go env GOROOT'), '\n', '', 'g')
+        else
+            let goroot = substitute(system('go env GOROOT'), '\n', '', 'g')
+        endif
+
         if v:shell_error
             echomsg '''go env GOROOT'' failed'
         endif
@@ -96,7 +101,11 @@ function! go#package#FromPath(arg)
 endfunction
 
 function! go#package#CompleteMembers(package, member)
-    silent! let content = system('godoc ' . a:package)
+    if go#has_vimproc()
+        silent! let content = vimproc#system2('godoc ' . a:package)
+    else
+        silent! let content = system('godoc ' . a:package)
+    endif
     if v:shell_error || !len(content)
         return []
     endif

--- a/autoload/go/play.vim
+++ b/autoload/go/play.vim
@@ -14,7 +14,11 @@ function! go#play#Share(count, line1, line2)
     call writefile(split(content, "\n"), share_file, "b")
 
     let command = "curl -s -X POST http://play.golang.org/share --data-binary '@".share_file."'"
-    let snippet_id = system(command)
+    if go#has_vimproc()
+        let snippet_id = vimproc#system2(command)
+    else
+        let snippet_id = system(command)
+    endif
 
     " we can remove the temp file because it's now posted.
     call delete(share_file)

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -76,7 +76,12 @@ function! go#tool#ExecuteInDir(cmd) abort
     let dir = getcwd()
     try
         execute cd.'`=expand("%:p:h")`'
-        let out = system(a:cmd)
+
+        if go#has_vimproc()
+            let out = vimproc#system2(a:cmd)
+        else
+            let out = system(a:cmd)
+        endif
     finally
         execute cd.'`=dir`'
     endtry
@@ -174,7 +179,11 @@ function! go#tool#OpenBrowser(url)
         exec cmd
     else
         let cmd = substitute(cmd, '%URL%', '\=shellescape(a:url)', 'g')
-        call system(cmd)
+        if go#has_vimproc()
+            call system(cmd)
+        else
+            call system(cmd)
+        endif
     endif
 endfunction
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -140,7 +140,11 @@ function! s:GoInstallBinaries(updateBinaries)
                 echo "vim-go: ". basename ." not found. Installing ". pkg . " to folder " . go_bin_path
             endif
 
-            let out = system("go get -u -v ".shellescape(pkg))
+            if go#has_vimproc()
+                let out = vimproc#system2("go get -u -v ".shellescape(pkg))
+            else
+                let out = system("go get -u -v ".shellescape(pkg))
+            endif
             if v:shell_error
                 echo "Error installing ". pkg . ": " . out
             endif


### PR DESCRIPTION
On windows, when call the system() function, a console window will be showed up, which will effect the user exprience terribly.
for example, when the auto-complete was enabled every single time a key pressed a console will interrupt the auto-comple window.
It's a nightmare :(
With the help of vimproc, that nightmare is gone. :)