### PR TITLE
GoInstallBinaries: add option to set command

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -774,6 +774,15 @@ supports will be added. By default it's enabled. >
 Adds custom text objects. By default it's enabled. >
 
 	let g:go_textobj_enabled = 1
+<
+
+                                                  *'g:go_install_command'*
+
+Sets the command for |GoInstallBinaries|. %s will be susbituted with a
+package.
+>
+  let g:go_install_command = "go get -u -f -v %s" 
+<
 
 
 ===============================================================================

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -63,12 +63,12 @@ function! s:GoInstallBinaries(updateBinaries)
         set noshellslash
     endif
 
-    let cmd = "go get -u -v "
-
+    
     " https://github.com/golang/go/issues/10791
-    if s:go_version > "1.4.0" && s:go_version < "1.5.0"
-        let cmd .= "-f " 
-    endif
+    let cmd = printf("go get -u -v %s %%s",
+                \ s:go_version > "1.4.0" && s:go_version < "1.5.0" ? "-f" : "")
+
+    let cmd = get(g:, 'go_install_command', cmd)
 
     for pkg in s:packages
         let basename = fnamemodify(pkg, ":t")
@@ -86,8 +86,7 @@ function! s:GoInstallBinaries(updateBinaries)
                 echo "vim-go: ". basename ." not found. Installing ". pkg . " to folder " . go_bin_path
             endif
 
-
-            let out = system(cmd . shellescape(pkg))
+            let out = system(printf(cmd, shellescape(pkg)))
             if v:shell_error
                 echo "Error installing ". pkg . ": " . out
             endif


### PR DESCRIPTION
I was unable to use the default `get` command because the directory `go` is installed to is not writable, with this I can change the command to `build`.