### PR TITLE
Add deadline flag support in gometalinter

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -6,6 +6,10 @@ if !exists("g:go_metalinter_enabled")
     let g:go_metalinter_enabled = ['vet', 'golint', 'errcheck']
 endif
 
+if !exists("g:go_metalinter_deadline")
+    let g:go_metalinter_deadline = "5s"
+endif
+
 if !exists("g:go_golint_bin")
     let g:go_golint_bin = "golint"
 endif
@@ -37,6 +41,8 @@ function! go#lint#Gometa(...) abort
             let meta_command .= " --enable=".linter
         endfor
 
+        " deadline
+        let meta_command .= " --deadline=" . g:go_metalinter_deadline
 
         let meta_command .=  " " . goargs
     else

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -423,7 +423,8 @@ COMMANDS                                                          *go-commands*
     errors in a quickfix window. By default the following linters are enabled:
     "'vet', 'golint', 'errcheck'". This can be changed with the
     |g:go_metalinter_enabled| variable. To override the command completely use
-    the variable |g:go_metalinter_command|
+    the variable |g:go_metalinter_command|. To override the maximum linters
+    execution time use |g:go_metalinter_deadline| variable.
 
 
 ===============================================================================
@@ -845,7 +846,14 @@ an advanced settings and is for users who want to have a complete control
 over of how `gometalinter` should be executed. By default it's empty.
 >
   let g:go_metalinter_command = ""
+<
+                                                  *'g:go_metalinter_deadline'*
 
+Overrides the maximum time the linters have to complete. By default it's 5
+seconds.
+>
+  let g:go_metalinter_deadline = "5s"
+<
 
 ===============================================================================
 TROUBLESHOOTING                                         *go-troubleshooting*


### PR DESCRIPTION
Gometalinter has a deadline flag which defaults to 5s.
```
      --deadline=5s         Cancel linters if they have not completed within
                            this duration.
```
This PR adds a `g:go_metalinter_deadline` parameter to customize this time.