### PR TITLE
syntax/go: do not treat builtins as keywords

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -117,8 +117,8 @@ syn match       goDeclaration       /\<func\>/
 
 
 " Predefined functions and values
-syn keyword     goBuiltins          append cap close complex copy delete imag len
-syn keyword     goBuiltins          make new panic print println real recover
+syn match       goBuiltins          /\v(append|cap|close|complex|copy|delete|imag|len)\ze\(/
+syn match       goBuiltins          /\v(make|new|panic|print|println|real|recover)\ze\(/
 syn keyword     goBoolean           iota true false nil
 
 hi def link     goBuiltins          Keyword


### PR DESCRIPTION
builtins have a very different property from keywords, the identifiers are
settable. It is perfectly valid to override the builtins, though hopefully used
sparingly.

Instead of using `syn keyword`, we now use `syn match` and detect a function
call by searching for an open parentheses.