### PR TITLE
gb support

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -50,7 +50,7 @@ function! go#cmd#Install(...)
     let command = 'go install "' . pkgs . '"'
     let out = go#tool#ExecuteInDir(command)
     if v:shell_error
-        call go#tool#ShowErrors(out)
+        call go#tool#ShowErrors(out, 1)
         cwindow
         let errors = getqflist()
         if !empty(errors)
@@ -125,7 +125,7 @@ function! go#cmd#Test(compile, ...)
     redraw
     let out = go#tool#ExecuteInDir(command)
     if v:shell_error
-        call go#tool#ShowErrors(out)
+        call go#tool#ShowErrors(out, 1)
         cwindow
         let errors = getqflist()
         if !empty(errors)
@@ -184,7 +184,7 @@ function! go#cmd#Coverage(...)
 
     let out = go#tool#ExecuteInDir(command)
     if v:shell_error
-        call go#tool#ShowErrors(out)
+        call go#tool#ShowErrors(out, 1)
     else
         " clear previous quick fix window
         call setqflist([])
@@ -208,7 +208,7 @@ function! go#cmd#Vet()
     echon "vim-go: " | echohl Identifier | echon "calling vet..." | echohl None
     let out = go#tool#ExecuteInDir('go vet')
     if v:shell_error
-        call go#tool#ShowErrors(out)
+        call go#tool#ShowErrors(out, 1)
     else
         call setqflist([])
     endif

--- a/autoload/go/gb.vim
+++ b/autoload/go/gb.vim
@@ -1,5 +1,35 @@
-function! go#gb#Build(bang, ...)
-		echo "calling gb build!"
+if !exists("g:go_jump_to_error")
+    let g:go_jump_to_error = 1
+endif
+
+" Build builds the project with 'gb build' and the passed arguments to it
+function! go#gb#Build(...)
+    let command = 'gb build '
+    if len(a:000)
+        let pkgs = join(a:000, ' ')
+        let command = 'gb build ' . pkgs
+    endif
+
+    echon "vim-go: " | echohl Identifier | echon "building ..."| echohl None
+    let out = go#tool#ExecuteInDir(command)
+    if v:shell_error
+        call go#tool#ShowErrors(out)
+        cwindow
+        let errors = getqflist()
+        if !empty(errors)
+            if g:go_jump_to_error
+                cc 1 "jump to first error if there is any
+            endif
+        endif
+        return
+    endif
+
+    redraws! | echon "vim-go: " | echohl Function | echon "[gb build] SUCCESS"| echohl None
+endfunction
+
+" BuildAll builds the project with 'gb build all'
+function! go#gb#BuildAll()
+    return go#gb#Build("all")
 endfunction
 
 " vim:ts=4:sw=4:et

--- a/autoload/go/gb.vim
+++ b/autoload/go/gb.vim
@@ -13,7 +13,17 @@ function! go#gb#Build(...)
     echon "vim-go: " | echohl Identifier | echon "building ..."| echohl None
     let out = go#tool#ExecuteInDir(command)
     if v:shell_error
-        call go#tool#ShowErrors(out)
+        let root_path = s:findProjectRoot()
+        if empty(root_path)
+              redraws! | echon "vim-go: [run] " | echohl ErrorMsg | echon "[gb build] PROJECT root not found"| echohl None
+            return
+        endif
+
+        let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
+        let current_dir = getcwd()
+        execute cd . fnameescape(root_path)
+
+        call go#tool#ShowErrors(out, 0)
         cwindow
         let errors = getqflist()
         if !empty(errors)
@@ -21,6 +31,8 @@ function! go#gb#Build(...)
                 cc 1 "jump to first error if there is any
             endif
         endif
+
+        execute cd . fnameescape(current_dir)
         return
     endif
 
@@ -41,7 +53,7 @@ function! s:findProjectRoot()
       return ''
     endif
 
-    return fnamemodify(root_path, ':p:h')
+    return fnamemodify(root_path, ':p:h:h')
 endfunction
 
 

--- a/autoload/go/gb.vim
+++ b/autoload/go/gb.vim
@@ -32,4 +32,17 @@ function! go#gb#BuildAll()
     return go#gb#Build("all")
 endfunction
 
+" findProjectRoot returns the project root by searching the src/ folder
+" recursively until it's been found till `/`
+function! s:findProjectRoot()
+    let current_dir = fnameescape(expand('%:p:h'))
+    let root_path = finddir("src/", current_dir .";")
+    if empty(root_path)
+      return ''
+    endif
+
+    return fnamemodify(root_path, ':p:h')
+endfunction
+
+
 " vim:ts=4:sw=4:et

--- a/autoload/go/gb.vim
+++ b/autoload/go/gb.vim
@@ -1,0 +1,5 @@
+function! go#gb#Build(bang, ...)
+		echo "calling gb build!"
+endfunction
+
+" vim:ts=4:sw=4:et

--- a/autoload/go/gb.vim
+++ b/autoload/go/gb.vim
@@ -36,6 +36,9 @@ function! go#gb#Build(...)
         return
     endif
 
+    " clear previous build errors
+    call setqflist([])
+    cwindow
     redraws! | echon "vim-go: " | echohl Function | echon "[gb build] SUCCESS"| echohl None
 endfunction
 

--- a/autoload/go/gb.vim
+++ b/autoload/go/gb.vim
@@ -52,6 +52,12 @@ endfunction
 " findProjectRoot returns the project root by searching the src/ folder
 " recursively until it's been found till `/`
 function! s:findProjectRoot()
+    " if set just return it
+    if $GB_PROJECT_DIR != ""
+        return $GB_PROJECT_DIR
+    endif
+
+    " otherwise go and search for the project diretory root path
     let current_dir = fnameescape(expand('%:p:h'))
     let root_path = finddir("src/", current_dir .";")
     if empty(root_path)
