### PR TITLE
Use vimporc shellescape

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -31,6 +31,9 @@ fu! s:system(str, ...)
 endf
 
 fu! s:gocodeShellescape(arg)
+    if go#vimproc#has_vimproc()
+        return vimproc#shellescape(a:arg)
+    endif
     try
         let ssl_save = &shellslash
         set noshellslash
@@ -53,7 +56,7 @@ fu! s:gocodeCommand(cmd, preargs, args)
         return
     endif
 
-    let result = s:system(printf('%s %s %s %s', bin_path, join(a:preargs), a:cmd, join(a:args)))
+    let result = s:system(printf('%s %s %s %s', s:gocodeShellescape(bin_path), join(a:preargs), s:gocodeShellescape(a:cmd), join(a:args)))
     if v:shell_error != 0
         return "[\"0\", []]"
     else


### PR DESCRIPTION
I have had the same problem as @alexaandru for completiion with vimproc on windows https://gist.github.com/alexaandru/d116c229c07983f80b03

This patch fixes the problem. Tested with and without vimproc on windows and linux.

Vimproc requires that arguments for its functions [were escaped](https://github.com/Shougo/vimproc.vim/issues/192#issuecomment-76941582)
 `s:gocodeShellescape` doesn't satisfies vimproc requirements for escaping (at least on windows), so I replaced it with `vimproc#shellescape`