### PR TITLE
Fix goCharacter syntax region to be contained

### DIFF
--- a/syntax/gotexttmpl.vim
+++ b/syntax/gotexttmpl.vim
@@ -37,7 +37,7 @@ hi def link     goRawString         String
 
 " Characters; their contents
 syn cluster     goCharacterGroup    contains=goEscapeOctal,goEscapeC,goEscapeX,goEscapeU,goEscapeBigU
-syn region      goCharacter         start=+'+ skip=+\\\\\|\\'+ end=+'+ contains=@goCharacterGroup
+syn region      goCharacter         contained start=+'+ skip=+\\\\\|\\'+ end=+'+ contains=@goCharacterGroup
 
 hi def link     goCharacter         Character
 


### PR DESCRIPTION
This commit sets the goCharacter syntax region to be contained; otherwise,
single-quotes are highlighted as strings outside of the gotplAction regions.

Fixes #603