### PR TITLE
Trim needless bracket

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -135,6 +135,11 @@ function! go#complete#Info()
     endif
 endfunction
 
+function! s:trim_bracket(val)
+    let a:val.word = substitute(a:val.word, '[(){}\[\]]\+$', '', '')
+    return a:val
+endfunction
+
 fu! go#complete#Complete(findstart, base)
     "findstart = 1 when we need to get the text length
     if a:findstart == 1
@@ -142,6 +147,10 @@ fu! go#complete#Complete(findstart, base)
         return col('.') - g:gocomplete_completions[0] - 1
         "findstart = 0 when we need to return the list of completions
     else
+        let s = getline(".")[col('.') - g:gocomplete_completions[0] - 1]
+        if s =~ '[(){}\{\}]'
+            return map(copy(g:gocomplete_completions[1]), 's:trim_bracket(v:val)')
+        endif
         return g:gocomplete_completions[1]
     endif
 endf


### PR DESCRIPTION
```
http.Handle()
```
When the cursor is at `n` on `Handle` in normal mode, and type `caw<c-x><c-o>`, we expect

```
http.DefaultMaxHeaderBytes()
```
But currently
```
http.DefaultMaxHeaderBytes(()
```
This patch remove trailing brackets (if it's not needed).
