### PR TITLE
fixed godocNotFound to not match 'os' pkg contents

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -76,7 +76,7 @@ function! s:godocNotFound(content)
         return 1
     endif
 
-    return a:content =~# '^.*: no such file or directory\n'
+    return a:content =~# '^.*: no such file or directory\n$'
 endfunction
 
 function! go#doc#OpenBrowser(...)


### PR DESCRIPTION
The no such file string appears in 'os' package's documentation, so it erroneously claims that documentation wasn't found. Forcing it to only match that string if it is found at the end of the content allows `:GoDoc os` to succeed, but `:GoDoc osx`, for example, to still fail.