### PR TITLE
Use Dispatch when available

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -6,17 +6,6 @@ if !exists("g:go_dispatch_enabled")
     let g:go_dispatch_enabled = 0
 endif
 
-" Run either `make` or `Make` depending on the user's configuration
-" `Make` required the vim-dispatch plugin by Tim Pope.
-" https://github.com/tpope/vim-dispatch
-function! s:runMake(...)
-    if g:go_dispatch_enabled && exists(':Make') == 2
-        silent exe 'Make'
-    else
-        silent exe 'make!'
-    endif
-endfunction
-
 function! go#cmd#Run(bang, ...)
     let goFiles = '"' . join(go#tool#Files(), '" "') . '"'
 
@@ -38,7 +27,11 @@ function! go#cmd#Run(bang, ...)
         let &makeprg = "go run " . expand(a:1)
     endif
 
-    call s:runMake()
+    if g:go_dispatch_enabled && exists(':Make') == 2
+        silent! exe 'Make!'
+    else
+        exe 'make!'
+    endif
     if !a:bang
         cwindow
         let errors = getqflist()
@@ -79,7 +72,11 @@ function! go#cmd#Build(bang, ...)
     endif
 
     echon "vim-go: " | echohl Identifier | echon "building ..."| echohl None
-    call s:runMake()
+    if g:go_dispatch_enabled && exists(':Make') == 2
+        silent! exe 'Make'
+    else
+        silent! exe 'make!'
+    endif
     redraw!
     if !a:bang
         cwindow

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -23,7 +23,11 @@ function! go#cmd#Run(bang, ...)
         let &makeprg = "go run " . expand(a:1)
     endif
 
-    exe 'make!'
+    if exists(':Make') == 2
+        silent! exe 'Make'
+    else
+        exe 'make!'
+    endif
     if !a:bang
         cwindow
         let errors = getqflist()
@@ -64,7 +68,11 @@ function! go#cmd#Build(bang, ...)
     endif
 
     echon "vim-go: " | echohl Identifier | echon "building ..."| echohl None
-    silent! exe 'make!'
+    if exists(':Make')
+        silent! exe 'Make!'
+    else
+        silent! exe 'make!'
+    endif
     redraw!
     if !a:bang
         cwindow
@@ -153,7 +161,7 @@ function! go#cmd#TestFunc(...)
         let a1 = a:1
 
         " add extra space
-        let flag = " " . flag 
+        let flag = " " . flag
     endif
 
     call go#cmd#Test(0, a1, flag)

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -2,6 +2,13 @@ if !exists("g:go_jump_to_error")
     let g:go_jump_to_error = 1
 endif
 
+if !exists("g:go_dispatch_enabled")
+    let g:go_dispatch_enabled = 0
+endif
+
+" Run either `make` or `Make` depending on the user's configuration
+" `Make` required the vim-dispatch plugin by Tim Pope.
+" https://github.com/tpope/vim-dispatch
 function! s:runMake(...)
     if g:go_dispatch_enabled && exists(':Make') == 2
         silent exe 'Make'

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -2,6 +2,14 @@ if !exists("g:go_jump_to_error")
     let g:go_jump_to_error = 1
 endif
 
+function! s:runMake(...)
+    if g:go_dispatch_enabled && exists(':Make') == 2
+        silent exe 'Make'
+    else
+        silent exe 'make!'
+    endif
+endfunction
+
 function! go#cmd#Run(bang, ...)
     let goFiles = '"' . join(go#tool#Files(), '" "') . '"'
 
@@ -23,11 +31,7 @@ function! go#cmd#Run(bang, ...)
         let &makeprg = "go run " . expand(a:1)
     endif
 
-    if exists(':Make') == 2
-        silent! exe 'Make'
-    else
-        exe 'make!'
-    endif
+    call s:runMake()
     if !a:bang
         cwindow
         let errors = getqflist()
@@ -68,11 +72,7 @@ function! go#cmd#Build(bang, ...)
     endif
 
     echon "vim-go: " | echohl Identifier | echon "building ..."| echohl None
-    if exists(':Make')
-        silent! exe 'Make!'
-    else
-        silent! exe 'make!'
-    endif
+    call s:runMake()
     redraw!
     if !a:bang
         cwindow

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -71,12 +71,12 @@ add the appropriate lines and execute the plugin's install command.
 <
 
 *  https://github.com/junegunn/vim-plug >
-  
+
     Plug 'fatih/vim-go'
 
 <
 *  https://github.com/Shougo/neobundle.vim >
-  
+
     NeoBundle 'fatih/vim-go'
 <
 
@@ -86,7 +86,7 @@ add the appropriate lines and execute the plugin's install command.
 
 <
 *  Manual >
-  
+
     Copy all of the files into your `~/.vim` directory
 <
 
@@ -231,8 +231,8 @@ COMMANDS                                                          *go-commands*
     Runs :GoTest, but only on the single test function immediate to your
     cursor using 'go test's '-run' flag.
 
-    Lookup is done starting at the cursor (including that line) moving up till 
-    a matching `func Test` pattern is found or top of file is reached. Search 
+    Lookup is done starting at the cursor (including that line) moving up till
+    a matching `func Test` pattern is found or top of file is reached. Search
     will not wrap around when at the top of the file.
 
                                                               *:GoTestCompile*
@@ -284,7 +284,7 @@ COMMANDS                                                          *go-commands*
 
     Show 'implements' relation for a selected package. A list of interfaces
     for the type that implements an interface under the cursor (or selected
-    package) is shown quickfix list. 
+    package) is shown quickfix list.
                                                                 *:GoRename*
 :GoRename [to]
 
@@ -320,14 +320,14 @@ COMMANDS                                                          *go-commands*
     Shows 'callstack' relation for the selected function. An arbitrary path
     from the root of the callgraph to the selected function is showed in a
     quickfix list. This may be useful to understand how the function is
-    reached in a given program. 
+    reached in a given program.
 
                                                               *:GoFreevars*
 :GoFreevars
 
     Enumerates the free variables of the selection. “Free variables” is a
     technical term meaning the set of variables that are referenced but not
-    defined within the selection, or loosely speaking, its inputs. 
+    defined within the selection, or loosely speaking, its inputs.
 
     This information is useful if you’re considering whether to refactor the
     selection into a function of its own, as the free variables would be the
@@ -339,11 +339,11 @@ COMMANDS                                                          *go-commands*
 :GoChannelPeers
 
     Shows the set of possible sends/receives on the channel operand of the
-    selected send or receive operation; the selection must be a <- token. 
+    selected send or receive operation; the selection must be a <- token.
 
-    For example, visually select a channel operand in the form of: 
+    For example, visually select a channel operand in the form of:
 
-      "done <- true" 
+      "done <- true"
 
     and call |GoChannelPeers| on it. It will show where it was allocated, and
     the sending and receiving endings.
@@ -598,6 +598,14 @@ enabled. Disabling it allows you to map something else to the mapping `gd`.
 Default is enabled. >
 
   let g:go_def_mapping_enabled = 1
+<
+                                                    *'g:go_dispatch_enabled'*
+
+Use this option to enable/disable the use of Dispatch to execute the
+`:GoGun` and `:GoBuild` commands.  More information about Dispatch is
+available at https://github.com/tpope/vim-dispatch. Default is disabled. >
+
+  let g:go_dispatch_enabled = 0
 <
                                                          *'g:go_doc_command'*
 


### PR DESCRIPTION
This has `vim-go` check for the `:Make` command provided by Tim Pope's [`vim-dispatch`](https://github.com/tpope/vim-dispatch) before using `make`, and if it's available, uses that instead.  This allows the `GoBuild` and `GoRun` commands to be run in a Tmux split instead, which is both asynchronous and a _lot_ faster.

I did a little profiling, and it seems like the performance increase is pretty significant

**`:GoBuild` profiling**

| Time | `make` | `Make` (Dispatch) |
| :-- | :--         | :-- |
| Total | 1.055178 s | 0.173488 s |
| Self | 0.016310 s | 0.008696 s |

If you want to check out the full profiling that I did, you can find the files [here](https://gist.github.com/alexlafroscia/d7d351c6fc9834efebe9)