### PR TITLE
fix 'No match: `=dir`'

### DIFF
--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -76,10 +76,10 @@ function! go#tool#ExecuteInDir(cmd) abort
     let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
     let dir = getcwd()
     try
-        execute cd.'`=expand("%:p:h")`'
+        execute cd . fnameescape(expand("%:p:h"))
         let out = system(a:cmd)
     finally
-        execute cd.'`=dir`'
+        execute cd . fnameescape(dir)
     endtry
     return out
 endfunction


### PR DESCRIPTION
Sometimes when I'm doing `:GoImport %lib%`, I see this error:

```Error detected while processing function go#import#SwitchImport..go#tool#Exists..go#tool#ExecuteInDir:
line    7:
E480: No match: `=dir`
```