### PR TITLE
Add GoOracleTags command to set build tags for oracle

### DIFF
--- a/autoload/go/oracle.vim
+++ b/autoload/go/oracle.vim
@@ -121,7 +121,6 @@ func! s:RunOracle(mode, selected, needs_package) range abort
     " info check Oracle's User Manual section about scopes:
     " https://docs.google.com/document/d/1SLk36YRjjMgKqe490mSRzOPYEDe0Y_WQNRv-EiFYUyw/view#heading=h.nwso96pj07q8
     let cmd .= ' ' . go#util#Shelljoin(scopes)
-    " echon "vim-go: " | echohl Function | echon "current cmd is: '". cmd ."'" | echohl None
 
     echon "vim-go: " | echohl Identifier | echon "analysing ..." | echohl None
 

--- a/autoload/go/oracle.vim
+++ b/autoload/go/oracle.vim
@@ -96,18 +96,24 @@ func! s:RunOracle(mode, selected, needs_package) range abort
     if empty(bin_path) 
         return 
     endif
+    
+    if exists('g:go_oracle_tags')
+        let tags = get(g:, 'go_oracle_tags')
+    else
+        let tags = ""
+    endif
 
     if a:selected != -1
         let pos1 = s:getpos(line("'<"), col("'<"))
         let pos2 = s:getpos(line("'>"), col("'>"))
-        let cmd = printf('%s -format plain -pos=%s:#%d,#%d %s',
+        let cmd = printf('%s -format plain -pos=%s:#%d,#%d -tags=%s %s',
                     \  bin_path,
-                    \  shellescape(fname), pos1, pos2, a:mode)
+                    \  shellescape(fname), pos1, pos2, tags, a:mode)
     else
         let pos = s:getpos(line('.'), col('.'))
-        let cmd = printf('%s -format plain -pos=%s:#%d %s',
+        let cmd = printf('%s -format plain -pos=%s:#%d -tags=%s %s',
                     \  bin_path,
-                    \  shellescape(fname), pos, a:mode)
+                    \  shellescape(fname), pos, tags, a:mode)
     endif
 
     " now append each scope to the end as Oracle's scope parameter. It can be
@@ -115,6 +121,7 @@ func! s:RunOracle(mode, selected, needs_package) range abort
     " info check Oracle's User Manual section about scopes:
     " https://docs.google.com/document/d/1SLk36YRjjMgKqe490mSRzOPYEDe0Y_WQNRv-EiFYUyw/view#heading=h.nwso96pj07q8
     let cmd .= ' ' . go#util#Shelljoin(scopes)
+    " echon "vim-go: " | echohl Function | echon "current cmd is: '". cmd ."'" | echohl None
 
     echon "vim-go: " | echohl Identifier | echon "analysing ..." | echohl None
 
@@ -153,6 +160,26 @@ function! go#oracle#Scope(...)
         echon "vim-go: " | echohl Function | echon "oracle scope is not set"| echohl None
     else
         echon "vim-go: " | echohl Function | echon "current oracle scope: '". g:go_oracle_scope ."'" | echohl None
+    endif
+endfunction
+
+function! go#oracle#Tags(...)
+    if a:0
+        if a:0 == 1 && a:1 == '""'
+            unlet g:go_oracle_tags
+            echon "vim-go: " | echohl Function | echon "oracle tags is cleared"| echohl None
+        else
+            let g:go_oracle_tags = a:1
+            echon "vim-go: " | echohl Function | echon "oracle tags changed to: '". g:go_oracle_tags ."'" | echohl None
+        endif
+
+        return
+    endif
+
+    if !exists('g:go_oracle_tags')
+        echon "vim-go: " | echohl Function | echon "oracle tags is not set"| echohl None
+    else
+        echon "vim-go: " | echohl Function | echon "current oracle tags: '". g:go_oracle_tags ."'" | echohl None
     endif
 endfunction
 

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -4,6 +4,11 @@ function! go#tool#Files()
     else
         let command = "go list -f '{{range $f := .GoFiles}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}{{range $f := .CgoFiles}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}'"
     endif
+
+    if exists('g:go_oracle_tags')
+        let command .= ' ' .command 
+    endif
+
     let out = go#tool#ExecuteInDir(command)
     return split(out, '\n')
 endfunction

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -4,11 +4,6 @@ function! go#tool#Files()
     else
         let command = "go list -f '{{range $f := .GoFiles}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}{{range $f := .CgoFiles}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}'"
     endif
-
-    if exists('g:go_oracle_tags')
-        let command .= ' ' .command 
-    endif
-
     let out = go#tool#ExecuteInDir(command)
     return split(out, '\n')
 endfunction

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -424,7 +424,15 @@ COMMANDS                                                          *go-commands*
     "'vet', 'golint', 'errcheck'". This can be changed with the
     |g:go_metalinter_enabled| variable. To override the command completely use
     the variable |g:go_metalinter_command|
+                                                             *:GoOracleTags*
+:GoOracleTags [tags]
 
+    Changes the custom |g:go_oracle_tags| setting and overrides it with the
+    given build tags. This command cooperate with GoReferrers command when 
+    there exist mulitiple build tags in your project,then you can set one 
+    of the build tags for GoReferrers to find more accurate.
+    The custom build tags is cleared (unset) if `""` is given. If no arguments
+    is given it prints the current custom build tags.
 
 ===============================================================================
 MAPPINGS                                                        *go-mappings*

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -11,6 +11,7 @@ command! -range=% GoCallstack call go#oracle#Callstack(<count>)
 command! -range=% GoFreevars call go#oracle#Freevars(<count>)
 command! -range=% GoChannelPeers call go#oracle#ChannelPeers(<count>)
 command! -range=% GoReferrers call go#oracle#Referrers(<count>)
+command! -nargs=? GoTags call go#oracle#Tags(<f-args>)
 
 " tool
 command! -nargs=0 GoFiles echo go#tool#Files()

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -11,7 +11,7 @@ command! -range=% GoCallstack call go#oracle#Callstack(<count>)
 command! -range=% GoFreevars call go#oracle#Freevars(<count>)
 command! -range=% GoChannelPeers call go#oracle#ChannelPeers(<count>)
 command! -range=% GoReferrers call go#oracle#Referrers(<count>)
-command! -nargs=? GoTags call go#oracle#Tags(<f-args>)
+command! -nargs=? GoOracleTags call go#oracle#Tags(<f-args>)
 
 " tool
 command! -nargs=0 GoFiles echo go#tool#Files()


### PR DESCRIPTION
When I reading docker source code, which locate in github.com/docker/docker/docker directory, I could not use GoReferrer to find "mainDaemon" when docker as daemon.What I found is client code when docker as client and without golang build tags "daemon".
So I try to add GoTags command,which can set oracle command param "-tags",then thing goes well!