### PR TITLE
Oracle improvements

### DIFF
--- a/autoload/go/oracle.vim
+++ b/autoload/go/oracle.vim
@@ -1,4 +1,3 @@
-" -*- text -*-
 "  oracle.vim -- Vim integration for the Go oracle.
 "
 "  Part of this plugin was taken directly from the oracle repo, however it's
@@ -46,7 +45,7 @@ endfun
 " via regex.
 func! s:qflistSecond(output)
     " backup users errorformat, will be restored once we are finished
-	let old_errorformat = &errorformat
+    let old_errorformat = &errorformat
 
     " match two possible styles of errorformats:
     "
@@ -56,13 +55,13 @@ func! s:qflistSecond(output)
     " We discard line2 and col2 for the first errorformat, because it's not
     " useful and quickfix only has the ability to show one line and column
     " number
-	let &errorformat = "%f:%l.%c-%[%^:]%#:\ %m,%f:%l:%c:\ %m"
+    let &errorformat = "%f:%l.%c-%[%^:]%#:\ %m,%f:%l:%c:\ %m"
 
     " create the quickfix list and open it
     cgetexpr split(a:output, "\n")
     cwindow
 
-	let &errorformat = old_errorformat
+    let &errorformat = old_errorformat
 endfun
 
 func! s:getpos(l, c)
@@ -85,7 +84,7 @@ func! s:RunOracle(mode, selected) range abort
         let unescaped_scopes = split(get(g:, 'go_oracle_scope'))
         let scopes = []
         for unescaped_scope in unescaped_scopes
-          call add(scopes, shellescape(unescaped_scope))
+            call add(scopes, shellescape(unescaped_scope))
         endfor
     elseif exists('g:go_oracle_include_tests') && pkg != -1
         " give import path so it includes all _test.go files too
@@ -120,7 +119,7 @@ func! s:RunOracle(mode, selected) range abort
     " info check Oracle's User Manual section about scopes:
     " https://docs.google.com/document/d/1SLk36YRjjMgKqe490mSRzOPYEDe0Y_WQNRv-EiFYUyw/view#heading=h.nwso96pj07q8
     for scope in scopes
-      let cmd .= ' ' . scope
+        let cmd .= ' ' . scope
     endfor
 
     echon "vim-go: " | echohl Identifier | echon "analysing ..." | echohl None
@@ -138,28 +137,28 @@ func! s:RunOracle(mode, selected) range abort
         " package which doesn't build. 
         redraw | echon "vim-go: " | echohl Statement | echon out | echohl None
         return ""
-    else
+    endif
 
     return out
-endfun
+endfunc
 
 function! go#oracle#Scope(...)
-	if len(a:000)
+    if len(a:000)
         if len(a:000) == 1 && a:1 == '""'
             let g:go_oracle_scope = ""
-		    echon "vim-go: " | echohl Function | echon "oracle scope is cleared"| echohl None
+            echon "vim-go: " | echohl Function | echon "oracle scope is cleared"| echohl None
         else
             let g:go_oracle_scope = join(a:000, ' ')
-		    echon "vim-go: " | echohl Function | echon "oracle scope changed to: '". g:go_oracle_scope ."'" | echohl None
+            echon "vim-go: " | echohl Function | echon "oracle scope changed to: '". g:go_oracle_scope ."'" | echohl None
         endif
 
         return
-	endif
+    endif
 
     if !exists(g:go_oracle_scope)
-	    echon "vim-go: " | echohl Function | echon "oracle scope is not set"| echohl None
+        echon "vim-go: " | echohl Function | echon "oracle scope is not set"| echohl None
     else
-	    echon "vim-go: " | echohl Function | echon "current oracle scope: '". g:go_oracle_scope ."'" | echohl None
+        echon "vim-go: " | echohl Function | echon "current oracle scope: '". g:go_oracle_scope ."'" | echohl None
     endif
 endfunction
 
@@ -212,3 +211,4 @@ function! go#oracle#Referrers(selected)
 endfunction
 
 " vim:ts=4:sw=4:et
+"

--- a/autoload/go/oracle.vim
+++ b/autoload/go/oracle.vim
@@ -143,6 +143,25 @@ func! s:RunOracle(mode, selected) range abort
     return out
 endfun
 
+function! go#oracle#Scope(...)
+	if len(a:000)
+        if len(a:000) == 1 && a:1 == '""'
+            let g:go_oracle_scope = ""
+		    echon "vim-go: " | echohl Function | echon "oracle scope is cleared"| echohl None
+        else
+            let g:go_oracle_scope = join(a:000, ' ')
+		    echon "vim-go: " | echohl Function | echon "oracle scope changed to: '". g:go_oracle_scope ."'" | echohl None
+        endif
+
+        return
+	endif
+
+    if !exists(g:go_oracle_scope)
+	    echon "vim-go: " | echohl Function | echon "oracle scope is not set"| echohl None
+    else
+	    echon "vim-go: " | echohl Function | echon "current oracle scope: '". g:go_oracle_scope ."'" | echohl None
+    endif
+endfunction
 
 " Show 'implements' relation for selected package
 function! go#oracle#Implements(selected)

--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -112,7 +112,11 @@ endfunction
 
 function! go#package#Complete(ArgLead, CmdLine, CursorPos)
     let words = split(a:CmdLine, '\s\+', 1)
