### PR TITLE
Return basename from BinPath function

### DIFF
--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -131,7 +131,14 @@ function! go#tool#BinPath(binpath)
         return ""
     endif
 
-    return basename
+    let $PATH = old_path
+
+    let sep = '/'
+    if IsWin()
+        let sep = '\'
+    endif
+
+    return go_bin_path . sep . basename
 endfunction
 
 " following two functions are from: https://github.com/mattn/gist-vim 

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -124,17 +124,14 @@ function! go#tool#BinPath(binpath)
     let old_path = $PATH
     let $PATH = $PATH . PathSep() .go_bin_path
 
-    if !executable(binpath) 
+    if !executable(basename)
         echo "vim-go: could not find '" . basename . "'. Run :GoInstallBinaries to fix it."
+        " restore back!
+        let $PATH = old_path
         return ""
     endif
 
-    " restore back!
-    if go_bin_path
-        let $PATH = old_path
-    endif
-
-    return go_bin_path . '/' . basename
+    return basename
 endfunction
 
 " following two functions are from: https://github.com/mattn/gist-vim 


### PR DESCRIPTION
If basename not found in PATH then restore PATH and return empty string
If basename found just return it. Otherwise we could face situation when BinPath returns something like this `D:\home\go\bin/gocode`. Related problem with vimproc https://github.com/Shougo/vimproc.vim/issues/192