### PR TITLE
Fixed a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ disabled/enabled easily.
 * Change or display `GOPATH` with `:GoPath`
 * Create a coverage profile and display annotated source code in browser to see
   which functions are covered with `:GoCoverage`
-* Call `gometalinter`, which is a tool that invokes all possible linters
+* Call `GoMetaLinter`, which is a tool that invokes all possible linters
   (golint, vet, errcheck, deadcode, etc..) and shows the warnings/errors
 * Lint your code with `:GoLint`
 * Run your code through `:GoVet` to catch static errors

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ disabled/enabled easily.
 * Change or display `GOPATH` with `:GoPath`
 * Create a coverage profile and display annotated source code in browser to see
   which functions are covered with `:GoCoverage`
-* Call `GoMetaLinter`, which is a tool that invokes all possible linters
+* Call `gometalinter` with `:GoMetaLinter`, which invokes all possible linters
   (golint, vet, errcheck, deadcode, etc..) and shows the warnings/errors
 * Lint your code with `:GoLint`
 * Run your code through `:GoVet` to catch static errors


### PR DESCRIPTION
The readme referenced 'gometalinter' but the correct command is
'GoMetaLinter'.