### PR TITLE
Add templates syntax highlighting 

### DIFF
--- a/ftdetect/gofiletype.vim
+++ b/ftdetect/gofiletype.vim
@@ -6,16 +6,16 @@ let s:current_fileencodings = ''
 
 " define fileencodings to open as utf-8 encoding even if it's ascii.
 function! s:gofiletype_pre()
-  let s:current_fileformats = &g:fileformats
-  let s:current_fileencodings = &g:fileencodings
-  set fileencodings=utf-8 fileformats=unix
-  setlocal filetype=go
+    let s:current_fileformats = &g:fileformats
+    let s:current_fileencodings = &g:fileencodings
+    set fileencodings=utf-8 fileformats=unix
+    setlocal filetype=go
 endfunction
 
 " restore fileencodings as others
 function! s:gofiletype_post()
-  let &g:fileformats = s:current_fileformats
-  let &g:fileencodings = s:current_fileencodings
+    let &g:fileformats = s:current_fileformats
+    let &g:fileencodings = s:current_fileencodings
 endfunction
 
 au BufNewFile *.go setlocal filetype=go fileencoding=utf-8 fileformat=unix
@@ -23,3 +23,5 @@ au BufRead *.go call s:gofiletype_pre()
 au BufReadPost *.go call s:gofiletype_post()
 
 au BufRead,BufNewFile *.tmpl set filetype=gohtmltmpl
+
+" vim:ts=4:sw=4:et

--- a/ftdetect/gofiletype.vim
+++ b/ftdetect/gofiletype.vim
@@ -23,4 +23,3 @@ au BufRead *.go call s:gofiletype_pre()
 au BufReadPost *.go call s:gofiletype_post()
 
 au BufRead,BufNewFile *.tmpl set filetype=gohtmltmpl
-

--- a/ftdetect/gofiletype.vim
+++ b/ftdetect/gofiletype.vim
@@ -21,3 +21,6 @@ endfunction
 au BufNewFile *.go setlocal filetype=go fileencoding=utf-8 fileformat=unix
 au BufRead *.go call s:gofiletype_pre()
 au BufReadPost *.go call s:gofiletype_post()
+
+au BufRead,BufNewFile *.tmpl set filetype=gohtmltmpl
+

--- a/syntax/gohtmltmpl.vim
+++ b/syntax/gohtmltmpl.vim
@@ -1,0 +1,14 @@
+if exists("b:current_syntax")
+  finish
+endif
+
+if !exists("main_syntax")
+  let main_syntax = 'html'
+endif
+
+runtime! syntax/gotexttmpl.vim
+runtime! syntax/html.vim
+unlet b:current_syntax
+
+let b:current_syntax = "gohtmltmpl"
+

--- a/syntax/gohtmltmpl.vim
+++ b/syntax/gohtmltmpl.vim
@@ -11,4 +11,3 @@ runtime! syntax/html.vim
 unlet b:current_syntax
 
 let b:current_syntax = "gohtmltmpl"
-

--- a/syntax/gohtmltmpl.vim
+++ b/syntax/gohtmltmpl.vim
@@ -1,9 +1,9 @@
 if exists("b:current_syntax")
-  finish
+    finish
 endif
 
 if !exists("main_syntax")
-  let main_syntax = 'html'
+    let main_syntax = 'html'
 endif
 
 runtime! syntax/gotexttmpl.vim
@@ -11,3 +11,5 @@ runtime! syntax/html.vim
 unlet b:current_syntax
 
 let b:current_syntax = "gohtmltmpl"
+
+" vim:ts=4:sw=4:et

--- a/syntax/gotexttmpl.vim
+++ b/syntax/gotexttmpl.vim
@@ -6,7 +6,7 @@
 
 " Quit when a (custom) syntax file was already loaded
 if exists("b:current_syntax")
-  finish
+    finish
 endif
 
 syn case match
@@ -81,3 +81,5 @@ hi def link gotplAction PreProc
 hi def link goTplComment Comment
 
 let b:current_syntax = "gotexttmpl"
+
+" vim:ts=4:sw=4:et

--- a/syntax/gotexttmpl.vim
+++ b/syntax/gotexttmpl.vim
@@ -81,4 +81,3 @@ hi def link gotplAction PreProc
 hi def link goTplComment Comment
 
 let b:current_syntax = "gotexttmpl"
-

