### PR TITLE
Remove trailing slash when you :GoImport github.com/user/pkg/

### DIFF
--- a/autoload/go/import.vim
+++ b/autoload/go/import.vim
@@ -50,6 +50,12 @@ function! go#import#SwitchImport(enabled, localname, path)
     if path[len(path)-1] == '"'
         let path = strpart(path, 0, len(path) - 1)
     endif
+
+    " if given a trailing slash, eg. `github.com/user/pkg/`, remove it
+    if path[len(path)-1] == '/'
+        let path = strpart(path, 0, len(path) - 1)
+    endif
+
     if path == ''
         call s:Error('Import path not provided')
         return


### PR DESCRIPTION
Removes the trailing slash when using `:GoImport`, this can happen when you happen to `<tab>` your way to the full path and forget to remove the slash yourself.