### PR TITLE
GoErrCheck: Only append gopath to report files if necessary

### DIFF
--- a/autoload/go/errcheck.vim
+++ b/autoload/go/errcheck.vim
@@ -27,7 +27,12 @@ function! go#errcheck#Run(...) abort
             let tokens = matchlist(line, mx)
 
             if !empty(tokens)
-                call add(errors, {"filename": expand(go#path#Default() . "/src/" . tokens[1]),
+                if tokens[1][0] == "/"
+                    let filename = tokens[1]
+                else
+                    let filename = expand(go#path#Default() . "/src/" . tokens[1])
+                endif
+                call add(errors, {"filename": filename,
                             \"lnum": tokens[2],
                             \"col": tokens[3],
                             \"text": tokens[4]})


### PR DESCRIPTION
The paths in the `GoErrCheck` reports contain the `GOPATH` twice: instead of `/Users/whatever/gopath/src/github.com/whatever/projectname`, I get `/Users/whatever/gopath/src//Users/whatever/gopath/src/github.com/whatever/projectname`. Pressing `<cr>` on an error opens an empty buffer (with the wrong path).

I've fixed it by checking if the filename (`tokens[1]`) starts with `/`: in this case it's an absolute path, and `GOPATH` should not be appended.

I've tested this on OSX (I always get absolute paths), both with vim and MacVim (7.4).