@@ -60,6 +66,5 @@ function! s:findProjectRoot()
 
     return fnamemodify(root_path, ':p:h:h')
 endfunction
-
 
 " vim:ts=4:sw=4:et

--- a/autoload/go/gb.vim
+++ b/autoload/go/gb.vim
@@ -11,11 +11,13 @@ function! go#gb#Build(...)
     endif
 
     echon "vim-go: " | echohl Identifier | echon "building ..."| echohl None
+    redraw
+
     let out = go#tool#ExecuteInDir(command)
     if v:shell_error
         let root_path = s:findProjectRoot()
         if empty(root_path)
-              redraws! | echon "vim-go: [run] " | echohl ErrorMsg | echon "[gb build] PROJECT root not found"| echohl None
+              echon "vim-go: [run] " | echohl ErrorMsg | echon "[gb build] PROJECT root not found"| echohl None
             return
         endif
 
@@ -39,7 +41,7 @@ function! go#gb#Build(...)
     " clear previous build errors
     call setqflist([])
     cwindow
-    redraws! | echon "vim-go: " | echohl Function | echon "[gb build] SUCCESS"| echohl None
+    echon "vim-go: " | echohl Function | echon "[gb build] SUCCESS"| echohl None
 endfunction
 
 " BuildAll builds the project with 'gb build all'

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -40,15 +40,17 @@ function! go#tool#Imports()
     return imports
 endfunction
 
-function! go#tool#ShowErrors(out)
+function! go#tool#ShowErrors(out, cd)
     " cd into the current files directory. This is important so fnamemodify
     " does create a full path for outputs when the token is only a single file
     " name (such as for a go test output, i.e.: 'demo_test.go'). For other
     " outputs, such as 'go install' we already get an absolute path (i.e.:
     " '../foo/foo.go') and fnamemodify successfuly creates the full path.
-    let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
-    let current_dir = getcwd()
-    execute cd . fnameescape(expand("%:p:h"))
+    if a:cd
+        let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
+        let current_dir = getcwd()
+        execute cd . fnameescape(expand("%:p:h"))
+    endif
 
     let errors = []
 
@@ -72,7 +74,9 @@ function! go#tool#ShowErrors(out)
     endfor
 
     " return back to old dir once we are finished with populating the errors
-    execute cd . fnameescape(current_dir)
+    if a:cd
+        execute cd . fnameescape(current_dir)
+    endif
 
     if !empty(errors)
         call setqflist(errors, 'r')

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -43,8 +43,8 @@ nnoremap <silent> <Plug>(go-doc-browser) :<C-u>call go#doc#OpenBrowser()<CR>
 
 nnoremap <silent> <Plug>(go-gbbuild) :<C-u>call go#gb#Build()<CR>
 
-command! -nargs=* -bang GbBuild call go#gb#Build(<f-args>)
-command! -nargs=* -bang GbBuildAll call go#gb#BuildAll()
+command -nargs=* -bang GbBuild call go#gb#Build(<f-args>)
+command -nargs=* -bang GbBuildAll call go#gb#BuildAll()
 
 " gorename
 command! -nargs=? GoRename call go#rename#Rename(<f-args>)

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -41,8 +41,10 @@ nnoremap <silent> <Plug>(go-doc-split) :<C-u>call go#doc#Open("new", "split")<CR
 nnoremap <silent> <Plug>(go-doc-browser) :<C-u>call go#doc#OpenBrowser()<CR>
 
 
-nnoremap <silent> <Plug>(go-gbbuild) :<C-u>call go#gb#Build('')<CR>
-command! -nargs=* -bang GbBuild call go#gb#Build(<bang>0,<f-args>)
+nnoremap <silent> <Plug>(go-gbbuild) :<C-u>call go#gb#Build()<CR>
+
+command! -nargs=* -bang GbBuild call go#gb#Build(<f-args>)
+command! -nargs=* -bang GbBuildAll call go#gb#BuildAll()
 
 " gorename
 command! -nargs=? GoRename call go#rename#Rename(<f-args>)

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -41,6 +41,9 @@ nnoremap <silent> <Plug>(go-doc-split) :<C-u>call go#doc#Open("new", "split")<CR
 nnoremap <silent> <Plug>(go-doc-browser) :<C-u>call go#doc#OpenBrowser()<CR>
 
 
+nnoremap <silent> <Plug>(go-gbbuild) :<C-u>call go#gb#Build('')<CR>
+command! -nargs=* -bang GbBuild call go#gb#Build(<bang>0,<f-args>)
+
 " gorename
 command! -nargs=? GoRename call go#rename#Rename(<f-args>)
 


### PR DESCRIPTION
This PR aims to bring full support for the http://getgb.io/ project. 

Currently implemented commands are:

* `:GbBuild` (valid arguments to `gb build` can be given, if not plan `gb build` is called)
* `:GbBuildAll` invokes `gb build all`

It doesn't matter from which directory the file is being edited. vim-go automatically finds the `$PROJECT` and populating the errors based on it. You don't need to do anything.

Todos:
- [x] Check `GB_PROJECT_DIR` to retrieve the project dir
- [ ] Implement `:GbFiles`
- [x] Implement `:GbTest`
- [ ] Implement `:GbImports`, this should be use the existing auto fmt hook we have currently

--

vim-go is a plugin to develop go code within vim. I'm always trying to add features to it (and also allow), to make it productive for everyone. `gb` is a very new tool and needs some traction of course. That's why I'm thinking of creating a new `vim-gb` plugin that is totally compatible and  orthogonal to `vim-go`. However I'm not sure about it, the current approach might be the correct one (may be). 

I'm curious about any thoughts here so please just comment on this :)


