### PR TITLE
Ensure $GOPATH in current shell is passed to tools.

### DIFF
--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -93,7 +93,7 @@ function! go#tool#ExecuteInDir(cmd) abort
     let dir = getcwd()
     try
         execute cd . fnameescape(expand("%:p:h"))
-        let out = system(a:cmd)
+        let out = system("env GOPATH=" . $GOPATH . " " . a:cmd)
     finally
         execute cd . fnameescape(dir)
     endtry


### PR DESCRIPTION
The `system` call spawns a new subshell. If you set your `$GOPATH` in your `.zshenv` (or bash equivalent) that value will be used instead of what you set in your current shell (and VIM's) breaking `gorename` and `go oracle` and is counterintuitive from the VIM user's POV. This changes ensure `$GOPATH` picked up by the tools are consistent with the shell that VIM started in.

Fix #472