### PR TITLE
cmd: auto jump to error for :GoInstall

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -52,6 +52,12 @@ function! go#cmd#Install(...)
     if v:shell_error
         call go#tool#ShowErrors(out)
         cwindow
+        let errors = getqflist()
+        if !empty(errors)
+            if g:go_jump_to_error
+                cc 1 "jump to first error if there is any
+            endif
+        endif
         return
     endif
 


### PR DESCRIPTION
There is no auto jump to errors for `:GoInstall`. All other commands have this. Just adding the missing piece.