### PR TITLE
util: add auto quickfix window height for errors [GH-592]

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -38,8 +38,10 @@ function! go#cmd#Build(bang, ...)
     endif
     redraw!
 
-    cwindow
+
     let errors = getqflist()
+    call go#util#Cwindow(len(errors))
+
     if !empty(errors) 
         if !a:bang
             cc 1 "jump to first error if there is any
@@ -47,6 +49,7 @@ function! go#cmd#Build(bang, ...)
     else
         redraws! | echon "vim-go: " | echohl Function | echon "[build] SUCCESS"| echohl None
     endif
+
 
     call delete(l:tmpname)
     let &makeprg = default_makeprg
@@ -108,11 +111,12 @@ function! go#cmd#Run(bang, ...)
         echohl Identifier | echon " from QuickFix list (nonvalid filename)" | echohl None
     endfor
 
+    call go#util#Cwindow(len(errors))
+
     call setqflist(errors)
     if !empty(errors) && !a:bang
         cc 1 "jump to first error if there is any
     endif
-    cwindow
     
     let $GOPATH = old_gopath
     let &makeprg = default_makeprg
@@ -127,15 +131,15 @@ function! go#cmd#Install(bang, ...)
     let out = go#tool#ExecuteInDir(command)
     if v:shell_error
         call go#tool#ShowErrors(out)
-        cwindow
         let errors = getqflist()
+        call go#util#Cwindow(len(errors))
         if !empty(errors) && !a:bang
             cc 1 "jump to first error if there is any
         endif
         return
     else
         call setqflist([])
-        cwindow
+        call go#util#Cwindow()
     endif
 
     echon "vim-go: " | echohl Function | echon "installed to ". $GOPATH | echohl None
@@ -172,15 +176,15 @@ function! go#cmd#Test(bang, compile, ...)
     let out = go#tool#ExecuteInDir(command)
     if v:shell_error
         call go#tool#ShowErrors(out)
-        cwindow
         let errors = getqflist()
+        call go#util#Cwindow(len(errors))
         if !empty(errors) && !a:bang
             cc 1 "jump to first error if there is any
         endif
         echon "vim-go: " | echohl ErrorMsg | echon "[test] FAIL" | echohl None
     else
         call setqflist([])
-        cwindow
+        call go#util#Cwindow()
 
         if a:compile
             echon "vim-go: " | echohl Function | echon "[test] SUCCESS" | echohl None
@@ -237,8 +241,8 @@ function! go#cmd#Coverage(bang, ...)
         let openHTML = 'go tool cover -html='.l:tmpname
         call go#tool#ExecuteInDir(openHTML)
     endif
-    cwindow
     let errors = getqflist()
+    call go#util#Cwindow(len(errors))
     if !empty(errors) && !a:bang
         cc 1 "jump to first error if there is any
     endif
@@ -269,8 +273,8 @@ function! go#cmd#Generate(bang, ...)
     endif
     redraw!
 
-    cwindow
     let errors = getqflist()
+    call go#util#Cwindow(len(errors))
     if !empty(errors) 
         if !a:bang
             cc 1 "jump to first error if there is any

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -124,7 +124,7 @@ function! go#fmt#Format(withGoimport)
         if s:got_fmt_error 
             let s:got_fmt_error = 0
             call setqflist([])
-            cwindow
+            call go#util#Cwindow()
         endif
     elseif g:go_fmt_fail_silently == 0 
         let splitted = split(out, '\n')
@@ -147,7 +147,7 @@ function! go#fmt#Format(withGoimport)
             echohl Error | echomsg "Gofmt returned error" | echohl None
         endif
         let s:got_fmt_error = 1
-        cwindow
+        call go#util#Cwindow(len(errors))
         " We didn't use the temp file, so clean up
         call delete(l:tmpname)
     endif

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -60,6 +60,7 @@ function! go#lint#Gometa(...) abort
         redraw | echo
         call setqflist([])
         echon "vim-go: " | echohl Function | echon "[metalinter] PASS" | echohl None
+        call go#util#Cwindow()
     else
         " backup users errorformat, will be restored once we are finished
         let old_errorformat = &errorformat
@@ -71,7 +72,8 @@ function! go#lint#Gometa(...) abort
 
         " create the quickfix list and open it
         cgetexpr split(out, "\n")
-        cwindow
+        let errors = getqflist()
+        call go#util#Cwindow(len(errors))
         cc 1
 
         let &errorformat = old_errorformat
@@ -91,8 +93,16 @@ function! go#lint#Golint(...) abort
     else
         let goargs = go#util#Shelljoin(a:000)
     endif
-    silent cexpr system(bin_path . " " . goargs)
-    cwindow
+
+    let out = system(bin_path . " " . goargs)
+    if empty(out)
+        echon "vim-go: " | echohl Function | echon "[lint] PASS" | echohl None
+        return
+    endif
+
+    cgetexpr out
+    let errors = getqflist()
+    call go#util#Cwindow(len(errors))
     cc 1
 endfunction
 
