### PR TITLE
cmd: add GoTestCompile command

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -81,13 +81,25 @@ function! go#cmd#Build(bang, ...)
     let &makeprg = default_makeprg
 endfunction
 
-function! go#cmd#Test(...)
-    let command = "go test ."
-    if len(a:000)
-        let command = "go test " . expand(a:1)
+function! go#cmd#Test(compile, ...)
+    let command = "go test "
+
+    " don't run the test, only compile it. Useful to capture and fix errors or
+    " to create a test binary.
+    if a:compile
+        let command .= "-c"
     endif
 
-    echon "vim-go: " | echohl Identifier | echon "testing ..." | echohl None
+    if len(a:000)
+        let command .= expand(a:1)
+    endif
+
+    if a:compile
+        echon "vim-go: " | echohl Identifier | echon "compiling tests ..." | echohl None
+    else
+        echon "vim-go: " | echohl Identifier | echon "testing ..." | echohl None
+    endif
+
     redraw
     let out = go#tool#ExecuteInDir(command)
     if v:shell_error
@@ -103,7 +115,12 @@ function! go#cmd#Test(...)
     else
         call setqflist([])
         cwindow
-        echon "vim-go: " | echohl Function | echon "[test] PASS" | echohl None
+
+        if a:compile
+            echon "vim-go: " | echohl Function | echon "[test] SUCCESS" | echohl None
+        else
+            echon "vim-go: " | echohl Function | echon "[test] PASS" | echohl None
+        endif
     endif
 endfunction
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -199,9 +199,18 @@ COMMANDS                                                          *go-commands*
                                                                     *:GoTest*
 :GoTest [expand]
 
-    Test your _test.go files via in your current directory. Errors are
+    Run the tests on your _test.go files via in your current directory. Errors
+    are populated in quickfix window.  If an argument is passed, 'expand' is
+    used as file selector (useful for cases like `:GoTest ./...`).
+
+                                                              *:GoTestCompile*
+:GoTestCompile [expand]
+
+    Compile your _test.go files via in your current directory. Errors are
     populated in quickfix window.  If an argument is passed, 'expand' is used
-    as file selector (useful for cases like `:GoTest ./...`).
+    as file selector (useful for cases like `:GoTest ./...`). Useful to not
+    run the tests and capture/fix errors before running the tests or to
+    create test binary.
 
                                                                 *:GoCoverage*
 :GoCoverage
@@ -358,6 +367,10 @@ Calls `go install` for the current package
                                                                  *(go-test)*
 
 Calls `go test` for the current package
+
+                                                          *(go-test-compile)*
+
+Calls `go test -c` for the current package
 
                                                              *(go-coverage)*
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -8,7 +8,8 @@ let g:go_loaded_commands = 1
 nnoremap <silent> <Plug>(go-run) :<C-u>call go#cmd#Run(expand('%'))<CR>
 nnoremap <silent> <Plug>(go-build) :<C-u>call go#cmd#Build('')<CR>
 nnoremap <silent> <Plug>(go-install) :<C-u>call go#cmd#Install()<CR>
-nnoremap <silent> <Plug>(go-test) :<C-u>call go#cmd#Test('')<CR>
+nnoremap <silent> <Plug>(go-test) :<C-u>call go#cmd#Test(0, '')<CR>
+nnoremap <silent> <Plug>(go-test-compile) :<C-u>call go#cmd#Test(1, '')<CR>
 nnoremap <silent> <Plug>(go-coverage) :<C-u>call go#cmd#Coverage('')<CR>
 nnoremap <silent> <Plug>(go-vet) :<C-u>call go#cmd#Vet()<CR>
 nnoremap <silent> <Plug>(go-files) :<C-u>call go#tool#Files()<CR>
@@ -63,7 +64,8 @@ command! -nargs=* GoInfo call go#complete#Info()
 command! -nargs=* -bang GoRun call go#cmd#Run(<bang>0,<f-args>)
 command! -nargs=* -bang GoBuild call go#cmd#Build(<bang>0,<f-args>)
 command! -nargs=* GoInstall call go#cmd#Install(<f-args>)
-command! -nargs=* GoTest call go#cmd#Test(<f-args>)
+command! -nargs=* GoTest call go#cmd#Test(0, <f-args>)
+command! -nargs=* GoTestCompile call go#cmd#Test(1, <f-args>)
 command! -nargs=* GoCoverage call go#cmd#Coverage(<f-args>)
 command! -nargs=0 GoVet call go#cmd#Vet()
 


### PR DESCRIPTION
This PR provides a new `:GoTestCompile` command to compile tests and create a test binary. It can be used to fix and capture errors before running the tests or to compile a test binary.

Closes #337 