### PR TITLE
commands: use bang attribute to jump to errors

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -35,8 +35,10 @@ function! go#cmd#Build(bang, ...)
 
     cwindow
     let errors = getqflist()
-    if !empty(errors) && !a:bang
-        cc 1 "jump to first error if there is any
+    if !empty(errors) 
+        if !a:bang
+            cc 1 "jump to first error if there is any
+        endif
     else
         redraws! | echon "vim-go: " | echohl Function | echon "[build] SUCCESS"| echohl None
     endif
@@ -232,8 +234,10 @@ function! go#cmd#Vet(bang)
     endif
 
     let errors = getqflist()
-    if !empty(errors) && !a:bang
-        cc 1 "jump to first error if there is any
+    if !empty(errors) 
+        if !a:bang
+            cc 1 "jump to first error if there is any
+        endif
     else
         redraw | echon "vim-go: " | echohl Function | echon "[vet] PASS" | echohl None
     endif

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -1,7 +1,3 @@
-if !exists("g:go_jump_to_error")
-    let g:go_jump_to_error = 1
-endif
-
 if !exists("g:go_dispatch_enabled")
     let g:go_dispatch_enabled = 0
 endif
@@ -36,16 +32,13 @@ function! go#cmd#Build(bang, ...)
         silent! exe 'make!'
     endif
     redraw!
-    if !a:bang
-        cwindow
-        let errors = getqflist()
-        if !empty(errors)
-            if g:go_jump_to_error
-                cc 1 "jump to first error if there is any
-            endif
-        else
-            redraws! | echon "vim-go: " | echohl Function | echon "[build] SUCCESS"| echohl None
-        endif
+
+    cwindow
+    let errors = getqflist()
+    if !empty(errors) && !a:bang
+        cc 1 "jump to first error if there is any
+    else
+        redraws! | echon "vim-go: " | echohl Function | echon "[build] SUCCESS"| echohl None
     endif
 
     let &makeprg = default_makeprg
@@ -86,14 +79,11 @@ function! go#cmd#Run(bang, ...)
     else
         exe 'make!'
     endif
-    if !a:bang
-        cwindow
-        let errors = getqflist()
-        if !empty(errors)
-            if g:go_jump_to_error
-                cc 1 "jump to first error if there is any
-            endif
-        endif
+
+    cwindow
+    let errors = getqflist()
+    if !empty(errors) && !a:bang
+        cc 1 "jump to first error if there is any
     endif
 
     let $GOPATH = old_gopath
@@ -103,7 +93,7 @@ endfunction
 " Install installs the package by simple calling 'go install'. If any argument
 " is given(which are passed directly to 'go insta'') it tries to install those
 " packages. Errors are populated in the quickfix window.
-function! go#cmd#Install(...)
+function! go#cmd#Install(bang, ...)
     let pkgs = join(a:000, '" "')
     let command = 'go install "' . pkgs . '"'
     call go#cmd#autowrite()
@@ -112,10 +102,8 @@ function! go#cmd#Install(...)
         call go#tool#ShowErrors(out)
         cwindow
         let errors = getqflist()
-        if !empty(errors)
-            if g:go_jump_to_error
-                cc 1 "jump to first error if there is any
-            endif
+        if !empty(errors) && !a:bang
+            cc 1 "jump to first error if there is any
         endif
         return
     endif
@@ -126,7 +114,7 @@ endfunction
 " Test runs `go test` in the current directory. If compile is true, it'll
 " compile the tests instead of running them (useful to catch errors in the
 " test files). Any other argument is appendend to the final `go test` command
-function! go#cmd#Test(compile, ...)
+function! go#cmd#Test(bang, compile, ...)
     let command = "go test "
 
     " don't run the test, only compile it. Useful to capture and fix errors or
@@ -156,10 +144,8 @@ function! go#cmd#Test(compile, ...)
         call go#tool#ShowErrors(out)
         cwindow
         let errors = getqflist()
-        if !empty(errors)
-            if g:go_jump_to_error
-                cc 1 "jump to first error if there is any
-            endif
+        if !empty(errors) && !a:bang
+            cc 1 "jump to first error if there is any
         endif
         echon "vim-go: " | echohl ErrorMsg | echon "[test] FAIL" | echohl None
     else
@@ -176,7 +162,7 @@ endfunction
 
 " Testfunc runs a single test that surrounds the current cursor position.
 " Arguments are passed to the `go test` command.
-function! go#cmd#TestFunc(...)
+function! go#cmd#TestFunc(bang, ...)
     " search flags legend (used only)
     " 'b' search backward instead of forward
     " 'c' accept a match at the cursor position
