### PR TITLE
Strip spaces from path in GoImport

### DIFF
--- a/autoload/go/import.vim
+++ b/autoload/go/import.vim
@@ -6,7 +6,7 @@
 "
 function! go#import#SwitchImport(enabled, localname, path, bang)
     let view = winsaveview()
-    let path = a:path
+    let path = substitute(a:path, '^\s*\(.\{-}\)\s*$', '\1', '')
 
     " Quotes are not necessary, so remove them if provided.
     if path[0] == '"'


### PR DESCRIPTION
Currently if I type `GoImport fmt <CR>`, the string `import "fmt "`
will be inserted in my file. This strips leading and trailing spaces
from the path argument to GoImport.