### PR TITLE
Improve to detect 'no documentation'

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -71,6 +71,14 @@ function! s:godocWord(args)
     return [pkg, exported_name]
 endfunction
 
+function! s:godocNotFound(content)
+    if len(a:content) == 0
+        return 1
+    endif
+
+    return a:content =~# '^.*: no such file or directory\n'
+endfunction
+
 function! go#doc#OpenBrowser(...)
     let pkgs = s:godocWord(a:000)
     if empty(pkgs)
@@ -97,7 +105,7 @@ function! go#doc#Open(newmode, mode, ...)
     let command = g:go_doc_command . ' ' . g:go_doc_options . ' ' . pkg
 
     silent! let content = system(command)
-    if v:shell_error || !len(content)
+    if v:shell_error || s:godocNotFound(content)
         echo 'No documentation found for "' . pkg . '".'
         return -1
     endif


### PR DESCRIPTION
## Problem

When `godoc` can't find any package for corresponding query like below,

    :GoDoc foobar

`:GoDoc` opens the window for 'not found' result like as below.

    2015/04/21 03:58:02 open /usr/local/Cellar/go/1.4.2/libexec/src/foobar: no such file or directory

## Solution

I fixed this problem with checking the content of result.
With this fix, `:GoDoc` command correctly echoes 'not found' result without opening window as
below.

    No documentation found for "foobar".

