### PR TITLE
Support function literals in `af` and `if` text objects

### DIFF
--- a/autoload/go/textobj.vim
+++ b/autoload/go/textobj.vim
@@ -2,14 +2,72 @@ if !exists("g:go_textobj_enabled")
     let g:go_textobj_enabled = 1
 endif
 
+let s:funcDecl = '\(^\|\W\|\s\)\@<=func\(\s\|(\).*{'
+let s:funcBegin = '\(^\|\W\|\s\)\@<=func\(\s\|(\)'
+
+function! s:char()
+  " Borrowed from Ingo Karkat's answer on Stack Overflow:
+  " http://stackoverflow.com/a/23323958/457812
+  return matchstr(getline('.'), '\%'.col('.').'c.')
+endfunction
+
 function! go#textobj#Function(mode)
-  if search('^\s*func .*{$', 'Wce', line('.')) <= 0
-        \ && search('^\s*func .*{$', 'bWce') <= 0
-    return
-  endif
+  " spos used to return cursor back to orig. position upon failure
+  let l:spos = getpos('.')
+  let l:line = -1
+  let l:lastline = 0
+
+  while 1
+    if l:line == l:lastline
+      call cursor(l:spos[1], l:spos[2], l:spos[3])
+      return
+    endif
+
+    let l:pos = getpos('.')
+    let l:lastline = l:line
+    let l:line = l:pos[1]
+
+    " If the cursor isn't already on an opening curl, go to one
+    if s:char() != '{'
+      normal! [{
+      if l:pos[2] == col('.') && l:pos[1] == line('.')
+        call cursor(l:spos[1], l:spos[2], l:spos[3])
+        return
+      endif
+      continue
+    endif
+
+    " Look for a boundary 'func' on this line
+    if search(s:funcDecl, 'bWce', l:pos[1]) == 0
+      " Skip to next opening curl unless found
+      normal! [{
+      continue
+    end
+
+    " 'func' found
+    break
+  endwhile
+
+  " If selecting the function, use visual mode
   if a:mode == 'a'
-    normal! Va{V
+    " Skip parentheses
+    normal! vF)%h
+    " See if we hit more parentheses (means last set was tuple return)
+    if s:char() == ' ' || s:char() == "\t"
+      normal! h%
+    endif
+
+    " Jump to boundary 'func'
+    if search(s:funcBegin, 'bWc', line('.')) == 0
+      " Can still fail?
+      call cursor(l:spos[1], l:spos[2], l:spos[3])
+      return
+    endif
+
+    " Expand other end of visual block to closing brace
+    normal! o]}
   else " a:mode == 'i'
+    " Otherwise visual line mode
     normal! Vi{V
   endif
 endfunction


### PR DESCRIPTION
This is sort of a preliminary thing more for discussion than anything else. _I strongly discourage merging this_ in because of the flaw mentioned in the commit message right now (below). I'm also not even sure if this is the sane way to be doing this, I just kind of threw it together over the last hour-ish.

The changes basically switch things around such that `if` still does more or less the same thing it already does where `af` will use visual mode to select only the extents of a function definition (i.e., all of `func …(…) { … }`). This works fine assuming that the return type of a function is either a) a tuple or b) anything else or c) nothing. This does not work if the function returns a `func(…)` (regardless of that func's return type), mainly because it looks like a completely normal function literal if read in reverse, which is what the `a` path does with these changes.

So, I figured I'd throw this up as a pull request and see if you or anyone else watching this had any ideas on how to proceed with this.

Edit: For a slightly funnier option, consider a return type of `func() func() func()`.

_Actual commit message follows._

----

Works fine except for the case were a function is returning only a
function (e.g., `func() func() { ... }`). Not sure if there's a good way
around this because that would also be a valid function literal, so the
main issue is trying to sort-of parse this in reverse using just motions
and the character under the cursor doesn't work all that well.

Probably need a forward parser.