### PR TITLE
Gopath detection and support for godep. Closes #425

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,23 @@ disabled/enabled easily.
 * Compile your package with `:GoBuild` , install it with `:GoInstall`
 * `:GoRun` quickly your current file/files
 * Run `:GoTest` and see any errors in quickfix window
+* Automatic `GOPATH` detection based on the directory structure (i.e: `godep`
+  vendored projects)
+* Change `GOPATH` with `:GoPath`, restore back to original at any time with
+  `:GoPathClear`
 * Create a coverage profile and display annotated source code in browser to see
   which functions are covered with `:GoCoverage`
 * Lint your code with `:GoLint`
 * Run your code through `:GoVet` to catch static errors.
-* Advanced source analysis tool with oracle, such as `:GoImplements`, `:GoCallees`, `:GoReferrers`
+* Advanced source analysis tool with oracle, such as `:GoImplements`,
+  `:GoCallees`, `:GoReferrers`
 * Precise type-safe renaming of identifiers with `:GoRename`
 * List all source files and dependencies
 * Checking with `:GoErrCheck` for unchecked errors.
 * Integrated and improved snippets. Supports `ultisnips` or `neosnippet`
 * Share your current code to [play.golang.org](http://play.golang.org) with `:GoPlay`
-* On-the-fly type information about the word under the cursor. Plug it into your custom vim function.
+* On-the-fly type information about the word under the cursor. Plug it into
+  your custom vim function.
 * Tagbar support to show tags of the source code in a sidebar with `gotags`
 * Custom vim text objects, such a `a function` or `inner function`
 

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -21,7 +21,7 @@ function! go#cmd#Build(bang, ...)
     let gofiles = join(go#tool#Files(), '" "')
 
     let old_gopath = $GOPATH
-    let $GOPATH = DetectGoPath()
+    let $GOPATH = go#path#Detect()
 
     if v:shell_error
         let &makeprg = "go build . errors"
@@ -60,9 +60,9 @@ function! go#cmd#Run(bang, ...)
     let goFiles = '"' . join(go#tool#Files(), '" "') . '"'
 
     let old_gopath = $GOPATH
-    let $GOPATH = DetectGoPath()
+    let $GOPATH = go#path#Detect()
 
-    if IsWin()
+    if go#util#IsWin()
         exec '!go run ' . goFiles
         if v:shell_error
             redraws! | echon "vim-go: [run] " | echohl ErrorMsg | echon "FAILED"| echohl None

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -12,72 +12,17 @@ function! go#cmd#autowrite()
     endif
 endfunction
 
-function! go#cmd#Run(bang, ...)
-    let goFiles = '"' . join(go#tool#Files(), '" "') . '"'
-
-    if IsWin()
-        exec '!go run ' . goFiles
-        if v:shell_error
-            redraws! | echon "vim-go: [run] " | echohl ErrorMsg | echon "FAILED"| echohl None
-        else
-            redraws! | echon "vim-go: [run] " | echohl Function | echon "SUCCESS"| echohl None
-        endif
-
-        return
-    endif
-
-    let default_makeprg = &makeprg
-    if !len(a:000)
-        let &makeprg = 'go run ' . goFiles
-    else
-        let &makeprg = "go run " . expand(a:1)
-    endif
-
-    if g:go_dispatch_enabled && exists(':Make') == 2
-        silent! exe 'Make!'
-    else
-        exe 'make!'
-    endif
-    if !a:bang
-        cwindow
-        let errors = getqflist()
-        if !empty(errors)
-            if g:go_jump_to_error
-                cc 1 "jump to first error if there is any
-            endif
-        endif
-    endif
-
-    let &makeprg = default_makeprg
-endfunction
-
-function! go#cmd#Install(...)
-    let pkgs = join(a:000, '" "')
-    let command = 'go install "' . pkgs . '"'
-    call go#cmd#autowrite()
-    let out = go#tool#ExecuteInDir(command)
-    if v:shell_error
-        call go#tool#ShowErrors(out)
-        cwindow
-        let errors = getqflist()
-        if !empty(errors)
-            if g:go_jump_to_error
-                cc 1 "jump to first error if there is any
-            endif
-        endif
-        return
-    endif
-
-    if exists("$GOBIN")
-        echon "vim-go: " | echohl Function | echon "installed to ". $GOBIN | echohl None
-    else
-        echon "vim-go: " | echohl Function | echon "installed to ". $GOPATH . "/bin" | echohl None
-    endif
-endfunction
-
+" Build buils the source code without producting any output binary. We live in
+" an editor so the best is to build it to catch errors and fix them. By
+" default it tries to call simply 'go build', but it first tries to get all
+" dependent files for the current folder and passes it to go build.
 function! go#cmd#Build(bang, ...)
     let default_makeprg = &makeprg
     let gofiles = join(go#tool#Files(), '" "')
+
+    let old_gopath = $GOPATH
+    let $GOPATH = DetectGoPath()
+
     if v:shell_error
         let &makeprg = "go build . errors"
     else
@@ -104,8 +49,83 @@ function! go#cmd#Build(bang, ...)
     endif
 
     let &makeprg = default_makeprg
+    let $GOPATH = old_gopath
 endfunction
 
+" Run runs the current file (and their dependencies if any) and outputs it.
+" This is intented to test small programs and play with them. It's not
+" suitable for long running apps, because vim is blocking by default and
+" calling long running apps will block the whole UI.
+function! go#cmd#Run(bang, ...)
+    let goFiles = '"' . join(go#tool#Files(), '" "') . '"'
+
+    let old_gopath = $GOPATH
+    let $GOPATH = DetectGoPath()
+
+    if IsWin()
+        exec '!go run ' . goFiles
+        if v:shell_error
+            redraws! | echon "vim-go: [run] " | echohl ErrorMsg | echon "FAILED"| echohl None
+        else
+            redraws! | echon "vim-go: [run] " | echohl Function | echon "SUCCESS"| echohl None
+        endif
+
+        let $GOPATH = old_gopath
+        return
+    endif
+
+    let default_makeprg = &makeprg
+    if !len(a:000)
+        let &makeprg = 'go run ' . goFiles
+    else
+        let &makeprg = "go run " . expand(a:1)
+    endif
+
+    if g:go_dispatch_enabled && exists(':Make') == 2
+        silent! exe 'Make!'
+    else
+        exe 'make!'
+    endif
+    if !a:bang
+        cwindow
+        let errors = getqflist()
+        if !empty(errors)
+            if g:go_jump_to_error
+                cc 1 "jump to first error if there is any
+            endif
+        endif
+    endif
+
+    let $GOPATH = old_gopath
+    let &makeprg = default_makeprg
+endfunction
+
+" Install installs the package by simple calling 'go install'. If any argument
+" is given(which are passed directly to 'go insta'') it tries to install those
+" packages. Errors are populated in the quickfix window.
+function! go#cmd#Install(...)
+    let pkgs = join(a:000, '" "')
+    let command = 'go install "' . pkgs . '"'
+    call go#cmd#autowrite()
+    let out = go#tool#ExecuteInDir(command)
+    if v:shell_error
+        call go#tool#ShowErrors(out)
+        cwindow
+        let errors = getqflist()
+        if !empty(errors)
+            if g:go_jump_to_error
+                cc 1 "jump to first error if there is any
+            endif
+        endif
+        return
+    endif
+
+    echon "vim-go: " | echohl Function | echon "installed to ". $GOPATH | echohl None
+endfunction
+
+" Test runs `go test` in the current directory. If compile is true, it'll
+" compile the tests instead of running them (useful to catch errors in the
+" test files). Any other argument is appendend to the final `go test` command
 function! go#cmd#Test(compile, ...)
     let command = "go test "
 
@@ -154,6 +174,8 @@ function! go#cmd#Test(compile, ...)
     endif
 endfunction
 
+" Testfunc runs a single test that surrounds the current cursor position.
+" Arguments are passed to the `go test` command.
 function! go#cmd#TestFunc(...)
     " search flags legend (used only)
     " 'b' search backward instead of forward
@@ -185,6 +207,8 @@ function! go#cmd#TestFunc(...)
     call go#cmd#Test(0, a1, flag)
 endfunction
 
+" Coverage creates a new cover profile with 'go test -coverprofile' and opens
+" a new HTML coverage page from that profile.
 function! go#cmd#Coverage(...)
     let l:tmpname=tempname()
 
@@ -213,6 +237,8 @@ function! go#cmd#Coverage(...)
     call delete(l:tmpname)
 endfunction
 
+" Vet calls "go vet' on the current directory. Any warnings are populated in
+" the quickfix window
 function! go#cmd#Vet()
     call go#cmd#autowrite()
     echon "vim-go: " | echohl Identifier | echon "calling vet..." | echohl None

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -51,7 +51,7 @@ fu! s:gocodeCommand(cmd, preargs, args)
         let a:preargs[i] = s:gocodeShellescape(a:preargs[i])
     endfor
 
-    let bin_path = go#tool#BinPath(g:go_gocode_bin)
+    let bin_path = go#path#CheckBinPath(g:go_gocode_bin)
     if empty(bin_path)
         return
     endif
@@ -59,7 +59,7 @@ fu! s:gocodeCommand(cmd, preargs, args)
     " we might hit cache problems, as gocode doesn't handle well different
     " GOPATHS: https://github.com/nsf/gocode/issues/239
     let old_gopath = $GOPATH
-    let $GOPATH = DetectGoPath()
+    let $GOPATH = go#path#Detect()
 
     let result = s:system(printf('%s %s %s %s', s:gocodeShellescape(bin_path), join(a:preargs), s:gocodeShellescape(a:cmd), join(a:args)))
 

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -56,7 +56,15 @@ fu! s:gocodeCommand(cmd, preargs, args)
         return
     endif
 
+    " we might hit cache problems, as gocode doesn't handle well different
+    " GOPATHS: https://github.com/nsf/gocode/issues/239
+    let old_gopath = $GOPATH
+    let $GOPATH = DetectGoPath()
+
     let result = s:system(printf('%s %s %s %s', s:gocodeShellescape(bin_path), join(a:preargs), s:gocodeShellescape(a:cmd), join(a:args)))
+
+    let $GOPATH = old_gopath
+
     if v:shell_error != 0
         return "[\"0\", []]"
     else

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -18,6 +18,9 @@ function! go#def#Jump(...)
 		return
 	endif
 
+	let old_gopath = $GOPATH
+	let $GOPATH = DetectGoPath()
+
 	let command = bin_path . " -f=" . expand("%:p") . " -i " . shellescape(arg)
 
 	" get output of godef
@@ -25,6 +28,7 @@ function! go#def#Jump(...)
 
 	" jump to it
 	call s:godefJump(out, "")
+	let $GOPATH = old_gopath
 endfunction
 
 
@@ -36,12 +40,16 @@ function! go#def#JumpMode(mode)
 		return
 	endif
 
+	let old_gopath = $GOPATH
+	let $GOPATH = DetectGoPath()
+
 	let command = bin_path . " -f=" . expand("%:p") . " -i " . shellescape(arg)
 
 	" get output of godef
 	let out=system(command, join(getbufline(bufnr('%'), 1, '$'), LineEnding()))
 
 	call s:godefJump(out, a:mode)
+	let $GOPATH = old_gopath
 endfunction
 
 

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -13,18 +13,18 @@ function! go#def#Jump(...)
 		let arg = a:1
 	endif
 
-	let bin_path = go#tool#BinPath(g:go_godef_bin)
+	let bin_path = go#path#CheckBinPath(g:go_godef_bin)
 	if empty(bin_path)
 		return
 	endif
 
 	let old_gopath = $GOPATH
-	let $GOPATH = DetectGoPath()
+	let $GOPATH = go#path#Detect()
 
 	let command = bin_path . " -f=" . expand("%:p") . " -i " . shellescape(arg)
 
 	" get output of godef
-	let out=system(command, join(getbufline(bufnr('%'), 1, '$'), LineEnding()))
+	let out=system(command, join(getbufline(bufnr('%'), 1, '$'), go#util#LineEnding()))
 
 	" jump to it
 	call s:godefJump(out, "")
@@ -35,18 +35,18 @@ endfunction
 function! go#def#JumpMode(mode)
 	let arg = s:getOffset()
 
-	let bin_path = go#tool#BinPath(g:go_godef_bin)
+	let bin_path = go#path#CheckBinPath(g:go_godef_bin)
 	if empty(bin_path)
 		return
 	endif
 
 	let old_gopath = $GOPATH
-	let $GOPATH = DetectGoPath()
+	let $GOPATH = go#path#Detect()
 
 	let command = bin_path . " -f=" . expand("%:p") . " -i " . shellescape(arg)
 
 	" get output of godef
-	let out=system(command, join(getbufline(bufnr('%'), 1, '$'), LineEnding()))
+	let out=system(command, join(getbufline(bufnr('%'), 1, '$'), go#util#LineEnding()))
 
 	call s:godefJump(out, a:mode)
 	let $GOPATH = old_gopath
@@ -59,7 +59,7 @@ function! s:getOffset()
 		let offs = line2byte(pos[0]) + pos[1] - 2
 	else
 		let c = pos[1]
-		let buf = line('.') == 1 ? "" : (join(getline(1, pos[0] - 1), LineEnding()) . LineEnding())
+		let buf = line('.') == 1 ? "" : (join(getline(1, pos[0] - 1), go#util#LineEnding()) . go#util#LineEnding())
 		let buf .= c == 1 ? "" : getline(pos[0])[:c-2]
 		let offs = len(iconv(buf, &encoding, "utf-8"))
 	endif
@@ -74,7 +74,7 @@ function! s:godefJump(out, mode)
 	let &errorformat = "%f:%l:%c"
 
 	if a:out =~ 'godef: '
-		let out=substitute(a:out, LineEnding() . '$', '', '')
+		let out=substitute(a:out, go#util#LineEnding() . '$', '', '')
 		echom out
 	else
 		let parts = split(a:out, ':')

--- a/autoload/go/errcheck.vim
+++ b/autoload/go/errcheck.vim
@@ -13,7 +13,7 @@ function! go#errcheck#Run(...) abort
         let package = a:1
     end
 
-    let bin_path = go#tool#BinPath(g:go_errcheck_bin)
+    let bin_path = go#path#CheckBinPath(g:go_errcheck_bin)
     if empty(bin_path)
         return
     endif
@@ -27,7 +27,7 @@ function! go#errcheck#Run(...) abort
             let tokens = matchlist(line, mx)
 
             if !empty(tokens)
-                call add(errors, {"filename": expand(DefaultGoPath() . "/src/" . tokens[1]),
+                call add(errors, {"filename": expand(go#path#Default() . "/src/" . tokens[1]),
                             \"lnum": tokens[2],
                             \"col": tokens[3],
                             \"text": tokens[4]})

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -79,10 +79,10 @@ function! go#fmt#Format(withGoimport)
 
     " if it's something else than gofmt, we need to check the existing of that
     " binary. For example if it's goimports, let us check if it's installed,
-    " if not the user get's a warning via go#tool#BinPath()
+    " if not the user get's a warning via go#path#CheckBinPath()
     if fmt_command != "gofmt"
         " check if the user has installed goimports
-        let bin_path = go#tool#BinPath(fmt_command) 
+        let bin_path = go#path#CheckBinPath(fmt_command) 
         if empty(bin_path) 
             return 
         endif

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -17,7 +17,7 @@ if !exists("g:go_golint_bin")
 endif
 
 function! go#lint#Run() abort
-	let bin_path = go#tool#BinPath(g:go_golint_bin) 
+	let bin_path = go#path#CheckBinPath(g:go_golint_bin) 
 	if empty(bin_path) 
 		return 
 	endif

--- a/autoload/go/oracle.vim
+++ b/autoload/go/oracle.vim
@@ -125,7 +125,13 @@ func! s:RunOracle(mode, selected) range abort
 
     echon "vim-go: " | echohl Identifier | echon "analysing ..." | echohl None
 
+    let old_gopath = $GOPATH
+    let $GOPATH = DetectGoPath()
+
     let out = system(cmd)
+
+    let $GOPATH = old_gopath
+
     if v:shell_error
         " unfortunaly oracle outputs a very long stack trace that is not
         " parsable to show the real error. But the main issue is usually the

--- a/autoload/go/oracle.vim
+++ b/autoload/go/oracle.vim
@@ -97,7 +97,7 @@ func! s:RunOracle(mode, selected) range abort
     endif
 
     "return with a warning if the bin doesn't exist
-    let bin_path = go#tool#BinPath(g:go_oracle_bin) 
+    let bin_path = go#path#CheckBinPath(g:go_oracle_bin) 
     if empty(bin_path) 
         return 
     endif
@@ -126,7 +126,7 @@ func! s:RunOracle(mode, selected) range abort
     echon "vim-go: " | echohl Identifier | echon "analysing ..." | echohl None
 
     let old_gopath = $GOPATH
-    let $GOPATH = DetectGoPath()
+    let $GOPATH = go#path#Detect()
 
     let out = system(cmd)
 

--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -44,11 +44,7 @@ function! go#package#Paths()
         let dirs += [goroot]
     endif
 
-    let pathsep = ':'
-    if s:goos == 'windows'
-        let pathsep = ';'
-    endif
-    let workspaces = split($GOPATH, pathsep)
+    let workspaces = split($GOPATH, go#util#PathListSep())
     if workspaces != []
         let dirs += workspaces
     endif

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -23,10 +23,10 @@ endfunction
 function! go#path#Detect()
     let gopath = $GOPATH
 
-    " if gopath is set manually, always return it, because this is something
+    " if gopath is set manually, set it as GOPATH, because this is something
     " the user explicitly wants
     if !empty(s:initial_go_path)
-        return s:initial_go_path
+        let gopath = s:initial_go_path
     endif
 
     " don't lookup for godeps if autodetect is disabled.

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -1,0 +1,138 @@
+" initial_go_path is used to store the initial GOPATH that was set when Vim
+" was started. It's used with :GoPathClear to restore the GOPATH when the user
+" changed it explicitly via :GoPath. Initially it's empty. It's being set when
+" :GoPath is used
+let s:initial_go_path = ""
+
+" Default returns the default GOPATH. If there is a single GOPATH it returns
+" it. For multiple GOPATHS separated with a the OS specific separator, only
+" the first one is returned
+function! go#path#Default()
+    let go_paths = split($GOPATH, go#util#PathListSep())
+
+    if len(go_paths) == 1
+        return $GOPATH
+    endif
+
+    return go_paths[0]
+endfunction
+
+" Detect returns the current GOPATH. If a package manager is used, such
+" as Godeps or something like gb (not supported yet), it will modify the
+" GOPATH so those directories take precedence over the current GOPATH.
+function! go#path#Detect()
+    let gopath = $GOPATH
+
+    " if gopath is set manually, always return it, because this is something
+    " the user explicitly wants
+    if !empty(s:initial_go_path)
+        return s:initial_go_path
+    endif
+
+    " don't lookup for godeps if autodetect is disabled.
+    if !get(g:, "go_autodetect_gopath", 1)
+        return gopath
+    endif
+
+    let current_dir = fnameescape(expand('%:p:h'))
+
+    " TODO(arslan): this should be changed so folders or files should be
+    " fetched from a customizable list. The user should define any new package
+    " management tool by it's own.
+    "
+    " Godeps
+    let godeps_root = finddir("Godeps", current_dir .";")
+    if !empty(godeps_root)
+        let godeps_path = join([fnamemodify(godeps_root, ':p:h:h'), "Godeps", "_workspace" ], go#util#PathSep())
+        let gopath =  godeps_path . go#util#PathListSep() . gopath
+    endif
+
+    return gopath
+endfunction
+
+
+" BinPath returns the binary path of installed go tools.
+function! go#path#BinPath()
+    let bin_path = ""
+
+    " check if our global custom path is set, if not check if $GOBIN is set so
+    " we can use it, otherwise use $GOPATH + '/bin'
+    if exists("g:go_bin_path")
+        let bin_path = g:go_bin_path
+    elseif $GOBIN != ""
+        let bin_path = $GOBIN
+    elseif $GOPATH != ""
+        let bin_path = expand(go#path#Default() . "/bin/")
+    else
+        " could not find anything
+    endif
+
+    return bin_path
+endfunction
+
+" CheckBinPath checks whether the given binary exists or not and returns the
+" path of the binary. It returns an empty string doesn't exists.
+function! go#path#CheckBinPath(binpath)
+    " remove whitespaces if user applied something like 'goimports   '
+    let binpath = substitute(a:binpath, '^\s*\(.\{-}\)\s*$', '\1', '')
+
+    " if it's in PATH just return it
+    if executable(binpath) 
+        return binpath
+    endif
+
+
+    " just get the basename
+    let basename = fnamemodify(binpath, ":t")
+
+    " check if we have an appropriate bin_path
+    let go_bin_path = go#path#BinPath()
+    if empty(go_bin_path)
+        echo "vim-go: could not find '" . basename . "'. Run :GoInstallBinaries to fix it."
+        return ""
+    endif
+
+    " append our GOBIN and GOPATH paths and be sure they can be found there...
+    " let us search in our GOBIN and GOPATH paths
+    let old_path = $PATH
+    let $PATH = $PATH . go#util#PathListSep() .go_bin_path
+
+    if !executable(basename)
+        echo "vim-go: could not find '" . basename . "'. Run :GoInstallBinaries to fix it."
+        " restore back!
+        let $PATH = old_path
+        return ""
+    endif
+
+    let $PATH = old_path
+
+    return go_bin_path . go#util#PathSep() . basename
+endfunction
+
+" GoPath sets or returns the current GOPATH. If no arguments are passed it
+" echoes the current GOPATH, if an argument is passed it replaces the current
+" GOPATH with it.
+function! go#path#GoPath(...)
+    " we have an argument, replace GOPATH
+    if len(a:000)
+        echon "vim-go: " | echohl Function | echon "GOPATH changed to ". a:1 | echohl None
+        let s:initial_go_path = $GOPATH
+        let $GOPATH = a:1
+        return
+    endif
+
+    echo go#path#Detect()
+endfunction
+
+" GoPathClear clears the current manually set GOPATH and restores it to the
+" initial GOPATH, which was set when Vim was started.
+function! go#path#GoPathClear()
+    if !empty(s:initial_go_path)
+        let $GOPATH = s:initial_go_path
+        let s:initial_go_path = ""
+    endif
+
+    echon "vim-go: " | echohl Function | echon "GOPATH restored to ". $GOPATH | echohl None
+endfunction
+
+

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -4,6 +4,36 @@
 " :GoPath is used
 let s:initial_go_path = ""
 
+" GoPath sets or returns the current GOPATH. If no arguments are passed it
+" echoes the current GOPATH, if an argument is passed it replaces the current
+" GOPATH with it.
+function! go#path#GoPath(...)
+    " we have an argument, replace GOPATH
+    if len(a:000)
+        echon "vim-go: " | echohl Function | echon "GOPATH changed to ". a:1 | echohl None
+        let s:initial_go_path = $GOPATH
+        let $GOPATH = a:1
+        return
+    endif
+
+			  echo "gopath " .s:initial_go_path
+
+    echo go#path#Detect()
+endfunction
+
+" GoPathClear clears the current manually set GOPATH and restores it to the
+" initial GOPATH, which was set when Vim was started.
+function! go#path#GoPathClear()
+    if !empty(s:initial_go_path)
+        let $GOPATH = s:initial_go_path
+        let s:initial_go_path = ""
+    endif
+
+    echon "vim-go: " | echohl Function | echon "GOPATH restored to ". $GOPATH | echohl None
+endfunction
+
+
+
 " Default returns the default GOPATH. If there is a single GOPATH it returns
 " it. For multiple GOPATHS separated with a the OS specific separator, only
 " the first one is returned
@@ -22,12 +52,6 @@ endfunction
 " GOPATH so those directories take precedence over the current GOPATH.
 function! go#path#Detect()
     let gopath = $GOPATH
-
-    " if gopath is set manually, set it as GOPATH, because this is something
-    " the user explicitly wants
-    if !empty(s:initial_go_path)
-        let gopath = s:initial_go_path
-    endif
 
     " don't lookup for godeps if autodetect is disabled.
     if !get(g:, "go_autodetect_gopath", 1)
@@ -108,31 +132,4 @@ function! go#path#CheckBinPath(binpath)
 
     return go_bin_path . go#util#PathSep() . basename
 endfunction
-
-" GoPath sets or returns the current GOPATH. If no arguments are passed it
-" echoes the current GOPATH, if an argument is passed it replaces the current
-" GOPATH with it.
-function! go#path#GoPath(...)
-    " we have an argument, replace GOPATH
-    if len(a:000)
-        echon "vim-go: " | echohl Function | echon "GOPATH changed to ". a:1 | echohl None
-        let s:initial_go_path = $GOPATH
-        let $GOPATH = a:1
-        return
-    endif
-
-    echo go#path#Detect()
-endfunction
-
-" GoPathClear clears the current manually set GOPATH and restores it to the
-" initial GOPATH, which was set when Vim was started.
-function! go#path#GoPathClear()
-    if !empty(s:initial_go_path)
-        let $GOPATH = s:initial_go_path
-        let s:initial_go_path = ""
-    endif
-
-    echon "vim-go: " | echohl Function | echon "GOPATH restored to ". $GOPATH | echohl None
-endfunction
-
 

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -8,28 +8,28 @@ let s:initial_go_path = ""
 " echoes the current GOPATH, if an argument is passed it replaces the current
 " GOPATH with it.
 function! go#path#GoPath(...)
-    " we have an argument, replace GOPATH
-    if len(a:000)
-        echon "vim-go: " | echohl Function | echon "GOPATH changed to ". a:1 | echohl None
-        let s:initial_go_path = $GOPATH
-        let $GOPATH = a:1
-        return
-    endif
+	" we have an argument, replace GOPATH
+	if len(a:000)
+		echon "vim-go: " | echohl Function | echon "GOPATH changed to ". a:1 | echohl None
+		let s:initial_go_path = $GOPATH
+		let $GOPATH = a:1
+		return
+	endif
 
-			  echo "gopath " .s:initial_go_path
+	echo "gopath " .s:initial_go_path
 
-    echo go#path#Detect()
+	echo go#path#Detect()
 endfunction
 
 " GoPathClear clears the current manually set GOPATH and restores it to the
 " initial GOPATH, which was set when Vim was started.
 function! go#path#GoPathClear()
-    if !empty(s:initial_go_path)
-        let $GOPATH = s:initial_go_path
-        let s:initial_go_path = ""
-    endif
+	if !empty(s:initial_go_path)
+		let $GOPATH = s:initial_go_path
+		let s:initial_go_path = ""
+	endif
 
-    echon "vim-go: " | echohl Function | echon "GOPATH restored to ". $GOPATH | echohl None
+	echon "vim-go: " | echohl Function | echon "GOPATH restored to ". $GOPATH | echohl None
 endfunction
 
 
@@ -38,98 +38,133 @@ endfunction
 " it. For multiple GOPATHS separated with a the OS specific separator, only
 " the first one is returned
 function! go#path#Default()
-    let go_paths = split($GOPATH, go#util#PathListSep())
+	let go_paths = split($GOPATH, go#util#PathListSep())
 
-    if len(go_paths) == 1
-        return $GOPATH
-    endif
+	if len(go_paths) == 1
+		return $GOPATH
+	endif
 
-    return go_paths[0]
+	return go_paths[0]
+endfunction
+
+" HasPath checks whether the given path exists in GOPATH environment variable
+" or not
+function! go#path#HasPath(path)
+	let go_paths = split($GOPATH, go#util#PathListSep())
+	let last_char = strlen(a:path) - 1
+
+	" check cases of '/foo/bar/' and '/foo/bar'
+	if a:path[last_char] == go#util#PathSep()
+		let withSep = a:path
+		let noSep = strpart(a:path, 0, last_char)
+	else
+		let withSep = a:path . go#util#PathSep()
+		let noSep = a:path
+	endif
+
+	let hasA = index(go_paths, withSep) != -1
+	let hasB = index(go_paths, noSep) != -1
+	return hasA || hasB
 endfunction
 
 " Detect returns the current GOPATH. If a package manager is used, such
 " as Godeps or something like gb (not supported yet), it will modify the
-" GOPATH so those directories take precedence over the current GOPATH.
+" GOPATH so those directories take precedence over the current GOPATH. It also
+" detects diretories whose are outside GOPATH.
 function! go#path#Detect()
-    let gopath = $GOPATH
+	let gopath = $GOPATH
 
-    " don't lookup for godeps if autodetect is disabled.
-    if !get(g:, "go_autodetect_gopath", 1)
-        return gopath
-    endif
+	" don't lookup for godeps if autodetect is disabled.
+	if !get(g:, "go_autodetect_gopath", 1)
+		return gopath
+	endif
 
-    let current_dir = fnameescape(expand('%:p:h'))
+	let current_dir = fnameescape(expand('%:p:h'))
 
-    " TODO(arslan): this should be changed so folders or files should be
-    " fetched from a customizable list. The user should define any new package
-    " management tool by it's own.
-    "
-    " Godeps
-    let godeps_root = finddir("Godeps", current_dir .";")
-    if !empty(godeps_root)
-        let godeps_path = join([fnamemodify(godeps_root, ':p:h:h'), "Godeps", "_workspace" ], go#util#PathSep())
-        let gopath =  godeps_path . go#util#PathListSep() . gopath
-    endif
+	" TODO(arslan): this should be changed so folders or files should be
+	" fetched from a customizable list. The user should define any new package
+	" management tool by it's own.
 
-    return gopath
+	" src folder outside $GOPATH
+	let src_root = finddir("src", current_dir .";")
+	if !empty(src_root)
+		let src_path = fnamemodify(src_root, ':p:h:h') . go#util#PathSep()
+
+		if !go#path#HasPath(src_path)
+			let gopath =  src_path . go#util#PathListSep() . gopath
+		endif
+	endif
+
+	" Godeps
+	let godeps_root = finddir("Godeps", current_dir .";")
+	if !empty(godeps_root)
+		let godeps_path = join([fnamemodify(godeps_root, ':p:h:h'), "Godeps", "_workspace" ], go#util#PathSep())
+
+		if !go#path#HasPath(godeps_path)
+			let gopath =  godeps_path . go#util#PathListSep() . gopath
+		endif
+	endif
+
+	return gopath
 endfunction
 
 
 " BinPath returns the binary path of installed go tools.
 function! go#path#BinPath()
-    let bin_path = ""
+	let bin_path = ""
 
-    " check if our global custom path is set, if not check if $GOBIN is set so
-    " we can use it, otherwise use $GOPATH + '/bin'
-    if exists("g:go_bin_path")
-        let bin_path = g:go_bin_path
-    elseif $GOBIN != ""
-        let bin_path = $GOBIN
-    elseif $GOPATH != ""
-        let bin_path = expand(go#path#Default() . "/bin/")
-    else
-        " could not find anything
-    endif
+	" check if our global custom path is set, if not check if $GOBIN is set so
+	" we can use it, otherwise use $GOPATH + '/bin'
+	if exists("g:go_bin_path")
+		let bin_path = g:go_bin_path
+	elseif $GOBIN != ""
+		let bin_path = $GOBIN
+	elseif $GOPATH != ""
+		let bin_path = expand(go#path#Default() . "/bin/")
+	else
+		" could not find anything
+	endif
 
-    return bin_path
+	return bin_path
 endfunction
 
 " CheckBinPath checks whether the given binary exists or not and returns the
 " path of the binary. It returns an empty string doesn't exists.
 function! go#path#CheckBinPath(binpath)
-    " remove whitespaces if user applied something like 'goimports   '
-    let binpath = substitute(a:binpath, '^\s*\(.\{-}\)\s*$', '\1', '')
+	" remove whitespaces if user applied something like 'goimports   '
+	let binpath = substitute(a:binpath, '^\s*\(.\{-}\)\s*$', '\1', '')
 
-    " if it's in PATH just return it
-    if executable(binpath) 
-        return binpath
-    endif
+	" if it's in PATH just return it
+	if executable(binpath) 
+		return binpath
+	endif
 
 
-    " just get the basename
-    let basename = fnamemodify(binpath, ":t")
+	" just get the basename
+	let basename = fnamemodify(binpath, ":t")
 
-    " check if we have an appropriate bin_path
-    let go_bin_path = go#path#BinPath()
-    if empty(go_bin_path)
-        echo "vim-go: could not find '" . basename . "'. Run :GoInstallBinaries to fix it."
-        return ""
-    endif
+	" check if we have an appropriate bin_path
+	let go_bin_path = go#path#BinPath()
+	if empty(go_bin_path)
+		echo "vim-go: could not find '" . basename . "'. Run :GoInstallBinaries to fix it."
+		return ""
+	endif
 
-    " append our GOBIN and GOPATH paths and be sure they can be found there...
-    " let us search in our GOBIN and GOPATH paths
-    let old_path = $PATH
-    let $PATH = $PATH . go#util#PathListSep() .go_bin_path
+	" append our GOBIN and GOPATH paths and be sure they can be found there...
+	" let us search in our GOBIN and GOPATH paths
+	let old_path = $PATH
+	let $PATH = $PATH . go#util#PathListSep() .go_bin_path
 
-    if !executable(basename)
-        echo "vim-go: could not find '" . basename . "'. Run :GoInstallBinaries to fix it."
-        " restore back!
-        let $PATH = old_path
-        return ""
-    endif
+	if !executable(basename)
+		echo "vim-go: could not find '" . basename . "'. Run :GoInstallBinaries to fix it."
+		" restore back!
+		let $PATH = old_path
+		return ""
+	endif
 
-    let $PATH = old_path
+	let $PATH = old_path
 
-    return go_bin_path . go#util#PathSep() . basename
+	return go_bin_path . go#util#PathSep() . basename
 endfunction
 
+" vim:ts=4:sw=4:et

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -16,8 +16,6 @@ function! go#path#GoPath(...)
 		return
 	endif
 
-	echo "gopath " .s:initial_go_path
-
 	echo go#path#Detect()
 endfunction
 

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -15,7 +15,7 @@ function! go#rename#Rename(...)
 
 
     "return with a warning if the bin doesn't exist
-    let bin_path = go#tool#BinPath(g:go_gorename_bin) 
+    let bin_path = go#path#CheckBinPath(g:go_gorename_bin) 
     if empty(bin_path) 
         return 
     endif

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -86,6 +86,9 @@ function! go#tool#ShowErrors(out)
 endfunction
 
 function! go#tool#ExecuteInDir(cmd) abort
+    let old_gopath = $GOPATH
+    let $GOPATH = DetectGoPath()
+
     let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
     let dir = getcwd()
     try
@@ -94,6 +97,8 @@ function! go#tool#ExecuteInDir(cmd) abort
     finally
         execute cd . fnameescape(dir)
     endtry
+
+    let $GOPATH = old_gopath
     return out
 endfunction
 
@@ -135,7 +140,7 @@ function! go#tool#BinPath(binpath)
     " append our GOBIN and GOPATH paths and be sure they can be found there...
     " let us search in our GOBIN and GOPATH paths
     let old_path = $PATH
-    let $PATH = $PATH . PathSep() .go_bin_path
+    let $PATH = $PATH . PathListSep() .go_bin_path
 
     if !executable(basename)
         echo "vim-go: could not find '" . basename . "'. Run :GoInstallBinaries to fix it."

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -1,0 +1,38 @@
+" PathSep returns the appropriate OS specific path separator.
+function! go#util#PathSep()
+    if go#util#IsWin()
+        return '\'
+    endif
+    return '/'
+endfunction
+
+" PathListSep returns the appropriate OS specific path list separator.
+function! go#util#PathListSep()
+    if go#util#IsWin()
+        return ";"
+    endif
+    return ":"
+endfunction
+
+" LineEnding returns the correct line ending, based on the current fileformat
+function! go#util#LineEnding()
+    if &fileformat == 'dos'
+        return "\r\n"
+    elseif &fileformat == 'mac'
+        return "\r"
+    endif
+
+    return "\n"
+endfunction
+
+" IsWin returns 1 if current OS is Windows or 0 otherwise
+function! go#util#IsWin()
+    let win = ['win16', 'win32', 'win32unix', 'win64', 'win95']
+    for w in win
+        if (has(w))
+            return 1
+        endif
+    endfor
+
+    return 0
+endfunction

--- a/autoload/go/vimproc.vim
+++ b/autoload/go/vimproc.vim
@@ -1,7 +1,7 @@
 "Check if has vimproc
 function! go#vimproc#has_vimproc()
     if !exists('g:go#use_vimproc')
-        if IsWin()
+        if go#util#IsWin()
             try
                 call vimproc#version()
                 let exists_vimproc = 1

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -110,6 +110,12 @@ https://github.com/Shougo/neosnippet.vim.
 ===============================================================================
 COMMANDS                                                          *go-commands*
 
+                                                                  *:GoPath*
+:GoPath [path]
+
+    GoPath sets and ovverides GOPATH with the given {path}. If no {path} is
+    given it shows the current GOPATH.
+
                                                                   *:GoImport*
 :GoImport [path]
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -116,6 +116,13 @@ COMMANDS                                                          *go-commands*
     GoPath sets and ovverides GOPATH with the given {path}. If no {path} is
     given it shows the current GOPATH.
 
+                                                              *:GoPathClear*
+:GoPathClear
+
+    GoPathClear clears the current `GOPATH` which was set with |GoPath| and
+    restores `GOPATH` back to the inital value which was sourced when Vim was
+    started.
+
                                                                   *:GoImport*
 :GoImport [path]
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -728,11 +728,24 @@ Highlights build constraints. By default it's disabled. >
 
 	let g:go_highlight_build_constraints = 0
 <
+
+                                                *'g:go_autodetect_gopath'*
+
+Automatically modifies GOPATH for certain directory structures, such as for
+the tool godep which has his own dependencies via the `Godeps` folder. What
+this means is that all tools are now working with the newly modified GOPATH.
+So |GoDef| for example jumps to the source inside the `Godeps` (vendored)
+source. Currently only `godep` is supported, in the near future more tool
+supports will be added. By default it's enabled. >
+
+	let g:go_autodetect_gopath = 1
+<
                                                   *'g:go_textobj_enabled'*
 
 Adds custom text objects. By default it's enabled. >
 
 	let g:go_textobj_enabled = 1
+
 
 ===============================================================================
 TROUBLESHOOTING                                         *go-troubleshooting*

--- a/ftplugin/go/tagbar.vim
+++ b/ftplugin/go/tagbar.vim
@@ -1,5 +1,5 @@
 " Check if tagbar is installed under plugins or is directly under rtp
-" this covers pathgen + Vundle/Bundle
+" this covers pathogen + Vundle/Bundle
 "
 " Also make sure the ctags command exists
 "
@@ -15,7 +15,7 @@ endif
 
 
 function! s:SetTagbar()
-	let bin_path = go#tool#BinPath(g:go_gotags_bin) 
+	let bin_path = go#path#CheckBinPath(g:go_gotags_bin) 
 	if empty(bin_path) 
 		return 
 	endif

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -147,7 +147,7 @@ function! DetectGoPath()
     " if gopath is set manually, always return it, because this is something
     " the user explicitly wants
     if !empty(s:initial_go_path)
-        return gopath
+        return s:initial_go_path
     endif
 
     " don't lookup for godeps if autodetect is disabled.

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -4,11 +4,6 @@ if exists("g:go_loaded_install")
 endif
 let g:go_loaded_install = 1
 
-" initial_go_path is used to store the initial GOPATH that was set when Vim
-" was started. It's used with :GoPathClear to restore the GOPATH when the user
-" changed it explicitly via :GoPath. Initially it's empty. It's being set when
-" :GoPath is used
-let s:initial_go_path = ""
 
 " these packages are used by vim-go and can be automatically installed if
 " needed by the user with GoInstallBinaries
@@ -26,150 +21,8 @@ let s:packages = [
 " These commands are available on any filetypes
 command! GoInstallBinaries call s:GoInstallBinaries(-1)
 command! GoUpdateBinaries call s:GoInstallBinaries(1)
-command! -nargs=? -complete=dir GoPath call s:GoPath(<f-args>)
-command! GoPathClear call s:GoPathClear()
-
-
-" LineEnding returns the correct line ending, based on the current fileformat
-function! LineEnding()
-    if &fileformat == 'dos'
-        return "\r\n"
-    elseif &fileformat == 'mac'
-        return "\r"
-    endif
-
-    return "\n"
-endfunction
-
-" IsWin returns 1 if current OS is Windows or 0 otherwise
-function! IsWin()
-    let win = ['win16', 'win32', 'win32unix', 'win64', 'win95']
-    for w in win
-        if (has(w))
-            return 1
-        endif
-    endfor
-
-    return 0
-endfunction
-
-" PathSep returns the appropriate OS specific path separator.
-function! PathSep()
-    if IsWin()
-        return '\'
-    endif
-    return '/'
-endfunction
-
-" PathListSep returns the appropriate OS specific path list separator.
-function! PathListSep()
-    if IsWin()
-        return ";"
-    endif
-    return ":"
-endfunction
-
-
-" DefaultGoPath returns the default GOPATH.  If there is only one GOPATH it
-" returns that, otherwise it returns the first one.
-function! DefaultGoPath()
-    let go_paths = split($GOPATH, PathListSep())
-
-    if len(go_paths) == 1
-        return $GOPATH
-    endif
-
-    return go_paths[0]
-endfunction
-
-" GetBinPath returns the binary path of installed go tools
-function! GetBinPath()
-    let bin_path = ""
-
-    " check if our global custom path is set, if not check if $GOBIN is set so
-    " we can use it, otherwise use $GOPATH + '/bin'
-    if exists("g:go_bin_path")
-        let bin_path = g:go_bin_path
-    elseif $GOBIN != ""
-        let bin_path = $GOBIN
-    elseif $GOPATH != ""
-        let bin_path = expand(DefaultGoPath() . "/bin/")
-    else
-        " could not find anything
-    endif
-
-    return bin_path
-endfunction
-
-
-" GoPath sets or returns the current GOPATH. If no arguments are passed it
-" echoes the current GOPATH, if an argument is passed it replaces the current
-" GOPATH with it.
-function! s:GoPath(...)
-    " we have an argument, replace GOPATH
-    if len(a:000)
-        echon "vim-go: " | echohl Function | echon "GOPATH changed to ". a:1 | echohl None
-        let s:initial_go_path = $GOPATH
-        let $GOPATH = a:1
-        return
-    endif
-
-    echo DetectGoPath()
-endfunction
-
-" GoPathClear clears the current manually set GOPATH and restores it to the
-" initial GOPATH, which was set when Vim was started.
-function! s:GoPathClear()
-    if !empty(s:initial_go_path)
-        let $GOPATH = s:initial_go_path
-        let s:initial_go_path = ""
-    endif
-
-    echon "vim-go: " | echohl Function | echon "GOPATH restored to ". $GOPATH | echohl None
-endfunction
-
-
-" callWithGopath calls the given function with the given GOPATH context. After
-" the function call GOPATH is restored to the previous GOPATH.
-function! s:callWithGopath(fn, gopath)
-    let old_gopath = $GOPATH
-    let $GOPATH = a:gopath
-    call a:fn()
-    let $GOPATH = old_gopath
-endfunction
-
-" DetectGoPath returns the current GOPATH. If a package manager is used, such
-" as Godeps or something like gb (not supported yet), it will modify the
-" GOPATH so those directories take precedence over the current GOPATH.
-function! DetectGoPath()
-    let gopath = $GOPATH
-
-    " if gopath is set manually, always return it, because this is something
-    " the user explicitly wants
-    if !empty(s:initial_go_path)
-        return s:initial_go_path
-    endif
-
-    " don't lookup for godeps if autodetect is disabled.
-    if !get(g:, "go_autodetect_gopath", 1)
-        return gopath
-    endif
-
-    let current_dir = fnameescape(expand('%:p:h'))
-
-    " TODO(arslan): this should be changed so folders or files should be
-    " fetched from a customizable list. The user should define any new package
-    " management tool by it's own.
-    "
-    " Godeps
-    let godeps_root = finddir("Godeps", current_dir .";")
-    if !empty(godeps_root)
-        let godeps_path = join([fnamemodify(godeps_root, ':p:h:h'), "Godeps", "_workspace" ], PathSep())
-        let gopath =  godeps_path . PathListSep() . gopath
-    endif
-
-    return gopath
-endfunction
+command! -nargs=? -complete=dir GoPath call go#path#GoPath(<f-args>)
+command! GoPathClear call go#path#GoPathClear()
 
 " GoInstallBinaries downloads and install all necessary binaries stated in the
 " packages variable. It uses by default $GOBIN or $GOPATH/bin as the binary
@@ -188,7 +41,7 @@ function! s:GoInstallBinaries(updateBinaries)
         return
     endif
 
-    let go_bin_path = GetBinPath()
+    let go_bin_path = go#path#BinPath()
 
     " change $GOBIN so go get can automatically install to it
     let $GOBIN = go_bin_path
@@ -197,7 +50,7 @@ function! s:GoInstallBinaries(updateBinaries)
     let old_path = $PATH
 
     " vim's executable path is looking in PATH so add our go_bin path to it
-    let $PATH = $PATH . PathListSep() .go_bin_path
+    let $PATH = $PATH . go#util#PathListSep() .go_bin_path
 
     " when shellslash is set on MS-* systems, shellescape puts single quotes
     " around the output string. cmd on Windows does not handle single quotes

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -150,13 +150,17 @@ function! DetectGoPath()
         return gopath
     endif
 
-    " don't lookup for godeps if autodetect is disabled
-    if !get(g:, "go_autodetect_gopath", 0)
+    " don't lookup for godeps if autodetect is disabled.
+    if !get(g:, "go_autodetect_gopath", 1)
         return gopath
     endif
 
     let current_dir = fnameescape(expand('%:p:h'))
 
+    " TODO(arslan): this should be changed so folders or files should be
+    " fetched from a customizable list. The user should define any new package
+    " management tool by it's own.
+    "
     " Godeps
     let godeps_root = finddir("Godeps", current_dir .";")
     if !empty(godeps_root)

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -4,6 +4,12 @@ if exists("g:go_loaded_install")
 endif
 let g:go_loaded_install = 1
 
+" initial_go_path is used to store the initial GOPATH that was set when Vim
+" was started. It's used with :GoPathClear to restore the GOPATH when the user
+" changed it explicitly via :GoPath. Initially it's empty. It's being set when
+" :GoPath is used
+let s:initial_go_path = ""
+
 " these packages are used by vim-go and can be automatically installed if
 " needed by the user with GoInstallBinaries
 let s:packages = [
@@ -20,6 +26,9 @@ let s:packages = [
 " These commands are available on any filetypes
 command! GoInstallBinaries call s:GoInstallBinaries(-1)
 command! GoUpdateBinaries call s:GoInstallBinaries(1)
+command! -nargs=? -complete=dir GoPath call s:GoPath(<f-args>)
+command! GoPathClear call s:GoPathClear()
+
 
 " LineEnding returns the correct line ending, based on the current fileformat
 function! LineEnding()
@@ -44,19 +53,27 @@ function! IsWin()
     return 0
 endfunction
 
-" PathSep returns the appropriate path separator based on OS.
+" PathSep returns the appropriate OS specific path separator.
 function! PathSep()
+    if IsWin()
+        return '\'
+    endif
+    return '/'
+endfunction
+
+" PathListSep returns the appropriate OS specific path list separator.
+function! PathListSep()
     if IsWin()
         return ";"
     endif
-
     return ":"
 endfunction
 
-" DefaultGoPath returns the default GOPATH.
-" If there is only one GOPATH it returns that, otherwise it returns the first one.
+
+" DefaultGoPath returns the default GOPATH.  If there is only one GOPATH it
+" returns that, otherwise it returns the first one.
 function! DefaultGoPath()
-    let go_paths = split($GOPATH, PathSep())
+    let go_paths = split($GOPATH, PathListSep())
 
     if len(go_paths) == 1
         return $GOPATH
@@ -82,6 +99,72 @@ function! GetBinPath()
     endif
 
     return bin_path
+endfunction
+
+
+" GoPath sets or returns the current GOPATH. If no arguments are passed it
+" echoes the current GOPATH, if an argument is passed it replaces the current
+" GOPATH with it.
+function! s:GoPath(...)
+    " we have an argument, replace GOPATH
+    if len(a:000)
+        echon "vim-go: " | echohl Function | echon "GOPATH changed to ". a:1 | echohl None
+        let s:initial_go_path = $GOPATH
+        let $GOPATH = a:1
+        return
+    endif
+
+    echo DetectGoPath()
+endfunction
+
+" GoPathClear clears the current manually set GOPATH and restores it to the
+" initial GOPATH, which was set when Vim was started.
+function! s:GoPathClear()
+    if !empty(s:initial_go_path)
+        let $GOPATH = s:initial_go_path
+        let s:initial_go_path = ""
+    endif
+
+    echon "vim-go: " | echohl Function | echon "GOPATH restored to ". $GOPATH | echohl None
+endfunction
+
+
+" callWithGopath calls the given function with the given GOPATH context. After
+" the function call GOPATH is restored to the previous GOPATH.
+function! s:callWithGopath(fn, gopath)
+    let old_gopath = $GOPATH
+    let $GOPATH = a:gopath
+    call a:fn()
+    let $GOPATH = old_gopath
+endfunction
+
+" DetectGoPath returns the current GOPATH. If a package manager is used, such
+" as Godeps or something like gb (not supported yet), it will modify the
+" GOPATH so those directories take precedence over the current GOPATH.
+function! DetectGoPath()
+    let gopath = $GOPATH
+
+    " if gopath is set manually, always return it, because this is something
+    " the user explicitly wants
+    if !empty(s:initial_go_path)
+        return gopath
+    endif
+
+    " don't lookup for godeps if autodetect is disabled
+    if !get(g:, "go_autodetect_gopath", 0)
+        return gopath
+    endif
+
+    let current_dir = fnameescape(expand('%:p:h'))
+
+    " Godeps
+    let godeps_root = finddir("Godeps", current_dir .";")
+    if !empty(godeps_root)
+        let godeps_path = join([fnamemodify(godeps_root, ':p:h:h'), "Godeps", "_workspace" ], PathSep())
+        let gopath =  godeps_path . PathListSep() . gopath
+    endif
+
+    return gopath
 endfunction
 
 " GoInstallBinaries downloads and install all necessary binaries stated in the
@@ -110,7 +193,7 @@ function! s:GoInstallBinaries(updateBinaries)
     let old_path = $PATH
 
     " vim's executable path is looking in PATH so add our go_bin path to it
-    let $PATH = $PATH . PathSep() .go_bin_path
+    let $PATH = $PATH . PathListSep() .go_bin_path
 
     " when shellslash is set on MS-* systems, shellescape puts single quotes
     " around the output string. cmd on Windows does not handle single quotes


### PR DESCRIPTION
This PR includes new features and improvements which brings better support for multiple `GOPATH`s  and tools that support this (such as `godep`). This also creates a foundation for other new project based building tools, such as `gb`. 

The  changes are : 

* A new `:GoPath` command that displays the current set `GOPATH`. It changes the current `GOPATH` when an argument is passed, i.e: `:GoPath /home/fatih/mypath`
* A new `:GoPathClear` command that clears the previous set `GOPATH` via
`:GoPath` and restores it to the initial` GOPATH` value. the current set
`GOPATH`.
* A new `go_autodetect_gopath` setting. This is enabled by default. When enabled, vim-go automatically modifies the `GOPATH` if a project uses a certain package tool (such as `godep`). For now only `godep` is supported. If a user edits a file and invokes any `vim-go` command, such as `:GoDef`, `:GoBuild`, etc.. the `GOPATH` will include the `Godeps` folder. For example any go-to-definition via `:GoDef` will jump to the source code inside `Godeps`. 
* Changes to vim-go code base to have better support for multiple OS.