--- a/syntax/gotexttmpl.vim
+++ b/syntax/gotexttmpl.vim
@@ -1,0 +1,84 @@
+" Copyright 2011 The Go Authors. All rights reserved.
+" Use of this source code is governed by a BSD-style
+" license that can be found in the LICENSE file.
+"
+" gotexttmpl.vim: Vim syntax file for Go templates.
+
+" Quit when a (custom) syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+syn case match
+
+" Go escapes
+syn match       goEscapeOctal       display contained "\\[0-7]\{3}"
+syn match       goEscapeC           display contained +\\[abfnrtv\\'"]+
+syn match       goEscapeX           display contained "\\x\x\{2}"
+syn match       goEscapeU           display contained "\\u\x\{4}"
+syn match       goEscapeBigU        display contained "\\U\x\{8}"
+syn match       goEscapeError       display contained +\\[^0-7xuUabfnrtv\\'"]+
+
+hi def link     goEscapeOctal       goSpecialString
+hi def link     goEscapeC           goSpecialString
+hi def link     goEscapeX           goSpecialString
+hi def link     goEscapeU           goSpecialString
+hi def link     goEscapeBigU        goSpecialString
+hi def link     goSpecialString     Special
+hi def link     goEscapeError       Error
+
+" Strings and their contents
+syn cluster     goStringGroup       contains=goEscapeOctal,goEscapeC,goEscapeX,goEscapeU,goEscapeBigU,goEscapeError
+syn region      goString            contained start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@goStringGroup
+syn region      goRawString         contained start=+`+ end=+`+
+
+hi def link     goString            String
+hi def link     goRawString         String
+
+" Characters; their contents
+syn cluster     goCharacterGroup    contains=goEscapeOctal,goEscapeC,goEscapeX,goEscapeU,goEscapeBigU
+syn region      goCharacter         start=+'+ skip=+\\\\\|\\'+ end=+'+ contains=@goCharacterGroup
+
+hi def link     goCharacter         Character
+
+" Integers
+syn match       goDecimalInt        contained "\<\d\+\([Ee]\d\+\)\?\>"
+syn match       goHexadecimalInt    contained "\<0x\x\+\>"
+syn match       goOctalInt          contained "\<0\o\+\>"
+syn match       goOctalError        contained "\<0\o*[89]\d*\>"
+syn cluster     goInt               contains=goDecimalInt,goHexadecimalInt,goOctalInt
+" Floating point
+syn match       goFloat             contained "\<\d\+\.\d*\([Ee][-+]\d\+\)\?\>"
+syn match       goFloat             contained "\<\.\d\+\([Ee][-+]\d\+\)\?\>"
+syn match       goFloat             contained "\<\d\+[Ee][-+]\d\+\>"
+" Imaginary literals
+syn match       goImaginary         contained "\<\d\+i\>"
+syn match       goImaginary         contained "\<\d\+\.\d*\([Ee][-+]\d\+\)\?i\>"
+syn match       goImaginary         contained "\<\.\d\+\([Ee][-+]\d\+\)\?i\>"
+syn match       goImaginary         contained "\<\d\+[Ee][-+]\d\+i\>"
+
+hi def link     goInt        Number
+hi def link     goFloat      Number
+hi def link     goImaginary  Number
+
+" Token groups
+syn cluster     gotplLiteral     contains=goString,goRawString,goCharacter,@goInt,goFloat,goImaginary
+syn keyword     gotplControl     contained   if else end range with template
+syn keyword     gotplFunctions   contained   and html index js len not or print printf println urlquery eq ne lt le gt ge
+syn match       gotplVariable    contained   /\$[^ ]*\>/
+syn match       goTplIdentifier  contained   /\.[^ ]*\>/
+
+hi def link     gotplControl        Keyword
+hi def link     gotplFunctions      Function
+hi def link     goTplVariable       Special
+
+syn region gotplAction start="{{" end="}}" contains=@gotplLiteral,gotplControl,gotplFunctions,gotplVariable,goTplIdentifier display
+syn region gotplAction start="\[\[" end="\]\]" contains=@gotplLiteral,gotplControl,gotplFunctions,gotplVariable display
+syn region goTplComment start="{{/\*" end="\*/}}" display
+syn region goTplComment start="\[\[/\*" end="\*/\]\]" display
+
+hi def link gotplAction PreProc
+hi def link goTplComment Comment
+
+let b:current_syntax = "gotexttmpl"
+


### PR DESCRIPTION
By default all .tmpl files will use the html/template syntax highlighting. However, you can apply highlighting to any file by using `:set syntax=gohtmltmpl`