### PR TITLE
Add note on Syntastic lag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,14 @@ let g:go_bin_path = expand("~/.gotools")
 let g:go_bin_path = "/home/fatih/.mypath"      "or give absolute path
 ```
 
+## Using with Syntastic
+Sometimes when using both `vim-go` and `syntastic` Vim will start lagging while saving and opening
+files. The following fixes this:
+
+```vim
+let g:syntastic_go_checkers = ['golint', 'govet', 'errcheck']
+let g:syntastic_mode_map = { 'mode': 'active', 'passive_filetypes': ['go'] }
+```
 
 ## More info
 


### PR DESCRIPTION
There have been a few different issues regarding making `vim-go` and `Syntastic` play well together. The fix I have added to the README in this PR seems to work the best out of all I have seen.

If there is another (better) fix, of course this should be replaced with that... But I believe it is important to have this kind of thing in the README.