### PR TITLE
Fix oracle scope to split on whitespace

### DIFF
--- a/autoload/go/oracle.vim
+++ b/autoload/go/oracle.vim
@@ -82,7 +82,11 @@ func! s:RunOracle(mode, selected) range abort
     if exists('g:go_oracle_scope')
         " let the user defines the scope, must be a space separated string,
         " example: 'fmt math net/http'
-        let scopes = split(shellescape(get(g:, 'go_oracle_scope')), '\W\+')
+        let unescaped_scopes = split(get(g:, 'go_oracle_scope'))
+        let scopes = []
+        for unescaped_scope in unescaped_scopes
+          call add(scopes, shellescape(unescaped_scope))
+        endfor
     elseif exists('g:go_oracle_include_tests') && pkg != -1
         " give import path so it includes all _test.go files too
         let scopes = [shellescape(pkg)]


### PR DESCRIPTION
`g:go_oracle_scope` is splitting on non-word characters, which includes valid import path characters like `/` and `.`. This fixes it to split only on whitespace.