### PR TITLE
Open *.slide files in browser automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ disabled/enabled easily.
   your custom vim function.
 * Tagbar support to show tags of the source code in a sidebar with `gotags`
 * Custom vim text objects, such a `a function` or `inner function`
+* Automatically open `present` slides with `:GoPresent`
 
 ## Install
 
@@ -195,6 +196,12 @@ By default when `:GoInstallBinaries` is called, the binaries are installed to
 ```vim
 let g:go_bin_path = expand("~/.gotools")
 let g:go_bin_path = "/home/fatih/.mypath"      "or give absolute path
+```
+
+Automatically start `present` server before opening presentation:
+
+```vim
+let g:go_slide_start_server = 1
 ```
 
 

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -24,7 +24,7 @@
 "
 
 if !exists("g:go_fmt_command")
-    let g:go_fmt_command = "gofmt"
+    let g:go_fmt_command = "goimports"
 endif
 
 if !exists("g:go_goimports_bin")

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -24,7 +24,7 @@
 "
 
 if !exists("g:go_fmt_command")
-    let g:go_fmt_command = "goimports"
+    let g:go_fmt_command = "gofmt"
 endif
 
 if !exists("g:go_goimports_bin")

--- a/autoload/slide/present.vim
+++ b/autoload/slide/present.vim
@@ -1,0 +1,39 @@
+if !exists("g:go_slide_open_browser")
+    let g:go_slide_open_browser = 1
+endif
+
+if !exists("g:go_slide_start_server")
+    let g:go_slide_start_server = 0
+endif
+
+
+function! slide#present#Present(filename)
+
+    if g:go_slide_start_server == 1
+        let command = "present &"
+        call system(command)
+
+        if v:shell_error
+            echo 'A error has occured. Run this command to see what the problem is:'
+            echo command
+            return
+        endif
+
+    endif
+    
+
+    let url = "http://127.0.0.1:3999/".a:filename
+
+    " copy to clipboard
+    if has('unix') && !has('xterm_clipboard') && !has('clipboard')
+        let @" = url
+    else
+        let @+ = url
+    endif
+
+    if g:go_slide_open_browser != 0
+        call go#tool#OpenBrowser(url)
+    endif
+
+    echo "vim-go: presentation loaded ".url
+endfunction

--- a/ftdetect/gofiletype.vim
+++ b/ftdetect/gofiletype.vim
@@ -5,11 +5,11 @@ let s:current_fileformats = ''
 let s:current_fileencodings = ''
 
 " define fileencodings to open as utf-8 encoding even if it's ascii.
-function! s:gofiletype_pre()
+function! s:gofiletype_pre(ftype)
     let s:current_fileformats = &g:fileformats
     let s:current_fileencodings = &g:fileencodings
     set fileencodings=utf-8 fileformats=unix
-    setlocal filetype=go
+    let &filetype = a:ftype
 endfunction
 
 " restore fileencodings as others
@@ -19,8 +19,13 @@ function! s:gofiletype_post()
 endfunction
 
 au BufNewFile *.go setlocal filetype=go fileencoding=utf-8 fileformat=unix
-au BufRead *.go call s:gofiletype_pre()
+au BufRead *.go call s:gofiletype_pre("go")
 au BufReadPost *.go call s:gofiletype_post()
+
+
+au BufNewFile *.slide setlocal filetype=slide fileencoding=utf-8 fileformat=unix
+au BufRead *.slide call s:gofiletype_pre("slide")
+au BufReadPost *.slide call s:gofiletype_post()
 
 au BufRead,BufNewFile *.tmpl set filetype=gohtmltmpl
 

--- a/ftplugin/slide/commands.vim
+++ b/ftplugin/slide/commands.vim
@@ -1,0 +1,9 @@
+if exists("g:slide_loaded_commands")
+    finish
+endif
+let g:slide_loaded_commands = 1
+
+" -- Present
+command! -nargs=0 -range=% GoPresent call slide#present#Present(expand('%:t'))
+
+" vim:ts=4:sw=4:et

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -4,6 +4,7 @@ if exists("g:go_loaded_install")
 endif
 let g:go_loaded_install = 1
 
+
 " these packages are used by vim-go and can be automatically installed if
 " needed by the user with GoInstallBinaries
 let s:packages = [

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -4,7 +4,6 @@ if exists("g:go_loaded_install")
 endif
 let g:go_loaded_install = 1
 
-
 " these packages are used by vim-go and can be automatically installed if
 " needed by the user with GoInstallBinaries
 let s:packages = [
@@ -16,6 +15,7 @@ let s:packages = [
             \ "github.com/golang/lint/golint",
             \ "github.com/kisielk/errcheck",
             \ "github.com/jstemmer/gotags",
+            \ "golang.org/x/tools/cmd/present",
             \ ]
 
 " These commands are available on any filetypes


### PR DESCRIPTION
The following PR allows *.slide files to be opened into the browser
through the "GoPresent" command. In addition go_slide_start_server can
be set to start "present" automatically.

@fatih this the first thing I've ever done for `vim`. Even though I've based into your current vim-go please take a careful look into it. 

Hopefully it's useful enough to merge.