@@ -204,12 +190,12 @@ function! go#cmd#TestFunc(...)
         let flag = " " . flag
     endif
 
-    call go#cmd#Test(0, a1, flag)
+    call go#cmd#Test(a:bang, 0, a1, flag)
 endfunction
 
 " Coverage creates a new cover profile with 'go test -coverprofile' and opens
 " a new HTML coverage page from that profile.
-function! go#cmd#Coverage(...)
+function! go#cmd#Coverage(bang, ...)
     let l:tmpname=tempname()
 
     let command = "go test -coverprofile=".l:tmpname
@@ -226,20 +212,16 @@ function! go#cmd#Coverage(...)
         call go#tool#ExecuteInDir(openHTML)
     endif
     cwindow
-
     let errors = getqflist()
-    if !empty(errors)
-        if g:go_jump_to_error
-            cc 1 "jump to first error if there is any
-        endif
+    if !empty(errors) && !a:bang
+        cc 1 "jump to first error if there is any
     endif
-
     call delete(l:tmpname)
 endfunction
 
 " Vet calls "go vet' on the current directory. Any warnings are populated in
 " the quickfix window
-function! go#cmd#Vet()
+function! go#cmd#Vet(bang)
     call go#cmd#autowrite()
     echon "vim-go: " | echohl Identifier | echon "calling vet..." | echohl None
     let out = go#tool#ExecuteInDir('go vet')
@@ -248,13 +230,10 @@ function! go#cmd#Vet()
     else
         call setqflist([])
     endif
-    cwindow
 
     let errors = getqflist()
-    if !empty(errors)
-        if g:go_jump_to_error
-            cc 1 "jump to first error if there is any
-        endif
+    if !empty(errors) && !a:bang
+        cc 1 "jump to first error if there is any
     else
         redraw | echon "vim-go: " | echohl Function | echon "[vet] PASS" | echohl None
     endif

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -182,13 +182,15 @@ COMMANDS                                                          *go-commands*
      'xterm-clipboard' otherwise it's get yanked into the `""` register.
 
                                                                      *:GoVet*
-:GoVet
+:GoVet[!]
 
     Run `go vet` for the directory under your current file. Vet examines Go
     source code and reports suspicious constructs, such as Printf calls whose
     arguments do not align with the format string. Vet uses heuristics that do not
     guarantee all reports are genuine problems, but it can find errors not caught
     by the compilers.
+
+    If [!] is not given the first error is jumped to.
 
                                                                      *:GoDef*
 :GoDef [identifier]
@@ -227,19 +229,23 @@ COMMANDS                                                          *go-commands*
 
 
                                                                  *:GoInstall*
-:GoInstall
+:GoInstall[!]
 
   Install your package with `go install`.
 
+    If [!] is not given the first error is jumped to.
+
                                                                     *:GoTest*
-:GoTest [expand]
+:GoTest[!] [expand]
 
     Run the tests on your _test.go files via in your current directory. Errors
     are populated in quickfix window.  If an argument is passed, 'expand' is
     used as file selector (useful for cases like `:GoTest ./...`).
 
+    If [!] is not given the first error is jumped to.
+
                                                               *:GoTestFunc*
-:GoTestFunc [expand]
+:GoTestFunc[!] [expand]
 
     Runs :GoTest, but only on the single test function immediate to your
     cursor using 'go test's '-run' flag.
@@ -248,8 +254,10 @@ COMMANDS                                                          *go-commands*
     a matching `func Test` pattern is found or top of file is reached. Search
     will not wrap around when at the top of the file.
 
+    If [!] is not given the first error is jumped to.
+
                                                               *:GoTestCompile*
-:GoTestCompile [expand]
+:GoTestCompile[!] [expand]
 
     Compile your _test.go files via in your current directory. Errors are
     populated in quickfix window.  If an argument is passed, 'expand' is used
@@ -257,11 +265,15 @@ COMMANDS                                                          *go-commands*
     run the tests and capture/fix errors before running the tests or to
     create test binary.
 
+    If [!] is not given the first error is jumped to.
+
                                                                 *:GoCoverage*
-:GoCoverage
+:GoCoverage[!]
 
     Create a coverage profile and open a browser to display the annotated
     source code of the current package.
+
+    If [!] is not given the first error is jumped to.
 
                                                                 *:GoErrCheck*
 :GoErrCheck
@@ -599,10 +611,10 @@ fails. By default it's disabled. >
 
 Use this option to enable fmt's experimental mode. This experimental mode is
 superior to the current mode as it fully saves the undo history, so undo/redo
