### PR TITLE
fix :GoRun with g:go_dispatch_enabled

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -77,7 +77,7 @@ function! go#cmd#Run(bang, ...)
     endif
 
     if g:go_dispatch_enabled && exists(':Make') == 2
-        silent! exe 'Make!'
+        silent! exe 'Make'
     else
         exe 'make!'
     endif


### PR DESCRIPTION
Running `:Make!` will not update the quickfix list (requires `:Copen`).
As a result the errors from the last build/run are shown which is
exceptionally confusing.