### PR TITLE
Fix Not enough args for go#import#SwitchImport when using :GoDrop

### DIFF
--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -99,7 +99,7 @@ command! -nargs=0 GoFmt call go#fmt#Format(-1)
 command! -nargs=0 GoImports call go#fmt#Format(1)
 
 " -- import
-command! -nargs=? -complete=customlist,go#package#Complete GoDrop call go#import#SwitchImport(0, '', <f-args>)
+command! -nargs=? -complete=customlist,go#package#Complete GoDrop call go#import#SwitchImport(0, '', <f-args>, '')
 command! -nargs=1 -bang -complete=customlist,go#package#Complete GoImport call go#import#SwitchImport(1, '', <f-args>, '<bang>')
 command! -nargs=* -bang -complete=customlist,go#package#Complete GoImportAs call go#import#SwitchImport(1, <f-args>, '<bang>')
 


### PR DESCRIPTION
This fixes the `:GoDrop <pkg>` issue for me., looks like a missing arg in the call. #499 