### PR TITLE
Add vimproc support for vim-go.

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -19,7 +19,12 @@ fu! s:gocodeCurrentBuffer()
     return file
 endf
 
-let s:vim_system = get(g:, 'gocomplete#system_function', 'system')
+
+if go#vimproc#has_vimproc()
+    let s:vim_system = get(g:, 'gocomplete#system_function', 'vimproc#system2')
+else
+    let s:vim_system = get(g:, 'gocomplete#system_function', 'system')
+endif
 
 fu! s:system(str, ...)
     return call(s:vim_system, [a:str] + a:000)

--- a/autoload/go/vimproc.vim
+++ b/autoload/go/vimproc.vim
@@ -1,0 +1,21 @@
+"Check if has vimproc
+function! go#vimproc#has_vimproc()
+    if !exists('g:go#use_vimproc')
+        if IsWin()
+            try
+                call vimproc#version()
+                let exists_vimproc = 1
+            catch
+                let exists_vimproc = 0
+            endtry
+        else
+            let exists_vimproc = 0
+        endif
+
+        let g:go#use_vimproc = exists_vimproc
+    endif
+
+    return g:go#use_vimproc
+endfunction
+
+" vim:ts=4:sw=4:et


### PR DESCRIPTION
On windows, when call the system() function, a console window will be showed up, which will effect the user exprience terribly.
for example, when the auto-complete was enabled every single time a key pressed a console will interrupt the auto-comple window.
It's a nightmare :(
With the help of vimproc, that nightmare is gone. :)