### PR TITLE
Avoid setting 'filetype' twice

### DIFF
--- a/ftdetect/gofiletype.vim
+++ b/ftdetect/gofiletype.vim
@@ -18,7 +18,7 @@ function! s:gofiletype_post()
     let &g:fileencodings = s:current_fileencodings
 endfunction
 
-au BufNewFile *.go setlocal filetype=go fileencoding=utf-8 fileformat=unix
+au BufNewFile *.go setfiletype go | setlocal fileencoding=utf-8 fileformat=unix
 au BufRead *.go call s:gofiletype_pre()
 au BufReadPost *.go call s:gofiletype_post()
 


### PR DESCRIPTION
Setting 'filetype' the second time is as expensive as the first time:

The previous filetype settings are undone using b:undo_ftplugin and
ftplugin, indent, etc. get fully re-sourced because variables like
b:did_ftplugin are removed then.

Thus use :setfiletype to set the 'filetype' only if not done yet.