@@ -112,13 +122,14 @@ function! go#lint#Vet(bang, ...)
         call setqflist([])
     endif
 
-    cwindow
     let errors = getqflist()
+    call go#util#Cwindow(len(errors))
     if !empty(errors) 
         if !a:bang
             cc 1 "jump to first error if there is any
         endif
     else
+        call go#util#Cwindow()
         redraw | echon "vim-go: " | echohl Function | echon "[vet] PASS" | echohl None
     endif
 endfunction
@@ -168,16 +179,16 @@ function! go#lint#Errcheck(...) abort
         if !empty(errors)
             redraw | echo
             call setqflist(errors, 'r')
-            cwindow
+            call go#util#Cwindow(len(errors))
             cc 1 "jump to first error if there is any
         endif
     else
         redraw | echo
         call setqflist([])
+        call go#util#Cwindow()
         echon "vim-go: " | echohl Function | echon "[errcheck] PASS" | echohl None
     endif
 
-    cwindow
 endfunction
 
 " vim:ts=4:sw=4:et

--- a/autoload/go/oracle.vim
+++ b/autoload/go/oracle.vim
@@ -36,7 +36,7 @@ func! s:qflist(output)
         call add(qflist, item)
     endfor
     call setqflist(qflist)
-    cwindow
+    call go#util#Cwindow(len(qflist))
 endfun
 
 " This uses Vim's errorformat to parse the output from Oracle's 'plain output
@@ -59,7 +59,8 @@ func! s:qflistSecond(output)
 
     " create the quickfix list and open it
     cgetexpr split(a:output, "\n")
-    cwindow
+    let errors = getqflist()
+    call go#util#Cwindow(len(errors))
 
     let &errorformat = old_errorformat
 endfun

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -32,15 +32,15 @@ function! go#rename#Rename(bang, ...)
 
     if v:shell_error
         call go#tool#ShowErrors(out)
-        cwindow
         let errors = getqflist()
+        call go#util#Cwindow(len(errors))
         if !empty(errors) && !a:bang
             cc 1 "jump to first error if there is any
         endif
         return
     else
         call setqflist([])
-        cwindow
+        call go#util#Cwindow()
         redraw | echon "vim-go: " | echohl Function | echon clean[0] | echohl None
     endif
 

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -58,4 +58,32 @@ function! go#util#Shelljoin(arglist, ...)
 	endif
 endfunction
 
+
+" Cwindow opens the quickfix window with the given height up to 10 lines
+" maximum. Otherwise g:go_quickfix_height is used. If no or zero height is
+" given it closes the window
+function! go#util#Cwindow(...)
+    " we don't use cwindow to close the quickfix window as we need also the
+    " ability to resize the window. So, we are going to use copen and cclose
+    " for a better user experience. If the number of errors in a current
+    " quickfix list increases/decreases, cwindow will not resize when a new
+    " updated height is passed. copen in the other hand resizes the screen.
+    if !a:0 || a:1 == 0
+        cclose
+        return
+    endif
+
+    let height = get(g:, "go_quickfix_height", 0)
+    if height == 0
+        " prevent creating a large quickfix height for a large set of numbers
+        if a:1 > 10
+            let height = 10
+        else
+            let height = a:1
+        endif
+    endif
+
+    exe 'copen '. height
+endfunction
+
 " vim:ts=4:sw=4:et

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -878,6 +878,14 @@ seconds.
 >
   let g:go_metalinter_deadline = "5s"
 <
+                                                  *'g:go_quickfix_height'*
+
+Specifies the current quickfix height for all quickfix windows. The default
+value (empty) sets automatically the height to the number of errors (maximum
+up to 10 errors to prevent large heights). Setting the value explicitly
+overrides this behavior. To get default Vim behavior set it to 10.
+>
+  let g:go_quickfix_height = 0
 
 ===============================================================================
 TROUBLESHOOTING                                         *go-troubleshooting*


### PR DESCRIPTION
Right now we are just calling `cwindow` without any arguments. By
default Vim opens a view with an height of 10. But this doesn't look
good if you have only on single error. It also takes display estate for 
small screens.

This PR introduces a new feature, which automatically resizes the
quickfix error for the number of errors. However to prevent consuming
all the view, it's capped at 10 lines (the default Vim value).

We also have a new setting, `g:go_quickfix_height` which let us to give
an explicit window height. If set, automatic resize is enabled and the
height will be always the value of `g:go_quickfix_height`.

Previous case:

![screen shot 2015-11-16 at 1 38 36 am](https://cloud.githubusercontent.com/assets/438920/11171843/24be865c-8c03-11e5-8dce-af94fe5e3a88.png)

Improved case (auto height feature):

![screen shot 2015-11-16 at 1 39 07 am](https://cloud.githubusercontent.com/assets/438920/11171845/2dd2af48-8c03-11e5-9fde-5c5f410fa2a0.png)


Closes #592