### PR TITLE
Oracle changes

### DIFF
--- a/autoload/go/oracle.vim
+++ b/autoload/go/oracle.vim
@@ -162,12 +162,6 @@ function! go#oracle#Callers(selected)
     call s:qflistSecond(out)
 endfunction
 
-" Show the callgraph of the current program.
-function! go#oracle#Callgraph(selected)
-    let out = s:RunOracle('callgraph', a:selected)
-    call s:qflistSecond(out)
-endfunction
-
 " Show path from callgraph root to selected function
 function! go#oracle#Callstack(selected)
     let out = s:RunOracle('callstack', a:selected)

--- a/autoload/go/oracle.vim
+++ b/autoload/go/oracle.vim
@@ -183,27 +183,6 @@ endfunction
 " Show all refs to entity denoted by selected identifier
 function! go#oracle#Referrers(selected)
     let out = s:RunOracle('referrers', a:selected)
-
-    " append line contents from Go source file for some messages:
-    " '...: referenced here'
-    " '...: reference to NAME'
-    let lines = split(out, "\n")
-    let extlines = []
-    for line in lines
-        if line =~# '\v: referenced here$|: reference to [^ :]*$'
-            let parts = split(line, ':')
-            " Note: we count -3 from end, to support additional comma in
-            " Windows-style C:\... paths
-            let filename = join(parts[0:-3], ':')
-            let linenum = parts[-2]
-            let extline = line . ': ' . readfile(filename, '', linenum)[linenum-1]
-            call add(extlines, extline)
-        else
-            call add(extlines, line)
-        endif
-    endfor
-    let out = join(extlines, "\n")
-
     call s:qflistSecond(out)
 endfunction
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -315,18 +315,11 @@ COMMANDS                                                          *go-commands*
     identifier), etc. Almost any piece of syntax may be described, and the
     oracle will try to print all the useful information it can.
 
-                                                              *:GoCallgraph*
-:GoCallgraph
-
-    Shows the 'callgraph' for the entire program. For more info about the
-    indentation checkout the Oracle User Manual:
-    golang.org/s/oracle-user-manual 
-
                                                               *:GoCallstack*
 :GoCallstack
 
     Shows 'callstack' relation for the selected function. An arbitrary path
-    from the root of the callgrap to the selected function is showed in a
+    from the root of the callgraph to the selected function is showed in a
     quickfix list. This may be useful to understand how the function is
     reached in a given program. 
 
@@ -491,10 +484,6 @@ Show possible callers of selected function
 
 Describe selected syntax: definition, methods, etc
 
-
-                                                            *(go-callgraph)*
-
-Show the callgraph of the current program.
 
                                                             *(go-callstack)*
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -22,7 +22,6 @@ nnoremap <silent> <Plug>(go-implements) :<C-u>call go#oracle#Implements(-1)<CR>
 nnoremap <silent> <Plug>(go-callees) :<C-u>call go#oracle#Callees(-1)<CR>
 nnoremap <silent> <Plug>(go-callers) :<C-u>call go#oracle#Callers(-1)<CR>
 nnoremap <silent> <Plug>(go-describe) :<C-u>call go#oracle#Describe(-1)<CR>
-nnoremap <silent> <Plug>(go-callgraph) :<C-u>call go#oracle#Callgraph(-1)<CR>
 nnoremap <silent> <Plug>(go-callstack) :<C-u>call go#oracle#Callstack(-1)<CR>
 nnoremap <silent> <Plug>(go-freevars) :<C-u>call go#oracle#Freevars(-1)<CR>
 nnoremap <silent> <Plug>(go-channelpeers) :<C-u>call go#oracle#ChannelPeers(-1)<CR>
@@ -50,7 +49,6 @@ command! -range=% GoImplements call go#oracle#Implements(<count>)
 command! -range=% GoCallees call go#oracle#Callees(<count>)
 command! -range=% GoDescribe call go#oracle#Describe(<count>)
 command! -range=% GoCallers call go#oracle#Callers(<count>)
-command! -range=% GoCallgraph call go#oracle#Callgraph(<count>)
 command! -range=% GoCallstack call go#oracle#Callstack(<count>)
 command! -range=% GoFreevars call go#oracle#Freevars(<count>)
 command! -range=% GoChannelPeers call go#oracle#ChannelPeers(<count>)


### PR DESCRIPTION
Includes the latest Oracle changes from https://go-review.googlesource.com/#/c/8243/

- Callgraph mode is removed, there is another tool which does it (http://golang.org/x/tools/cmd/callgraph).
- Referrers mode is now showing the matching lines, so there is no need anymore to parse them manualy (/cc @akavel )

