### PR TITLE
Operator highlighting cleanup/fixes

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -236,13 +236,11 @@ hi def link     goTodo              Todo
 
 " Operators; 
 if g:go_highlight_operators != 0
-	" match single-char operators:          - + % < > ! & | ^ =
-	" and corresponding two-char operators: -= += %= <= >= != &= |= ^= ==
-	syn match goOperator /[-+%<>!&|\^=]=\?/
-	" match * and *=
-	syn match goOperator /[^\/]\zs\*=\?/
+	" match single-char operators:          - + % < > ! & | ^ * =
+	" and corresponding two-char operators: -= += %= <= >= != &= |= ^= *= ==
+	syn match goOperator /[-+%<>!&|^*=]=\?/
 	" match / and /=
-	syn match goOperator /\/\%(=\|\ze[^\/\*]\)/
+	syn match goOperator /\/\%(=\|\ze[^/*]\)/
 	" match two-char operators:               << >> &^
 	" and corresponding three-char operators: <<= >>= &^=
 	syn match goOperator /\%(<<\|>>\|&^\)=\?/


### PR DESCRIPTION
* Fix highlighting of X*foo where X is any other syntax match by
  removing unnecessary comment-matching protection
* Remove some unnecessary escaping in character classes

Fixes #394.