### PR TITLE
Use double quotes for regexp in TestFunc

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -146,7 +146,7 @@ function! go#cmd#TestFunc(...)
 
     let line = getline(test)
     let name = split(split(line, " ")[1], "(")[0]
-    let flag = "-run '" . name . "$'"
+    let flag = "-run \"" . name . "$\""
 
     let a1 = ""
     if len(a:000)


### PR DESCRIPTION
On Windows, I was having false negatives when using GoTestFunc, and it turns out that the regexp for go test -run doesn't match with single quotes, and so will always pass since it can't find the test. Using double quotes fixes this.