### PR TITLE
Fix path output for GoErrCheck

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -149,7 +149,7 @@ function! go#lint#Errcheck(...) abort
         for line in split(out, '\n')
             let tokens = matchlist(line, mx)
             if !empty(tokens)
-                call add(errors, {"filename": expand(go#path#Default() . "/src/" . tokens[1]),
+                call add(errors, {"filename": tokens[1],
                             \"lnum": tokens[2],
                             \"col": tokens[3],
                             \"text": tokens[4]})


### PR DESCRIPTION
With recent changes to the way errcheck is called (using ExecuteInDir),
prepending the GOPATH results in invalid expansion.