### PR TITLE
Update def.vim to enable split mode option

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -26,8 +26,14 @@ function! go#def#Jump(...)
 	" get output of godef
 	let out=system(command, join(getbufline(bufnr('%'), 1, '$'), go#util#LineEnding()))
 
+	" get jump mode
+	let split_mode = ""
+	if exists("g:godef_split")
+		let split_mode = g:godef_split
+	endif
+	
 	" jump to it
-	call s:godefJump(out, "")
+	call s:godefJump(out, split_mode)
 	let $GOPATH = old_gopath
 endfunction
 


### PR DESCRIPTION
Updated def.vim to allow user to set `g:godef_split` to take advantage of split mode options. Plagiarized from [vim-godef](https://github.com/dgryski/vim-godef/blob/master/plugin/godef.vim#L46-L52). Will default to normal behavior if not set.