-doesn't break. However it's causing problems on some Vim versions. By default
-it's disabled. >
+doesn't break. However it's slows (creates/deletes a file for every save) and
+it's causing problems on some Vim versions. By default it's disabled. >
 
-  let g:go_fmt_experimental = 1
+  let g:go_fmt_experimental = 0
 <
                                               *'g:go_doc_keywordprg_enabled'*
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -578,6 +578,18 @@ By default it's disabled >
 
   let g:go_auto_type_info = 0
 <
+
+                                                      *'g:go_jump_to_error'*
+
+Use this option to enable/disable passing the bang attribute to the mappings
+|(go-build)|, |(go-run)|, etc..  When enabled it will jump to the first error
+automatically (means it will NOT pass the bang attribute to the appropriate
+command, i.e: (go-run) -> :GoRun ). Note, that calling this doesn't have any
+affect on calling the commands manually. This setting is only useful for
+changing the behaviour of our custom static mappings. By default it's enabled.
+>
+  let g:go_jump_to_error = 1
+<
                                                         *'g:go_fmt_autosave'*
 
 Use this option to auto |:GoFmt| on save. By default it's enabled >

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -3,16 +3,26 @@ if exists("g:go_loaded_commands")
 endif
 let g:go_loaded_commands = 1
 
+" go_jump_to_error defines whether we should pass the bang attribute to the
+" command or not. This is only used for mappings, because the user can't pass
+" the bang attribute to the plug mappings below. So instead of hardcoding it
+" as 0 (no '!' attribute) or 1 (with '!' attribute) we pass the user setting,
+" which by default is enabled. For commands the user has the ability to pass
+" the '!', such as :GoBuild or :GoBuild!
+if !exists("g:go_jump_to_error")
+    let g:go_jump_to_error = 1
+endif
+
 
 " Some handy plug mappings
-nnoremap <silent> <Plug>(go-run) :<C-u>call go#cmd#Run(0,expand('%'))<CR>
-nnoremap <silent> <Plug>(go-build) :<C-u>call go#cmd#Build(0,'')<CR>
-nnoremap <silent> <Plug>(go-install) :<C-u>call go#cmd#Install(0)<CR>
-nnoremap <silent> <Plug>(go-test) :<C-u>call go#cmd#Test(0, 0, '')<CR>
-nnoremap <silent> <Plug>(go-test-func) :<C-u>call go#cmd#TestFunc(0, '')<CR>
-nnoremap <silent> <Plug>(go-test-compile) :<C-u>call go#cmd#Test(0, 1, '')<CR>
-nnoremap <silent> <Plug>(go-coverage) :<C-u>call go#cmd#Coverage(0, '')<CR>
-nnoremap <silent> <Plug>(go-vet) :<C-u>call go#cmd#Vet(0)<CR>
+nnoremap <silent> <Plug>(go-run) :<C-u>call go#cmd#Run(!g:go_jump_to_error,expand('%'))<CR>
+nnoremap <silent> <Plug>(go-build) :<C-u>call go#cmd#Build(!g:go_jump_to_error,'')<CR>
+nnoremap <silent> <Plug>(go-install) :<C-u>call go#cmd#Install(!g:go_jump_to_error)<CR>
+nnoremap <silent> <Plug>(go-test) :<C-u>call go#cmd#Test(!g:go_jump_to_error, 0, '')<CR>
+nnoremap <silent> <Plug>(go-test-func) :<C-u>call go#cmd#TestFunc(!g:go_jump_to_error, '')<CR>
+nnoremap <silent> <Plug>(go-test-compile) :<C-u>call go#cmd#Test(!g:go_jump_to_error, 1, '')<CR>
+nnoremap <silent> <Plug>(go-coverage) :<C-u>call go#cmd#Coverage(!g:go_jump_to_error, '')<CR>
+nnoremap <silent> <Plug>(go-vet) :<C-u>call go#cmd#Vet(!g:go_jump_to_error)<CR>
 
 nnoremap <silent> <Plug>(go-files) :<C-u>call go#tool#Files()<CR>
 nnoremap <silent> <Plug>(go-deps) :<C-u>call go#tool#Deps()<CR>

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -5,14 +5,15 @@ let g:go_loaded_commands = 1
 
 
 " Some handy plug mappings
