### PR TITLE
Add gb-vendor plugin's folder to gopath

### DIFF
--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -88,6 +88,13 @@ function! go#path#Detect()
     if !empty(src_root)
         let src_path = fnamemodify(src_root, ':p:h:h') . go#util#PathSep()
 
+        " gb vendor plugin
+        " (https://github.com/constabulary/gb/tree/master/cmd/gb-vendor)
+        let gb_vendor_root = src_path . "vendor" . go#util#PathSep()
+        if !empty(gb_vendor_root) && !go#path#HasPath(gb_vendor_root)
+            let gopath = gb_vendor_root . go#util#PathListSep() . gopath
+        endif
+
         if !go#path#HasPath(src_path)
             let gopath =  src_path . go#util#PathListSep() . gopath
         endif


### PR DESCRIPTION
This adds a 'vendor' folder under the discovered 'gb' gopath to your gopath. It does not generalize to vendor folders in your existing gopath.

Per the TODO a few lines above, it might make sense to turn this into a configurable option (e.g. an array of 'vendor', 'third_party' searched for as subdirectories of each part of your gopath), but that change is a little more involved and this change does solve a problem for me and, perhaps, others.