### PR TITLE
Do not add log output to quickfix list

### DIFF
--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -54,7 +54,7 @@ function! go#tool#ShowErrors(out)
 
     for line in split(a:out, '\n')
         let fatalerrors = matchlist(line, '^\(fatal error:.*\)$')
-        let tokens = matchlist(line, '^\s*\(.\{-}\):\(\d\+\):\s*\(.*\)')
+        let tokens = matchlist(line, '^\s\+\(.\{-}\):\(\d\+\):\s*\(.*\)')
 
         if !empty(fatalerrors)
             call add(errors, {"text": fatalerrors[1]})


### PR DESCRIPTION
I ran into a problem where the output of `log.Println` was added to the quickfix window when some tests failed. Here is some example code the reproduce the issue:

```go
// testing_example.go
package main

import (
	"fmt"
	"log"
)

func SayName() string {
	log.Println("log line")
	fmt.Println("fmt line!")
	return "wrong"
}

// testing_example_test.go
package main

import "testing"

func TestSayname(t *testing.T) {
	result := SayName()

	if result != "foobar" {
		t.Error("foobar")
	}
}
```

When the tests were run with `:GoTest` or `:GoTest!` the `log.Println` line was included in the quickfix list, which looked like this:

![image](https://cloud.githubusercontent.com/assets/1185253/10365550/911a474e-6dc4-11e5-9360-27559f61ecfe.png)

My guess was that the regex that's responsible for parsing the output was not meant to parse the log line, but only did so accidently.

So I changed the regex to only parse lines for filenames and linenumbers that begin with _at least_ one whitespace (which log lines do not).

(See the commit message for more details)

What do you think? :)