### PR TITLE
Improve :GoCommand argument handling

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -215,10 +215,14 @@ endfunction
 
 " Vet calls "go vet' on the current directory. Any warnings are populated in
 " the quickfix window
-function! go#cmd#Vet(bang)
+function! go#cmd#Vet(bang, ...)
     call go#cmd#autowrite()
     echon "vim-go: " | echohl Identifier | echon "calling vet..." | echohl None
-    let out = go#tool#ExecuteInDir('go vet')
+    if a:0 == 0
+        let out = go#tool#ExecuteInDir('go vet')
+    else
+        let out = go#tool#ExecuteInDir('go tool vet ' . go#util#Shelljoin(a:000))
+    endif
     if v:shell_error
         call go#tool#ShowErrors(out)
     else

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -14,7 +14,6 @@ endfunction
 " dependent files for the current folder and passes it to go build.
 function! go#cmd#Build(bang, ...)
     let default_makeprg = &makeprg
-    let gofiles = join(go#tool#Files(), '" "')
 
     let old_gopath = $GOPATH
     let $GOPATH = go#path#Detect()
@@ -22,7 +21,10 @@ function! go#cmd#Build(bang, ...)
     if v:shell_error
         let &makeprg = "go build . errors"
     else
-        let &makeprg = "go build -o /dev/null " . join(a:000, ' ') . ' "' . gofiles . '"'
+        " :make expands '%' and '#' wildcards, so they must also be escaped
+        let goargs = go#util#Shelljoin(map(copy(a:000), "expand(v:val)"), 1)
+        let gofiles = go#util#Shelljoin(go#tool#Files(), 1)
+        let &makeprg = "go build -o /dev/null " . goargs . ' ' . gofiles
     endif
 
     echon "vim-go: " | echohl Identifier | echon "building ..."| echohl None

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -122,15 +122,11 @@ function! go#cmd#Test(bang, compile, ...)
     " don't run the test, only compile it. Useful to capture and fix errors or
     " to create a test binary.
     if a:compile
-        let command .= "-c"
+        let command .= "-c "
     endif
 
-    if len(a:000)
-        let command .= expand(a:1)
-    endif
-
-    if len(a:000) == 2
-        let command .= a:2
+    if a:0
+        let command .= go#util#Shelljoin(map(copy(a:000), "expand(v:val)"))
     endif
 
     call go#cmd#autowrite()
@@ -182,17 +178,13 @@ function! go#cmd#TestFunc(bang, ...)
 
     let line = getline(test)
     let name = split(split(line, " ")[1], "(")[0]
-    let flag = "-run \"" . name . "$\""
+    let args = [a:bang, 0, "-run", name . "$"]
 
-    let a1 = ""
-    if len(a:000)
-        let a1 = a:1
-
-        " add extra space
-        let flag = " " . flag
+    if a:0
+        call extend(args, a:000)
     endif
 
-    call go#cmd#Test(a:bang, 0, a1, flag)
+    call call('go#cmd#Test', args)
 endfunction
 
 " Coverage creates a new cover profile with 'go test -coverprofile' and opens

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -238,15 +238,17 @@ endfunction
 " Generate runs 'go generate' in similar fashion to go#cmd#Build()
 function! go#cmd#Generate(bang, ...)
     let default_makeprg = &makeprg
-    let gofiles = join(go#tool#Files(), '" "')
 
     let old_gopath = $GOPATH
     let $GOPATH = go#path#Detect()
 
+    " :make expands '%' and '#' wildcards, so they must also be escaped
+    let goargs = go#util#Shelljoin(map(copy(a:000), "expand(v:val)"), 1)
     if v:shell_error
-        let &makeprg = "go generate " . join(a:000, ' ')
+        let &makeprg = "go generate " . goargs
     else
-        let &makeprg = "go generate " . join(a:000, ' ') . ' "' . gofiles . '"'
+        let gofiles = go#util#Shelljoin(go#tool#Files(), 1)
+        let &makeprg = "go generate " . goargs . ' ' . gofiles
     endif
 
     echon "vim-go: " | echohl Identifier | echon "generating ..."| echohl None

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -97,8 +97,7 @@ endfunction
 " is given(which are passed directly to 'go insta'') it tries to install those
 " packages. Errors are populated in the quickfix window.
 function! go#cmd#Install(bang, ...)
-    let pkgs = join(a:000, '" "')
-    let command = 'go install "' . pkgs . '"'
+    let command = 'go install ' . go#util#Shelljoin(a:000)
     call go#cmd#autowrite()
     let out = go#tool#ExecuteInDir(command)
     if v:shell_error

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -192,7 +192,7 @@ endfunction
 function! go#cmd#Coverage(bang, ...)
     let l:tmpname=tempname()
 
-    let command = "go test -coverprofile=".l:tmpname
+    let command = "go test -coverprofile=" . l:tmpname . ' ' . go#util#Shelljoin(a:000)
 
     call go#cmd#autowrite()
     let out = go#tool#ExecuteInDir(command)

--- a/autoload/go/errcheck.vim
+++ b/autoload/go/errcheck.vim
@@ -4,14 +4,14 @@ endif
 
 function! go#errcheck#Run(...) abort
     if a:0 == 0
-        let package = go#package#ImportPath(expand('%:p:h'))
-        if package == -1
+        let goargs = go#package#ImportPath(expand('%:p:h'))
+        if goargs == -1
             echohl Error | echomsg "vim-go: package is not inside GOPATH src" | echohl None
             return
         endif
     else
-        let package = a:1
-    end
+        let goargs = go#util#Shelljoin(a:000)
+    endif
 
     let bin_path = go#path#CheckBinPath(g:go_errcheck_bin)
     if empty(bin_path)
@@ -19,7 +19,7 @@ function! go#errcheck#Run(...) abort
     endif
 
     echon "vim-go: " | echohl Identifier | echon "errcheck analysing ..." | echohl None
-    let out = system(bin_path . ' ' . package)
+    let out = system(bin_path . ' ' . goargs)
     if v:shell_error
         let errors = []
         let mx = '^\(.\{-}\):\(\d\+\):\(\d\+\)\s*\(.*\)'

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -8,7 +8,7 @@
 "
 " This filetype plugin add a new commands for go buffers:
 "
-"   :GoLint
+"   :GoLint [options]
 "
 "       Run golint for the current Go file.
 "
@@ -16,13 +16,18 @@ if !exists("g:go_golint_bin")
     let g:go_golint_bin = "golint"
 endif
 
-function! go#lint#Run() abort
+function! go#lint#Run(...) abort
 	let bin_path = go#path#CheckBinPath(g:go_golint_bin) 
 	if empty(bin_path) 
 		return 
 	endif
 
-    silent cexpr system(bin_path . " " . shellescape(expand('%')))
+    if a:0 == 0
+        let goargs = shellescape(expand('%'))
+    else
+        let goargs = go#util#Shelljoin(a:000)
+    endif
+    silent cexpr system(bin_path . " " . goargs)
     cwindow
 endfunction
 

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -48,4 +48,14 @@ function! go#util#StripPathSep(path)
 	return a:path
 endfunction
 
+" Shelljoin returns a shell-safe string representation of arglist. The
+" {special} argument of shellescape() may optionally be passed.
+function! go#util#Shelljoin(arglist, ...)
+	if a:0
+		return join(map(copy(a:arglist), 'shellescape(v:val, ' . a:1 . ')'), ' ')
+	else
+		return join(map(copy(a:arglist), 'shellescape(v:val)'), ' ')
+	endif
+endfunction
+
 " vim:ts=4:sw=4:et

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -207,14 +207,14 @@ COMMANDS                                                          *go-commands*
     If [!] is not given the first error is jumped to.
 
                                                                    *:GoBuild*
-:GoBuild[!] [options]
+:GoBuild[!] [expand]
 
     Build your package with `go build`. It automatically builds only the files
     that depends on the current file. GoBuild doesn't produce a result file.
     Use 'make' to create a result file.
 
     You may optionally pass any valid go build flags/options. For a full list
-    please see `go help build`.
+    please see `go help build`. Options are expanded with 'expand'.
 
     If [!] is not given the first error is jumped to.
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -240,9 +240,12 @@ COMMANDS                                                          *go-commands*
 
 
                                                                  *:GoInstall*
-:GoInstall[!]
+:GoInstall[!] [options]
 
-  Install your package with `go install`.
+    Install your package with `go install`.
+
+    You may optionally pass any valid go install flags/options. For a full list
+    please see `go help install`.
 
     If [!] is not given the first error is jumped to.
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -256,6 +256,9 @@ COMMANDS                                                          *go-commands*
     are populated in quickfix window.  If an argument is passed, 'expand' is
     used as file selector (useful for cases like `:GoTest ./...`).
 
+    You may optionally pass any valid go test flags/options. For a full list
+    please see `go help test`.
+
     If [!] is not given the first error is jumped to.
 
                                                               *:GoTestFunc*

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -285,10 +285,13 @@ COMMANDS                                                          *go-commands*
     If [!] is not given the first error is jumped to.
 
                                                                 *:GoCoverage*
-:GoCoverage[!]
+:GoCoverage[!] [options]
 
     Create a coverage profile and open a browser to display the annotated
     source code of the current package.
+
+    You may optionally pass any valid go test flags/options, such as
+    `-covermode set,count,atomic`. For a full list please see `go help test`.
 
     If [!] is not given the first error is jumped to.
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -179,13 +179,17 @@ COMMANDS                                                          *go-commands*
      'xterm-clipboard' otherwise it's get yanked into the `""` register.
 
                                                                      *:GoVet*
-:GoVet[!]
+:GoVet[!] [options]
 
     Run `go vet` for the directory under your current file. Vet examines Go
     source code and reports suspicious constructs, such as Printf calls whose
     arguments do not align with the format string. Vet uses heuristics that do not
     guarantee all reports are genuine problems, but it can find errors not caught
     by the compilers.
+
+    You may optionally pass any valid go tool vet flags/options. In this case,
+    `go tool vet` is run in place of `go vet`. For a full list please see
+    `go tool vet -h`.
 
     If [!] is not given the first error is jumped to.
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -204,6 +204,9 @@ COMMANDS                                                          *go-commands*
     current file is used. If an argument is passed, 'expand' is used as file
     selector. For example use `:GoRun %` to select the current file only.
 
+    You may optionally pass any valid go run flags/options. For a full list
+    please see `go help run`.
+
     If [!] is not given the first error is jumped to.
 
                                                                    *:GoBuild*

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -222,13 +222,13 @@ COMMANDS                                                          *go-commands*
     If [!] is not given the first error is jumped to.
 
                                                                    *:GoGenerate*
-:GoGenerate[!] [options]
+:GoGenerate[!] [expand]
 
     Creates or updates your auto-generated source files by running `go
     generate`.
 
     You may optionally pass any valid go generate flags/options. For a full list
-    please see `go help generate`.
+    please see `go help generate`. Options are expanded with 'expand'.
 
     If [!] is not given the first error is jumped to.
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -140,9 +140,9 @@ COMMANDS                                                          *go-commands*
     displayed and the buffer will be untouched.
 
                                                                     *:GoLint*
-:GoLint
+:GoLint [packages]
 
-    Run golint for the current Go file.
+    Run golint for the current Go file, or for given packages.
 
                                                                      *:GoDoc*
 :GoDoc [word]

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -296,10 +296,13 @@ COMMANDS                                                          *go-commands*
     If [!] is not given the first error is jumped to.
 
                                                                 *:GoErrCheck*
-:GoErrCheck
+:GoErrCheck [options]
 
     Check for unchecked errors in you current package. Errors are populated in
     quickfix window.
+
+    You may optionally pass any valid errcheck flags/options. For a full list
+    please see `errcheck -h`.
 
                                                                    *:GoFiles*
 :GoFiles

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -17,7 +17,7 @@ endif
 " Some handy plug mappings
 nnoremap <silent> <Plug>(go-run) :<C-u>call go#cmd#Run(!g:go_jump_to_error, '%')<CR>
 nnoremap <silent> <Plug>(go-build) :<C-u>call go#cmd#Build(!g:go_jump_to_error)<CR>
-nnoremap <silent> <Plug>(go-generate) :<C-u>call go#cmd#Generate(!g:go_jump_to_error,'')<CR>
+nnoremap <silent> <Plug>(go-generate) :<C-u>call go#cmd#Generate(!g:go_jump_to_error)<CR>
 nnoremap <silent> <Plug>(go-install) :<C-u>call go#cmd#Install(!g:go_jump_to_error)<CR>
 nnoremap <silent> <Plug>(go-test) :<C-u>call go#cmd#Test(!g:go_jump_to_error, 0)<CR>
 nnoremap <silent> <Plug>(go-test-func) :<C-u>call go#cmd#TestFunc(!g:go_jump_to_error)<CR>

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -104,7 +104,7 @@ command! -nargs=1 -bang -complete=customlist,go#package#Complete GoImport call g
 command! -nargs=* -bang -complete=customlist,go#package#Complete GoImportAs call go#import#SwitchImport(1, <f-args>, '<bang>')
 
 " -- lint
-command! GoLint call go#lint#Run()
+command! -nargs=* GoLint call go#lint#Run(<f-args>)
 
 " -- errcheck
 command! -nargs=* -complete=customlist,go#package#Complete GoErrCheck call go#errcheck#Run(<f-args>)

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -16,7 +16,7 @@ endif
 
 " Some handy plug mappings
 nnoremap <silent> <Plug>(go-run) :<C-u>call go#cmd#Run(!g:go_jump_to_error,expand('%'))<CR>
-nnoremap <silent> <Plug>(go-build) :<C-u>call go#cmd#Build(!g:go_jump_to_error,'')<CR>
+nnoremap <silent> <Plug>(go-build) :<C-u>call go#cmd#Build(!g:go_jump_to_error)<CR>
 nnoremap <silent> <Plug>(go-generate) :<C-u>call go#cmd#Generate(!g:go_jump_to_error,'')<CR>
 nnoremap <silent> <Plug>(go-install) :<C-u>call go#cmd#Install(!g:go_jump_to_error)<CR>
 nnoremap <silent> <Plug>(go-test) :<C-u>call go#cmd#Test(!g:go_jump_to_error, 0, '')<CR>

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -15,7 +15,7 @@ endif
 
 
 " Some handy plug mappings
-nnoremap <silent> <Plug>(go-run) :<C-u>call go#cmd#Run(!g:go_jump_to_error,expand('%'))<CR>
+nnoremap <silent> <Plug>(go-run) :<C-u>call go#cmd#Run(!g:go_jump_to_error, '%')<CR>
 nnoremap <silent> <Plug>(go-build) :<C-u>call go#cmd#Build(!g:go_jump_to_error)<CR>
 nnoremap <silent> <Plug>(go-generate) :<C-u>call go#cmd#Generate(!g:go_jump_to_error,'')<CR>
 nnoremap <silent> <Plug>(go-install) :<C-u>call go#cmd#Install(!g:go_jump_to_error)<CR>

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -82,7 +82,7 @@ command! -nargs=* -bang GoTest call go#cmd#Test(<bang>0, 0, <f-args>)
 command! -nargs=* -bang GoTestFunc call go#cmd#TestFunc(<bang>0, <f-args>)
 command! -nargs=* -bang GoTestCompile call go#cmd#Test(<bang>0, 1, <f-args>)
 command! -nargs=* -bang GoCoverage call go#cmd#Coverage(<bang>0, <f-args>)
-command! -nargs=0 -bang GoVet call go#cmd#Vet(<bang>0)
+command! -nargs=* -bang GoVet call go#cmd#Vet(<bang>0, <f-args>)
 
 " -- play
 command! -nargs=0 -range=% GoPlay call go#play#Share(<count>, <line1>, <line2>)

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -22,7 +22,7 @@ nnoremap <silent> <Plug>(go-install) :<C-u>call go#cmd#Install(!g:go_jump_to_err
 nnoremap <silent> <Plug>(go-test) :<C-u>call go#cmd#Test(!g:go_jump_to_error, 0)<CR>
 nnoremap <silent> <Plug>(go-test-func) :<C-u>call go#cmd#TestFunc(!g:go_jump_to_error)<CR>
 nnoremap <silent> <Plug>(go-test-compile) :<C-u>call go#cmd#Test(!g:go_jump_to_error, 1)<CR>
-nnoremap <silent> <Plug>(go-coverage) :<C-u>call go#cmd#Coverage(!g:go_jump_to_error, '')<CR>
+nnoremap <silent> <Plug>(go-coverage) :<C-u>call go#cmd#Coverage(!g:go_jump_to_error)<CR>
 nnoremap <silent> <Plug>(go-vet) :<C-u>call go#cmd#Vet(!g:go_jump_to_error)<CR>
 
 nnoremap <silent> <Plug>(go-files) :<C-u>call go#tool#Files()<CR>

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -19,9 +19,9 @@ nnoremap <silent> <Plug>(go-run) :<C-u>call go#cmd#Run(!g:go_jump_to_error, '%')
 nnoremap <silent> <Plug>(go-build) :<C-u>call go#cmd#Build(!g:go_jump_to_error)<CR>
 nnoremap <silent> <Plug>(go-generate) :<C-u>call go#cmd#Generate(!g:go_jump_to_error,'')<CR>
 nnoremap <silent> <Plug>(go-install) :<C-u>call go#cmd#Install(!g:go_jump_to_error)<CR>
-nnoremap <silent> <Plug>(go-test) :<C-u>call go#cmd#Test(!g:go_jump_to_error, 0, '')<CR>
-nnoremap <silent> <Plug>(go-test-func) :<C-u>call go#cmd#TestFunc(!g:go_jump_to_error, '')<CR>
-nnoremap <silent> <Plug>(go-test-compile) :<C-u>call go#cmd#Test(!g:go_jump_to_error, 1, '')<CR>
+nnoremap <silent> <Plug>(go-test) :<C-u>call go#cmd#Test(!g:go_jump_to_error, 0)<CR>
+nnoremap <silent> <Plug>(go-test-func) :<C-u>call go#cmd#TestFunc(!g:go_jump_to_error)<CR>
+nnoremap <silent> <Plug>(go-test-compile) :<C-u>call go#cmd#Test(!g:go_jump_to_error, 1)<CR>
 nnoremap <silent> <Plug>(go-coverage) :<C-u>call go#cmd#Coverage(!g:go_jump_to_error, '')<CR>
 nnoremap <silent> <Plug>(go-vet) :<C-u>call go#cmd#Vet(!g:go_jump_to_error)<CR>
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -107,6 +107,6 @@ command! -nargs=* -bang -complete=customlist,go#package#Complete GoImportAs call
 command! GoLint call go#lint#Run()
 
 " -- errcheck
-command! -nargs=? -complete=customlist,go#package#Complete GoErrCheck call go#errcheck#Run(<f-args>)
+command! -nargs=* -complete=customlist,go#package#Complete GoErrCheck call go#errcheck#Run(<f-args>)
 
 " vim:ts=4:sw=4:et


### PR DESCRIPTION
Hi @fatih,

This patch series concentrates on `:GoCommand` argument handling:

1. GoRun, GoTest{,Func,Compile}, GoCoverage, GoGenerate, GoErrcheck, GoLint,
   and GoVet can now all handle an arbitrary number of command arguments so
   that the user can pass more flags, packages, etc. to respective programs.

   This allows for maximum flexibility while still providing simple defaults.

   For instance, #461 is addressed with these changes.

2. All command arguments are now properly escaped for shell invocation,
   which will avoid bugs involving users that have go source paths with vim
   wildcards such as `%` and `#`.

3. All command arguments that will invoked via `makeprg` are escaped with the
   `{special}` option of `shellescape` to avoid a double wildcard expansion.

   Example:

```vim
" I have go source file at /src/99%/file.go
set makeprg=go\ build\ /src/99%/file.go
:make
" make expands the '%' wildcard with the current file!
" => stat /src/99/src/99%/file.go/file.go: no such file or directory
```

These are all issues I've had with vim-go because of my idiosyncratic setup
and tastes. I would love to address any concerns about these patches, so
please don't hesitate to critique.

Thank you very much for vim-go. It really pulls together all the fantastic go
tooling into a very first-class vim experience.
