### PR TITLE
gorename: create and populate errors in quickfix window

### DIFF
--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -2,7 +2,7 @@ if !exists("g:go_gorename_bin")
     let g:go_gorename_bin = "gorename"
 endif
 
-function! go#rename#Rename(...)
+function! go#rename#Rename(bang, ...)
     let to = ""
     if a:0 == 0
         let from = expand("<cword>")
@@ -31,8 +31,16 @@ function! go#rename#Rename(...)
     let clean = split(out, '\n')
 
     if v:shell_error
-        redraw | echon "vim-go: " | echohl Statement | echon clean[0] | echohl None
+        call go#tool#ShowErrors(out)
+        cwindow
+        let errors = getqflist()
+        if !empty(errors) && !a:bang
+            cc 1 "jump to first error if there is any
+        endif
+        return
     else
+        call setqflist([])
+        cwindow
         redraw | echon "vim-go: " | echohl Function | echon clean[0] | echohl None
     endif
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -338,10 +338,12 @@ COMMANDS                                                          *go-commands*
     for the type that implements an interface under the cursor (or selected
     package) is shown quickfix list.
                                                                 *:GoRename*
-:GoRename [to]
+:GoRename[!] [to]
 
     Rename the identifier under the cursor to the desired new name. If no
     argument is given a prompt will ask for the desired identifier.
+
+    If [!] is not given the first error is jumped to.
 
 
                                                             *:GoOracleScope*

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -1,5 +1,5 @@
 " gorename
-command! -nargs=? GoRename call go#rename#Rename(<f-args>)
+command! -nargs=? GoRename call go#rename#Rename(<bang>0,<f-args>)
 
 " oracle
 command! -nargs=* -complete=customlist,go#package#Complete GoOracleScope call go#oracle#Scope(<f-args>)

--- a/ftplugin/go/mappings.vim
+++ b/ftplugin/go/mappings.vim
@@ -33,7 +33,7 @@ nnoremap <silent> <Plug>(go-freevars) :<C-u>call go#oracle#Freevars(-1)<CR>
 nnoremap <silent> <Plug>(go-channelpeers) :<C-u>call go#oracle#ChannelPeers(-1)<CR>
 nnoremap <silent> <Plug>(go-referrers) :<C-u>call go#oracle#Referrers(-1)<CR>
 
-nnoremap <silent> <Plug>(go-rename) :<C-u>call go#rename#Rename()<CR>
+nnoremap <silent> <Plug>(go-rename) :<C-u>call go#rename#Rename(!g:go_jump_to_error)<CR>
 
 nnoremap <silent> <Plug>(go-def) :<C-u>call go#def#Jump()<CR>
 nnoremap <silent> <Plug>(go-def-vertical) :<C-u>call go#def#JumpMode("vsplit")<CR>


### PR DESCRIPTION
This fixes #566 and also introduces parsing errors for `:GoRename`
command. Now it's acting like our other commands such as `:GoTest`,
`:GoBuild`, etc.. It fully parses the errors and jumps to the first
error it founds.