-    if len(words) > 2 && words[0] != "GoImportAs"
+
+    " do not complete package members for these commands
+    let neglect_commands = ["GoImportAs", "GoOracleScope"]
+
+    if len(words) > 2 && index(neglect_commands, words[0]) == -1
         " Complete package members
         return go#package#CompleteMembers(words[1], words[2])
     endif

--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -142,6 +142,11 @@ function! go#package#Complete(ArgLead, CmdLine, CursorPos)
                 endif
                 let i = substitute(substitute(i[len(r)+1:], '[\\]', '/', 'g'),
                                   \ '\.a$', '', 'g')
+
+                " without this the result can have duplicates in form of
+                " 'encoding/json' and '/encoding/json/'
+                let i = go#util#StripPathSep(i)
+
                 let ret[i] = i
             endfor
         endfor

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -36,3 +36,14 @@ function! go#util#IsWin()
 
     return 0
 endfunction
+
+" StripPath strips the path's last character if it's a path separator.
+" example: '/foo/bar/'  -> '/foo/bar'
+function! go#util#StripPathSep(path)
+	let last_char = strlen(a:path) - 1
+	if a:path[last_char] == go#util#PathSep()
+		return strpart(a:path, 0, last_char)
+	endif
+
+	return a:path
+endfunction

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -1,40 +1,40 @@
 " PathSep returns the appropriate OS specific path separator.
 function! go#util#PathSep()
-    if go#util#IsWin()
-        return '\'
-    endif
-    return '/'
+	if go#util#IsWin()
+		return '\'
+	endif
+	return '/'
 endfunction
 
 " PathListSep returns the appropriate OS specific path list separator.
 function! go#util#PathListSep()
-    if go#util#IsWin()
-        return ";"
-    endif
-    return ":"
+	if go#util#IsWin()
+		return ";"
+	endif
+	return ":"
 endfunction
 
 " LineEnding returns the correct line ending, based on the current fileformat
 function! go#util#LineEnding()
-    if &fileformat == 'dos'
-        return "\r\n"
-    elseif &fileformat == 'mac'
-        return "\r"
-    endif
+	if &fileformat == 'dos'
+		return "\r\n"
+	elseif &fileformat == 'mac'
+		return "\r"
+	endif
 
-    return "\n"
+	return "\n"
 endfunction
 
 " IsWin returns 1 if current OS is Windows or 0 otherwise
 function! go#util#IsWin()
-    let win = ['win16', 'win32', 'win32unix', 'win64', 'win95']
-    for w in win
-        if (has(w))
-            return 1
-        endif
-    endfor
+	let win = ['win16', 'win32', 'win32unix', 'win64', 'win95']
+	for w in win
+		if (has(w))
+			return 1
+		endif
+	endfor
 
-    return 0
+	return 0
 endfunction
 
 " StripPath strips the path's last character if it's a path separator.
@@ -47,3 +47,5 @@ function! go#util#StripPathSep(path)
 
 	return a:path
 endfunction
+
+" vim:ts=4:sw=4:et

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -304,6 +304,15 @@ COMMANDS                                                          *go-commands*
     Rename the identifier under the cursor to the desired new name. If no
     argument is given a prompt will ask for the desired identifier.
 
+
+                                                            *:GoOracleScope*
+:GoOracleScope [path1] [path2] ...
+
+    Changes the custom |g:go_oracle_scope| setting and overrides it with the
+    given import paths. The custom scope is cleared (unset) if `""` is given
+    as the only path. If no arguments is given it prints the current custom
+    scope.
+
                                                               *:GoCallees*
 :GoCallees
 
@@ -654,7 +663,8 @@ is used. Use "neosnippet" for neosnippet.vim: >
 
 Use this option to define the scope of the analysis to be passed for Oracle
 related commands, such as |GoImplements|, |GoCallers|, etc..  By default it's
-not set, so only the current packages go files are passed as scope. For more
+not set, so only the current packages go files are passed as scope. You can
+change it on-the-fly with |GoOracleScope|. For more
 info please have look at Oracle's User Manual:
 https://docs.google.com/document/d/1SLk36YRjjMgKqe490mSRzOPYEDe0Y_WQNRv-EiFYUyw/view#heading=h.nwso96pj07q8
 >

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -54,6 +54,8 @@ command! -range=% GoFreevars call go#oracle#Freevars(<count>)
 command! -range=% GoChannelPeers call go#oracle#ChannelPeers(<count>)
 command! -range=% GoReferrers call go#oracle#Referrers(<count>)
 
+command! -nargs=* -complete=customlist,go#package#Complete GoOracleScope call go#oracle#Scope(<f-args>)
+
 " tool
 command! -nargs=0 GoFiles echo go#tool#Files()
 command! -nargs=0 GoDeps echo go#tool#Deps()


### PR DESCRIPTION
1. Add new `:GoOracleScope` with following usages:
  *. `:GoOracleScope` prints the current custom scope
  *. `:GoOracleScope fmt github.com/fatih/color` sets the custom scope from given arguments. It overrides the `g:go_oracle_scope` argument.
  *. `:GoOracleScope ""` clears the scope and unsets it

2. Add package completion to `:GoOracleScope`. So  when we hit `tab` for the following command `:GoOracleScope gith...`  it'll be completed to `:GoOracleScope github.com/...` with possible results to complete the finish. It completes any package in `GOPATH`

3. This PR also includes a fix where the completion would show duplicates paths for completion results, such as `github.com/fatih/color` and `github.com/fatih/color/`. 

These are improvements for #423. 

/cc @tsenart