### PR TITLE
errcheck: fix command for absolute paths

### DIFF
--- a/autoload/go/errcheck.vim
+++ b/autoload/go/errcheck.vim
@@ -21,7 +21,9 @@ function! go#errcheck#Run(...) abort
     echon "vim-go: " | echohl Identifier | echon "errcheck analysing ..." | echohl None
     redraw
 
-    let out = system(bin_path . ' ' . goargs)
+    let command = bin_path . ' ' . goargs
+    let out = go#tool#ExecuteInDir(command)
+
     if v:shell_error
         let errors = []
         let mx = '^\(.\{-}\):\(\d\+\):\(\d\+\)\s*\(.*\)'


### PR DESCRIPTION
Unify command executing just like we do for the other commands.