### PR TITLE
goFormatSpecifier width and precision match

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -147,7 +147,7 @@ hi def link     goEscapeError       Error
 syn cluster     goStringGroup       contains=goEscapeOctal,goEscapeC,goEscapeX,goEscapeU,goEscapeBigU,goEscapeError
 syn region      goString            start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@goStringGroup
 syn region      goRawString         start=+`+ end=+`+
-syn match       goFormatSpecifier   /%[#0\-\ \+\*]*[vTtbcdoqxXUeEfgGsp]/ contained containedin=goString
+syn match       goFormatSpecifier   /%[-#0 +]*\%(\*\|\d\+\)\=\%(\.\%(\*\|\d\+\)\)*[vTtbcdoqxXUeEfgGsp]/ contained containedin=goString
 
 hi def link     goString            String
 hi def link     goRawString         String


### PR DESCRIPTION
Fix to match and highlight width and precision in goFormatSpecifier.
```
%s %5s %-5s %5.5f %.5f
```
Using a part of the [Python syntax](https://github.com/hdima/python-syntax/blob/44f1855902b6e2836ff95bec3fc221ad17021ee3/syntax/python.vim#L306). 

