### PR TITLE
Fix :GoImports when g:go_fmt_options is set

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -90,8 +90,12 @@ function! go#fmt#Format(withGoimport)
         let fmt_command = bin_path
     endif
 
-    " populate the final command with user based fmt options
-    let command = fmt_command . ' ' . g:go_fmt_options
+    if a:withGoimport == 1
+        let command = fmt_command
+    else
+        " populate the final command with user based fmt options
+        let command = fmt_command . ' ' . g:go_fmt_options
+    endif
 
     " execute our command...
     let out = system(command . " " . l:tmpname)


### PR DESCRIPTION
goimports doesn't accept "go fmt" options, so don't try to append them
to the command line when we're calling goimports.