### PR TITLE
Provide default value for rename input

### DIFF
--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -5,8 +5,9 @@ endif
 function! go#rename#Rename(...)
     let to = ""
     if a:0 == 0
-        let ask = printf("vim-go: rename '%s' to: ",  expand("<cword>"))
-        let to = input(ask)
+        let from = expand("<cword>")
+        let ask = printf("vim-go: rename '%s' to: ", from)
+        let to = input(ask, from)
         redraw
     else
         let to = a:1


### PR DESCRIPTION
In the prompt, the default value now is the previous symbol.
You see: vim-go: rename 'xxxx' to: xxx
and then you can edit the symbol by starting from the previous name. Many code refactor tools provides this. It is useful when you want to rename a word to something similar without retyping it.