### PR TITLE
Use absolute paths for gometalinter, so that filenames resolve correctly

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -6,10 +6,6 @@ if !exists("g:go_metalinter_enabled")
     let g:go_metalinter_enabled = ['vet', 'golint', 'errcheck']
 endif
 
-if !exists("g:go_metalinter_path")
-    let g:go_metalinter_path = "./..."
-endif
-
 if !exists("g:go_golint_bin")
     let g:go_golint_bin = "golint"
 endif
@@ -18,17 +14,23 @@ if !exists("g:go_errcheck_bin")
     let g:go_errcheck_bin = "errcheck"
 endif
 
-function! go#lint#Gometa(path_to_lint) abort
+function! go#lint#Gometa(...) abort
+    if a:0 == 0
+        let goargs = expand('%:p:h')
+    else
+        let goargs = go#util#Shelljoin(a:000)
+    endif
+
     let meta_command = "gometalinter --disable-all"
     if empty(g:go_metalinter_command)
-        let bin_path = go#path#CheckBinPath("gometalinter") 
-        if empty(bin_path) 
-            return 
+        let bin_path = go#path#CheckBinPath("gometalinter")
+        if empty(bin_path)
+            return
         endif
 
         if empty(g:go_metalinter_enabled)
             echohl Error | echomsg "vim-go: please enable linters with the setting g:go_metalinter_enabled" | echohl None
-            return 
+            return
         endif
 
         for linter in g:go_metalinter_enabled
@@ -36,13 +38,7 @@ function! go#lint#Gometa(path_to_lint) abort
         endfor
 
 
-        " by default we search for all underlying files
-        let path = g:go_metalinter_path
-        if !empty(a:path_to_lint)
-            let path = a:path_to_lint
-        endif
-
-        let meta_command .=  " " . path
+        let meta_command .=  " " . goargs
     else
         " the user wants something else, let us use it.
         let meta_command = g:go_metalinter_command

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -420,12 +420,10 @@ COMMANDS                                                          *go-commands*
 :GoMetaLinter [path]
 
     Calls the underlying `gometalinter` tool and displays all warnings and
-    errors in a quickfix window. By default it lints the files for the path
-    `./...` . This can be changed with the 'path' argument temoporary or with the
-    |g:go_metalinter_path| variable permanently. By default the following
-    linters are enabled: "'vet', 'golint', 'errcheck'". This can be changed
-    with the |g:go_metalinter_enabled| variable. To override the command
-    completely use the variable |g:go_metalinter_command|
+    errors in a quickfix window. By default the following linters are enabled:
+    "'vet', 'golint', 'errcheck'". This can be changed with the
+    |g:go_metalinter_enabled| variable. To override the command completely use
+    the variable |g:go_metalinter_command|
 
 
 ===============================================================================
@@ -847,15 +845,7 @@ an advanced settings and is for users who want to have a complete control
 over of how `gometalinter` should be executed. By default it's empty.
 >
   let g:go_metalinter_command = ""
-<
-                                                     *'g:go_metalinter_path'*
 
-Defines the default path to be linted for the |GoMetaLinter| command. By
-default it's set to `./...`, which recursively lints all files underd the
-current directory.
->
-  let g:go_metalinter_path = "./..."
-<
 
 ===============================================================================
 TROUBLESHOOTING                                         *go-troubleshooting*

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -47,7 +47,7 @@ command! -nargs=1 -bang -complete=customlist,go#package#Complete GoImport call g
 command! -nargs=* -bang -complete=customlist,go#package#Complete GoImportAs call go#import#SwitchImport(1, <f-args>, '<bang>')
 
 " -- linters
-command! -nargs=* GoMetaLinter call go#lint#Gometa('')
+command! -nargs=* GoMetaLinter call go#lint#Gometa(<f-args>)
 command! -nargs=* GoLint call go#lint#Golint(<f-args>)
 command! -nargs=* -bang GoVet call go#lint#Vet(<bang>0, <f-args>)
 command! -nargs=* -complete=customlist,go#package#Complete GoErrCheck call go#lint#Errcheck(<f-args>)


### PR DESCRIPTION
Because gometalinter is run using ExecuteInDir, it outputs filenames
relative to the source file being edited, which means that you cannot
open them from quickfix.  By using absolute paths, quickfix output is
usable for jumps.

This change also drops the superfluous go_metalinter_path.