-nnoremap <silent> <Plug>(go-run) :<C-u>call go#cmd#Run(expand('%'))<CR>
-nnoremap <silent> <Plug>(go-build) :<C-u>call go#cmd#Build('')<CR>
-nnoremap <silent> <Plug>(go-install) :<C-u>call go#cmd#Install()<CR>
-nnoremap <silent> <Plug>(go-test) :<C-u>call go#cmd#Test(0, '')<CR>
-nnoremap <silent> <Plug>(go-test-func) :<C-u>call go#cmd#TestFunc('')<CR>
-nnoremap <silent> <Plug>(go-test-compile) :<C-u>call go#cmd#Test(1, '')<CR>
-nnoremap <silent> <Plug>(go-coverage) :<C-u>call go#cmd#Coverage('')<CR>
-nnoremap <silent> <Plug>(go-vet) :<C-u>call go#cmd#Vet()<CR>
+nnoremap <silent> <Plug>(go-run) :<C-u>call go#cmd#Run(0,expand('%'))<CR>
+nnoremap <silent> <Plug>(go-build) :<C-u>call go#cmd#Build(0,'')<CR>
+nnoremap <silent> <Plug>(go-install) :<C-u>call go#cmd#Install(0)<CR>
+nnoremap <silent> <Plug>(go-test) :<C-u>call go#cmd#Test(0, 0, '')<CR>
+nnoremap <silent> <Plug>(go-test-func) :<C-u>call go#cmd#TestFunc(0, '')<CR>
+nnoremap <silent> <Plug>(go-test-compile) :<C-u>call go#cmd#Test(0, 1, '')<CR>
+nnoremap <silent> <Plug>(go-coverage) :<C-u>call go#cmd#Coverage(0, '')<CR>
+nnoremap <silent> <Plug>(go-vet) :<C-u>call go#cmd#Vet(0)<CR>
+
 nnoremap <silent> <Plug>(go-files) :<C-u>call go#tool#Files()<CR>
 nnoremap <silent> <Plug>(go-deps) :<C-u>call go#tool#Deps()<CR>
 nnoremap <silent> <Plug>(go-info) :<C-u>call go#complete#Info()<CR>
@@ -62,15 +63,14 @@ command! -nargs=0 GoDeps echo go#tool#Deps()
 command! -nargs=* GoInfo call go#complete#Info()
 
 " cmd
-command! -nargs=* -bang GoRun call go#cmd#Run(<bang>0,<f-args>)
 command! -nargs=* -bang GoBuild call go#cmd#Build(<bang>0,<f-args>)
-command! -nargs=* GoInstall call go#cmd#Install(<f-args>)
-command! -nargs=* GoTest call go#cmd#Test(0, <f-args>)
-command! -nargs=* GoTestFunc call go#cmd#TestFunc(<f-args>)
-command! -nargs=* GoTestCompile call go#cmd#Test(1, <f-args>)
-command! -nargs=* GoCoverage call go#cmd#Coverage(<f-args>)
-command! -nargs=0 GoVet call go#cmd#Vet()
-command! -nargs=0 GoErrCheck call go#errcheck#Run(<f-args>)
+command! -nargs=* -bang GoRun call go#cmd#Run(<bang>0,<f-args>)
+command! -nargs=* -bang GoInstall call go#cmd#Install(<bang>0, <f-args>)
+command! -nargs=* -bang GoTest call go#cmd#Test(<bang>0, 0, <f-args>)
+command! -nargs=* -bang GoTestFunc call go#cmd#TestFunc(<bang>0, <f-args>)
+command! -nargs=* -bang GoTestCompile call go#cmd#Test(<bang>0, 1, <f-args>)
+command! -nargs=* -bang GoCoverage call go#cmd#Coverage(<bang>0, <f-args>)
+command! -nargs=0 -bang GoVet call go#cmd#Vet(<bang>0)
 
 " -- play
 command! -nargs=0 -range=% GoPlay call go#play#Share(<count>, <line1>, <line2>)


### PR DESCRIPTION
Previously we were using a custom global variable to control the
behavior of jumpting to an error when we called any command in cmd.vim
(such as :GoInstall, :GoTest, etc..)

However we don't need this actually because the default :make command
in vim has the behavior of no jumping to the error when the `!` attribute
is passed to the command, i.e: `:make!`. We have this feature already
for `:GoBuild` and `:GoRun` but those were also conflicting with our
manual `g:go_jump_to_error` setting. Basically even if you call
`:GoBuild` (without `!`) it would not jump if `g:go_jump_to_error` was
set to `0`.

This PR adds the bang attribute, removes the `go_jump_to_error` setting
for the following commands:

* `:GoBuild`
* `:GoRun`
* `:GoInstall`
* `:GoTest`
* `:GoTestFunc`
* `:GoTestCompile`
* `:GoVet`
* `:GoCoverage`

Now basically the behavior is just like `:make`:

* `:GoBuild` jumps to the error
* `:GoBuild!` does not jump to the error

Relates issue #440 