### PR TITLE
Use shiftwidth() instead of '&shiftwidth'

### DIFF
--- a/indent/go.vim
+++ b/indent/go.vim
@@ -37,20 +37,21 @@ function! GoIndent(lnum)
   let previ = indent(prevlnum)
 
   let ind = previ
+  let s:shiftwidth = shiftwidth()
 
   if prevl =~ '[({]\s*$'
     " previous line opened a block
-    let ind += &sw
+    let ind += s:shiftwidth
   endif
   if prevl =~# '^\s*\(case .*\|default\):$'
     " previous line is part of a switch statement
-    let ind += &sw
+    let ind += s:shiftwidth
   endif
   " TODO: handle if the previous line is a label.
 
   if thisl =~ '^\s*[)}]'
     " this line closed a block
-    let ind -= &sw
+    let ind -= s:shiftwidth
   endif
 
   " Colons are tricky.
@@ -58,7 +59,7 @@ function! GoIndent(lnum)
   " We ignore trying to deal with jump labels because (a) they're rare, and
   " (b) they're hard to disambiguate from a composite literal key.
   if thisl =~# '^\s*\(case .*\|default\):$'
-    let ind -= &sw
+    let ind -= s:shiftwidth
   endif
 
   return ind


### PR DESCRIPTION
I'm using vim-sleuth[1] from tpope to automatically detect indent
settings for files that I edit. The latest version sets 'shiftwidth' to
zero for files that are detected to be indented only with hard tabs, so
that the value of 'tabstop' is used instead of 'shiftwidth'. This
change[2] was done to allow people setting 'tabstop' to their preferred
value, and to have 'shiftwidth' automatically follow.

The vim documentation about 'shiftwidth' states:

     When zero the 'ts' value will be used.  Use the shiftwidth()
     function to get the effective shiftwidth value.

Therefore this commit changes using 'sw' directly and instead calls
shiftwidth().

[1] https://github.com/tpope/vim-sleuth
[2] https://github.com/tpope/vim-sleuth/commit/b6b4c3b237678f1214ea2eca0e3e50eaafb30e3a