### PR TITLE
set tabstop=8 in gofiletype_pre function

### DIFF
--- a/ftdetect/gofiletype.vim
+++ b/ftdetect/gofiletype.vim
@@ -9,6 +9,7 @@ function! s:gofiletype_pre()
     let s:current_fileformats = &g:fileformats
     let s:current_fileencodings = &g:fileencodings
     set fileencodings=utf-8 fileformats=unix
+		set tabstop=8
     setlocal filetype=go
 endfunction
 


### PR DESCRIPTION
As my ADHD made me actualy count the spaces on numerous examples, I figured that "fmt" is allways in sync with main in package main and thats 8 spaces :) just feels right like that.