### PR TITLE
support git url.<base>.insteadOf and custom import paths of binaries

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -140,7 +140,7 @@ function! s:GoInstallBinaries(updateBinaries)
                 echo "vim-go: ". basename ." not found. Installing ". pkg . " to folder " . go_bin_path
             endif
 
-            let out = system("go get -u -v ".shellescape(pkg))
+            let out = system("go get -u -v -f ".shellescape(pkg))
             if v:shell_error
                 echo "Error installing ". pkg . ": " . out
             endif


### PR DESCRIPTION
Fix GoUpdateBinaries to support using the git url.<base>.insteadOf
configuration. `go get` is already fixed on the tip of the go sources, but
GoUpateBinaries with go1.4 fails to update any binary whose remote.origin.url
is not the custom import path.

relates to golang/go#10791