### PR TITLE
fix bug of handling of trailing /

### DIFF
--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -66,7 +66,8 @@ function! go#package#ImportPath(arg)
         return -1
     endif
 
-    return substitute(path, workspace . '/src/', '', '')
+    let srcdir = substitute(workspace . '/src/', '//', '/', '')
+    return substitute(path, srcdir, '', '')
 endfunction
 
 function! go#package#FromPath(arg)


### PR DESCRIPTION
- the GOPATH may be in the form of /home/user/go/ or /home/user/go, the
  trailing / matters. the match pattern may fail if there is trailing /