### PR TITLE
Discard quickfix errors when quickfix doesn't locate a file to jump to

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -83,12 +83,33 @@ function! go#cmd#Run(bang, ...)
         exe 'make!'
     endif
 
-    cwindow
-    let errors = getqflist()
+    " Remove any nonvalid filename from the qflist to avoid opening an empty
+    " buffer. See https://github.com/fatih/vim-go/issues/287 for details.
+    let qflist = getqflist()
+    let errors = []
+    let is_readable = {}
+
+    for item in qflist
+        let filename = bufname(item.bufnr)
+        if !has_key(is_readable, filename)
+            let is_readable[filename] = filereadable(filename)
+        endif
+        if is_readable[filename]
+            call add(errors, item)
+        endif
+    endfor
+
+    for k in keys(filter(is_readable, '!v:val'))
+        echo "vim-go: " | echohl Identifier | echon "[run] Dropped " | echohl Constant | echon  '"' . k . '"'
+        echohl Identifier | echon " from QuickFix list (nonvalid filename)" | echohl None
+    endfor
+
+    call setqflist(errors)
     if !empty(errors) && !a:bang
         cc 1 "jump to first error if there is any
     endif
-
+    cwindow
+    
     let $GOPATH = old_gopath
     let &makeprg = default_makeprg
 endfunction

--- a/compiler/go.vim
+++ b/compiler/go.vim
@@ -21,14 +21,15 @@ else
     CompilerSet makeprg=go\ build
 endif
 
-CompilerSet errorformat=
-      \%-G#\ %.%#,
-      \%-G%.%#panic:\ %m,
-      \%Ecan\'t\ load\ package:\ %m,
-      \%A%f:%l:%c:\ %m,
-      \%A%f:%l:\ %m,
-      \%C%*\\s%m,
-      \%-G%.%#
+" Define the patterns that will be recognized by QuickFix when parsing the output of GoRun.
+" More information at http://vimdoc.sourceforge.net/htmldoc/quickfix.html#errorformat
+CompilerSet errorformat =%-G#\ %.%#                   " Ignore lines beginning with '#' ('# command-line-arguments' line sometimes appears?)
+CompilerSet errorformat+=%-G%.%#panic:\ %m            " Ignore lines containing 'panic: message'
+CompilerSet errorformat+=%Ecan\'t\ load\ package:\ %m " Start of multiline error string is 'can\'t load package'
+CompilerSet errorformat+=%A%f:%l:%c:\ %m              " Start of multiline unspecified string is 'filename:linenumber:columnnumber:'
+CompilerSet errorformat+=%A%f:%l:\ %m                 " Start of multiline unspecified string is 'filename:linenumber:'
+CompilerSet errorformat+=%C%*\\s%m                    " Continuation of multiline error message is indented
+CompilerSet errorformat+=%-G%.%#                      " All lines not matching any of the above patterns are ignored
 
 let &cpo = s:save_cpo
 unlet s:save_cpo


### PR DESCRIPTION
Tries to fix #287 by dropping from the QuickFix list any items that don't locate existing files.

Known issue: If `cc 1` jumps to a new buffer immediately, the open-buffer message  `"{filename}" {linenumber}L, {colnumber}C` hides the messages that tell the user about the dropped errors. Haven't been able to figure out how to get around that. The messages are just a little "extra" anyway.

Please review when able and let me know if you find any other issues.