### PR TITLE
Disuse go_fmt_options with GoImports

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -94,7 +94,10 @@ function! go#fmt#Format(withGoimport)
     endif
 
     " populate the final command with user based fmt options
-    let command = fmt_command . ' -w ' . g:go_fmt_options
+    let command = fmt_command . ' -w '
+    if a:withGoimport  != 1 
+        let command  = command . g:go_fmt_options
+    endif
 
     " execute our command...
     let out = system(command . " " . l:tmpname)


### PR DESCRIPTION
When using `go_fmt_options` for `GoFmt`, `GoImports` also use it.

I want to use `-s` option with `GoFmt`, but `GoImports` will not work.