### PR TITLE
Adding Deoplete to Autocomplete List

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ packages.
 * Autocompletion is enabled by default via `<C-x><C-o>`. To get real-time
 completion (completion by type) install:
 [YCM](https://github.com/Valloric/YouCompleteMe) or
-[neocomplete](https://github.com/Shougo/neocomplete.vim).
+[neocomplete](https://github.com/Shougo/neocomplete.vim) or 
+[deoplete](https://github.com/Shougo/deoplete.nvim).
 * To display source code tag information on a sidebar install
 [tagbar](https://github.com/majutsushi/tagbar).
 * For snippet features install:


### PR DESCRIPTION
Fast, asynchronous completions for neovim. Confirmed to be working this morning: 
![screen shot 2015-11-13 at 9 32 42 am](https://cloud.githubusercontent.com/assets/613964/11152805/8b85f09e-89e9-11e5-8287-cfbef8666596.png)
