### PR TITLE
Neovim integration

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -60,24 +60,12 @@ function! go#cmd#Build(bang, ...)
     let $GOPATH = old_gopath
 endfunction
 
+
 " Run runs the current file (and their dependencies if any) in a new terminal.
 function! go#cmd#RunTerm(mode)
-    " guard for other callers
-    if !has('nvim')
-        return
-    endif
-
     let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
-
-    " if empty call the default term
-    if empty(a:mode)
-        call go#term#new(cmd)
-        return
-    endif
-
     call go#term#newmode(cmd, a:mode)
 endfunction
-
 
 " Run runs the current file (and their dependencies if any) and outputs it.
 " This is intented to test small programs and play with them. It's not
@@ -103,7 +91,6 @@ function! go#cmd#Run(bang, ...)
         let $GOPATH = old_gopath
         return
     endif
-
 
     " :make expands '%' and '#' wildcards, so they must also be escaped
     let default_makeprg = &makeprg
@@ -199,6 +186,11 @@ function! go#cmd#Test(bang, compile, ...)
         echon "vim-go: " | echohl Identifier | echon "compiling tests ..." | echohl None
     else
         echon "vim-go: " | echohl Identifier | echon "testing ..." | echohl None
+    endif
+
+    if has('nvim')
+        call go#term#new(command)
+        return
     endif
 
     redraw

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -66,9 +66,8 @@ endfunction
 " calling long running apps will block the whole UI.
 function! go#cmd#Run(bang, ...)
     if has('nvim')
-        call go#term#vsplit()
         let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
-        call go#term#new(cmd)
+        call go#term#new(cmd, "vsplit")
         return
     endif
 

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -67,7 +67,7 @@ endfunction
 function! go#cmd#Run(bang, ...)
     if has('nvim')
         let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
-        call go#term#new(cmd, "vsplit")
+        call go#term#new(cmd)
         return
     endif
 

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -34,8 +34,11 @@ function! go#cmd#Build(bang, ...)
     if g:go_dispatch_enabled && exists(':Make') == 2
         silent! exe 'Make'
     elseif has('nvim')
+        " autowrite is not enabled for jobs
+        call go#cmd#autowrite()
         let job1 = go#jobcontrol#Run(['build', '.', 'errors'])
-        " rest is handled by go#jobcontrol#run :)
+
+        " rest is handled by go#jobcontrol#Run :)
         return
     else
         silent! exe 'make!'

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -33,11 +33,14 @@ function! go#cmd#Build(bang, ...)
     echon "vim-go: " | echohl Identifier | echon "building ..."| echohl None
     if g:go_dispatch_enabled && exists(':Make') == 2
         silent! exe 'Make'
+    elseif has('nvim')
+        let job1 = go#jobcontrol#Run(['build', '.', 'errors'])
+        " rest is handled by go#jobcontrol#run :)
+        return
     else
         silent! exe 'make!'
     endif
     redraw!
-
 
     let errors = getqflist()
     call go#util#Cwindow(len(errors))

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -27,7 +27,7 @@ function! go#cmd#Build(bang, ...)
 
     " if we have nvim, call it asynchronously and return early ;)
     if has('nvim')
-        call go#jobcontrol#Spawn("building ...", args)
+        call go#jobcontrol#Spawn("build", args)
         return
     endif
 
@@ -189,7 +189,7 @@ function! go#cmd#Test(bang, compile, ...)
         if get(g:, 'go_term_enabled', 0)
             call go#term#new(["go"] + args)
         else
-            call go#jobcontrol#Spawn("testing ...", args)
+            call go#jobcontrol#Spawn("test", args)
         endif
         return
     endif

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -30,17 +30,16 @@ function! go#cmd#Build(bang, ...)
         let &makeprg = "go build -o " . l:tmpname . ' ' . goargs . ' ' . gofiles
     endif
 
-    echon "vim-go: " | echohl Identifier | echon "building ..."| echohl None
     if g:go_dispatch_enabled && exists(':Make') == 2
+        call go#util#EchoProgress("building dispatched ...")
         silent! exe 'Make'
     elseif has('nvim')
-        " autowrite is not enabled for jobs
-        call go#cmd#autowrite()
-        let job = go#jobcontrol#Spawn(['build', '.', 'errors'])
-
+        let job_id = go#jobcontrol#Spawn(['build', '.', 'errors'])
+        call go#util#EchoProgress(printf("building with id [%d] ...", job_id))
         " rest is handled by go#jobcontrol#Run :)
         return
     else
+        call go#util#EchoProgress("building ...")
         silent! exe 'make!'
     endif
     redraw!

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -65,6 +65,11 @@ endfunction
 " suitable for long running apps, because vim is blocking by default and
 " calling long running apps will block the whole UI.
 function! go#cmd#Run(bang, ...)
+    if has('nvim')
+        call go#term#new("go run ". go#util#Shelljoin(go#tool#Files()))
+        return
+    endif
+
     let old_gopath = $GOPATH
     let $GOPATH = go#path#Detect()
 
@@ -79,6 +84,7 @@ function! go#cmd#Run(bang, ...)
         let $GOPATH = old_gopath
         return
     endif
+
 
     " :make expands '%' and '#' wildcards, so they must also be escaped
     let default_makeprg = &makeprg

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -66,7 +66,9 @@ endfunction
 " calling long running apps will block the whole UI.
 function! go#cmd#Run(bang, ...)
     if has('nvim')
-        call go#term#new("go run ". go#util#Shelljoin(go#tool#Files()))
+        call go#term#vsplit()
+        let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
+        call go#term#new(cmd)
         return
     endif
 

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -36,7 +36,7 @@ function! go#cmd#Build(bang, ...)
     elseif has('nvim')
         " autowrite is not enabled for jobs
         call go#cmd#autowrite()
-        let job1 = go#jobcontrol#Run(['build', '.', 'errors'])
+        let job = go#jobcontrol#Spawn(['build', '.', 'errors'])
 
         " rest is handled by go#jobcontrol#Run :)
         return

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -60,14 +60,32 @@ function! go#cmd#Build(bang, ...)
     let $GOPATH = old_gopath
 endfunction
 
+" Run runs the current file (and their dependencies if any) in a new terminal.
+function! go#cmd#RunTerm(mode)
+    " guard for other callers
+    if !has('nvim')
+        return
+    endif
+
+    let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
+
+    " if empty call the default term
+    if empty(a:mode)
+        call go#term#new(cmd)
+        return
+    endif
+
+    call go#term#newmode(cmd, a:mode)
+endfunction
+
+
 " Run runs the current file (and their dependencies if any) and outputs it.
 " This is intented to test small programs and play with them. It's not
 " suitable for long running apps, because vim is blocking by default and
 " calling long running apps will block the whole UI.
 function! go#cmd#Run(bang, ...)
     if has('nvim')
-        let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
-        call go#term#new(cmd)
+        call go#cmd#RunTerm('')
         return
     endif
 

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -43,6 +43,8 @@ if !exists("g:go_fmt_experimental")
     let g:go_fmt_experimental = 0
 endif
 
+let s:got_fmt_error = 0
+
 "  we have those problems : 
 "  http://stackoverflow.com/questions/12741977/prevent-vim-from-updating-its-undo-tree
 "  http://stackoverflow.com/questions/18532692/golang-formatter-and-vim-how-to-destroy-history-record?rq=1
@@ -117,9 +119,12 @@ function! go#fmt#Format(withGoimport)
         let &fileformat = old_fileformat
         let &syntax = &syntax
 
-        " clean up previous location list
-        call go#list#Clean()
-        call go#list#Window()
+        " clean up previous location list, but only if it's due fmt
+        if s:got_fmt_error 
+            let s:got_fmt_error = 0
+            call go#list#Clean()
+            call go#list#Window()
+        endif
     elseif g:go_fmt_fail_silently == 0 
         let splitted = split(out, '\n')
         "otherwise get the errors and put them to location list
@@ -141,6 +146,7 @@ function! go#fmt#Format(withGoimport)
             echohl Error | echomsg "Gofmt returned error" | echohl None
         endif
 
+        let s:got_fmt_error = 1
         call go#list#Window(len(errors))
 
         " We didn't use the temp file, so clean up

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -1,10 +1,18 @@
+" s:jobs is a global reference to all jobs started with Spawn() or with the
+" internal function s:spawn
 let s:jobs = {}
 
+" Spawn is a wrapper around s:spawn. It can be executed by other files and
+" scripts if needed.
 function! go#jobcontrol#Spawn(args)
   let job = s:spawn(a:args[0], a:args)
   return job.id
 endfunction
 
+" spawn spawns a go subcommand with the name and arguments with jobstart. Once
+" a job is started a reference will be stored inside s:jobs. spawn changes the
+" GOPATH when g:go_autodetect_gopath is enabled. The job is started inside the
+" current files folder.
 function! s:spawn(name, args)
   let job = { 
         \ 'name': a:name, 
@@ -14,9 +22,6 @@ function! s:spawn(name, args)
         \ 'on_stderr': function('s:on_stderr'),
         \ 'on_exit' : function('s:on_exit'),
         \ }
-
-  " abort previous running jobs
-  " call self.abort(a:name)
 
   " modify GOPATH if needed
   let old_gopath = $GOPATH
@@ -45,6 +50,8 @@ function! s:spawn(name, args)
   return job
 endfunction
 
+" on_stdout is the stdout handler for jobstart(). It collects the output of
+" stderr and stores them to the jobs internal stdout list. 
 function! s:on_stdout(job_id, data)
   if !has_key(s:jobs, a:job_id)
     return
@@ -54,6 +61,8 @@ function! s:on_stdout(job_id, data)
   call extend(job.stdout, a:data)
 endfunction
 
+" on_stderr is the stderr handler for jobstart(). It collects the output of
+" stderr and stores them to the jobs internal stderr list.
 function! s:on_stderr(job_id, data)
   if !has_key(s:jobs, a:job_id)
     return
@@ -63,6 +72,9 @@ function! s:on_stderr(job_id, data)
   call extend(job.stderr, a:data)
 endfunction
 
+" on_exit is the exit handler for jobstart(). It handles cleaning up the job
+" references and also displaying errors in the quickfix window collected by
+" on_stderr handler
 function! s:on_exit(job_id, data)
   if !has_key(s:jobs, a:job_id)
     return
@@ -72,22 +84,26 @@ function! s:on_exit(job_id, data)
   if empty(job.stderr)
     call setqflist([])
     call go#util#Cwindow()
+
     redraws! | echon "vim-go: " | echohl Function | echon printf("[%s] SUCCESS", self.name) | echohl None
     return
   else
-    redraws! | echon "vim-go: " | echohl ErrorMsg | echon printf("[%s] FAILED", self.name)| echohl None
     call go#tool#ShowErrors(join(job.stderr, "\n"))
     let errors = getqflist()
     call go#util#Cwindow(len(errors))
+
     if !empty(errors)
       cc 1 "jump to first error if there is any
     endif
+
+    redraws! | echon "vim-go: " | echohl ErrorMsg | echon printf("[%s] FAILED", self.name)| echohl None
   endif
 
   " do not keep anything when we are finished
   unlet s:jobs[a:job_id]
 endfunction
 
+" abort_all aborts all current jobs created with s:spawn()
 function! s:abort_all()
   if empty(s:jobs)
     return
@@ -102,6 +118,8 @@ function! s:abort_all()
   let s:jobs = {}
 endfunction
 
+" abort aborts the job with the given name, where name is the first argument
+" passed to s:spawn()
 function! s:abort(name)
   if empty(s:jobs)
     return

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -19,8 +19,10 @@ function! go#jobcontrol#Statusline() abort
     return ''
   endif
 
+  let import_path =  go#package#ImportPath(expand('%:p:h'))
+
   for job in values(s:jobs)
-    if job.filename != fnameescape(expand("%:p"))
+    if job.importpath != import_path
       continue
     endif
 
@@ -42,8 +44,8 @@ function! s:spawn(desc, name, args)
   let job = { 
         \ 'name': a:name, 
         \ 'desc': a:desc, 
-        \ 'id': '',
         \ 'winnr': winnr(),
+        \ 'importpath': go#package#ImportPath(expand('%:p:h')),
         \ 'state': "RUNNING",
         \ 'stderr' : [],
         \ 'stdout' : [],
@@ -58,11 +60,10 @@ function! s:spawn(desc, name, args)
 
   " execute go build in the files directory
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
-  let job.filename = fnameescape(expand("%:p"))
 
   " cleanup previous jobs for this file
   for jb in values(s:jobs)
-    if jb.filename == job.filename
+    if jb.importpath == job.importpath
       unlet s:jobs[jb.id]
     endif
   endfor
@@ -83,6 +84,7 @@ function! s:spawn(desc, name, args)
 
   " restore back GOPATH
   let $GOPATH = old_gopath
+
   return job
 endfunction
 

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -51,9 +51,8 @@ function! s:spawn(desc, name, args)
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
   let dir = getcwd()
   try
-    let job.dir = fnameescape(expand("%:p:h"))
     let job.filename = fnameescape(expand("%:p"))
-    execute cd . job.dir
+    execute cd . fnameescape(expand("%:p:h"))
 
     " append the subcommand, such as 'build'
     let argv = ['go'] + a:args

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -20,9 +20,15 @@ function! go#jobcontrol#Statusline() abort
   endif
 
   for job in values(s:jobs)
-    if job.filename == fnameescape(expand("%:p"))
-      return printf("%s [%s]", job.desc, job.state)
+    if job.filename != fnameescape(expand("%:p"))
+      continue
     endif
+
+    if job.state == "SUCCESS"
+      return ''
+    endif
+
+    return printf("%s [%s]", job.desc, job.state)
   endfor
 
   return ''

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -103,16 +103,16 @@ function! s:on_exit(job_id, data)
   let job = s:jobs[a:job_id]
 
   if empty(job.stderr)
-    call setqflist([])
-    call go#util#Cwindow()
+    call go#list#Clean()
+    call go#list#Window()
     call go#util#EchoSuccess(printf("[%s] SUCCESS", self.name))
   else
-    call go#tool#ShowErrors(join(job.stderr, "\n"))
-    let errors = getqflist()
-    call go#util#Cwindow(len(errors))
+    let errors = go#tool#ParseErrors(job.stderr)
+    call go#list#Populate(errors)
+    call go#list#Window(len(errors))
 
     if !empty(errors)
-      cc 1 "jump to first error if there is any
+      call go#list#JumpToFirst()
     endif
 
     call go#util#EchoError(printf("[%s] FAILED", self.name))

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -1,0 +1,73 @@
+let Go = {}
+
+function Go.on_stdout(job_id, data)
+	call extend(self.stdout, a:data)
+endfunction
+
+function Go.on_stderr(job_id, data)
+	call extend(self.stderr, a:data)
+endfunction
+
+function Go.on_exit(job_id, data)
+	call self.quickfix()
+endfunction
+
+function Go.quickfix()
+	" echo self.stderr
+	" return
+
+	call go#tool#ShowErrors(join(self.stderr, "\n"))
+	let errors = getqflist()
+	call go#util#Cwindow(len(errors))
+	if !empty(errors)
+		cc 1 "jump to first error if there is any
+	endif
+endfunction
+
+function Go.cmd(...)
+	let argv = ['go']
+	if a:0 > 0
+		call extend(argv, a:000) " append the subcommand, such as 'build'
+	else
+		redraws! | echon "vim-go: " | echohl ErrorMsg | echon "subcommand not passed"| echohl None
+		return -1
+	endif
+
+	" each Go instance has these local fields.
+	" name: defines the subcommand
+	" stderr: stores the stderr
+	" stdout: stores the stdout
+	let fields = {
+				\ 'name': a:1,  
+				\ 'stderr':[], 
+				\ 'stdout':[]
+				\ }
+
+	" populate the instace with on_stdout, on_stderr ... functions. These are
+	" needed by jobstart.
+	let instance = extend(copy(g:Go), fields)
+
+	" modify GOPATH if needed
+	let old_gopath = $GOPATH
+	let $GOPATH = go#path#Detect()
+
+	" execute go build in the files directory
+	let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
+	let dir = getcwd()
+	try
+		execute cd . fnameescape(expand("%:p:h"))
+		" run, forrest, run!
+		let instance.id = jobstart(argv, instance)
+	finally
+		execute cd . fnameescape(dir)
+	endtry
+
+	" restore back GOPATH
+	let $GOPATH = old_gopath
+
+	return instance
+endfunction
+
+let job1 = Go.cmd('build', '.', 'errors')
+
+" vim:ts=4:sw=4:et

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -30,7 +30,7 @@ function! go#jobcontrol#Statusline() abort
       return ''
     endif
 
-    return printf("%s [%s]", job.desc, job.state)
+    return printf("%s ... [%s]", job.desc, job.state)
   endfor
 
   return ''
@@ -106,6 +106,9 @@ function! s:on_exit(job_id, data)
 
   if !len(errors)
     " no errors could be past, just return
+    call go#list#Clean()
+    call go#list#Window()
+
     let self.state = "SUCCESS"
     return
   endif

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -9,7 +9,7 @@ function! go#jobcontrol#Spawn(desc, args)
   " autowrite is not enabled for jobs
   call go#cmd#autowrite()
 
-  let job = s:spawn(a:desc, a:args[0], a:args)
+  let job = s:spawn(a:desc, a:args)
   return job.id
 endfunction
 
@@ -40,9 +40,8 @@ endfunction
 " a job is started a reference will be stored inside s:jobs. spawn changes the
 " GOPATH when g:go_autodetect_gopath is enabled. The job is started inside the
 " current files folder.
-function! s:spawn(desc, name, args)
+function! s:spawn(desc, args)
   let job = { 
-        \ 'name': a:name, 
         \ 'desc': a:desc, 
         \ 'winnr': winnr(),
         \ 'importpath': go#package#ImportPath(expand('%:p:h')),
@@ -141,16 +140,15 @@ endfunction
 
 " abort aborts the job with the given name, where name is the first argument
 " passed to s:spawn()
-function! s:abort(name)
+function! s:abort(path)
   if empty(s:jobs)
     return
   endif
 
   for job in values(s:jobs)
-    if job.name == name && job.id > 0
+    if job.importpath == path && job.id > 0
       silent! call jobstop(job.id)
       unlet s:jobs['job.id']
-      call go#util#EchoWarning(printf("[%s] ABORTED", a:name))
     endif
   endfor
 endfunction

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -9,19 +9,20 @@ function Go.on_stderr(job_id, data)
 endfunction
 
 function Go.on_exit(job_id, data)
-	call self.quickfix()
+	call self.set_quickfix()
+	call self.show_quickfix()
 endfunction
 
-function Go.quickfix()
-	" echo self.stderr
-	" return
-
-	call go#tool#ShowErrors(join(self.stderr, "\n"))
+function Go.show_quickfix()
 	let errors = getqflist()
 	call go#util#Cwindow(len(errors))
 	if !empty(errors)
 		cc 1 "jump to first error if there is any
 	endif
+endfunction
+
+function Go.set_quickfix()
+	call go#tool#ShowErrors(join(self.stderr, "\n"))
 endfunction
 
 function Go.cmd(...)

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -16,7 +16,11 @@ endfunction
 function GoCommandJob.show_quickfix()
 	let errors = getqflist()
 	call go#util#Cwindow(len(errors))
-    " redraws! | echon "vim-go: " | echohl Function | echon printf("[%s] SUCCESS", self.name) | echohl None
+	if !empty(errors)
+		cc 1 "jump to first error if there is any
+    else
+        redraws! | echon "vim-go: " | echohl Function | echon printf("[%s] SUCCESS", self.name) | echohl None
+	endif
 endfunction
 
 function GoCommandJob.update_quickfix()
@@ -24,7 +28,7 @@ function GoCommandJob.update_quickfix()
         call setqflist([])
         call go#util#Cwindow()
     else
-        " redraws! | echon "vim-go: " | echohl ErrorMsg | echon printf("[%s] FAILED", self.name)| echohl None
+        redraws! | echon "vim-go: " | echohl ErrorMsg | echon printf("[%s] FAILED", self.name)| echohl None
 	    call go#tool#ShowErrors(join(self.stderr, "\n"))
     endif
 endfunction

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -96,7 +96,6 @@ function! s:on_exit(job_id, data)
   if empty(self.stderr)
     call go#list#Clean()
     call go#list#Window()
-    call go#util#EchoSuccess(printf("[%s] SUCCESS", self.name))
 
     " do not keep anything when we are finished
     unlet s:jobs[a:job_id]
@@ -107,14 +106,13 @@ function! s:on_exit(job_id, data)
   " if we are still in the same windows show the list
   if self.winnr == winnr()
     let errors = go#tool#ParseErrors(self.stderr)
-    call go#list#PopulateWin(self.winnr, errors)
+    call go#list#Populate(errors)
     call go#list#Window(len(errors))
+    " call go#list#JumpToFirst()
 
     if has_key(s:jobs, a:job_id) 
       unlet s:jobs[a:job_id]
     endif
-
-    call go#util#EchoError(printf("[%s] FAILED", self.name))
   endif
 endfunction
 

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -13,12 +13,18 @@ function! go#jobcontrol#Spawn(args)
 endfunction
 
 " Statusline returns the current status of the job
-function! go#jobcontrol#Statusline(id) abort
+function! go#jobcontrol#Statusline() abort
   if empty(s:jobs)
     return ''
   endif
-  "TODO(arslan): change this according to the type of job
-  return "building ..."
+
+  for job in values(s:jobs)
+    if job.filename == fnameescape(expand("%:p"))
+      return printf("job [%d] running...", job.id)
+    endif
+  endfor
+
+  return ''
 endfunction
 
 " spawn spawns a go subcommand with the name and arguments with jobstart. Once
@@ -43,11 +49,12 @@ function! s:spawn(name, args)
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
   let dir = getcwd()
   try
-    execute cd . fnameescape(expand("%:p:h"))
+    let job.dir = fnameescape(expand("%:p:h"))
+    let job.filename = fnameescape(expand("%:p"))
+    execute cd . job.dir
 
     " append the subcommand, such as 'build'
     let argv = ['go'] + a:args
-    " call extend(argv, a:args) 
 
     " run, forrest, run!
     let id = jobstart(argv, job)

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -101,8 +101,9 @@ function! s:on_exit(job_id, data)
     return
   endif
 
-
   let errors = go#tool#ParseErrors(std_combined)
+  let errors = go#tool#FilterValids(errors)
+
   if !len(errors)
     " no errors could be past, just return
     let self.state = "SUCCESS"

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -3,12 +3,13 @@
 let s:jobs = {}
 
 " Spawn is a wrapper around s:spawn. It can be executed by other files and
-" scripts if needed.
-function! go#jobcontrol#Spawn(args)
+" scripts if needed. Desc defines the description for printing the status
+" during the job execution (useful for statusline integration).
+function! go#jobcontrol#Spawn(desc, args)
   " autowrite is not enabled for jobs
   call go#cmd#autowrite()
 
-  let job = s:spawn(a:args[0], a:args)
+  let job = s:spawn(a:desc, a:args[0], a:args)
   return job.id
 endfunction
 
@@ -20,7 +21,7 @@ function! go#jobcontrol#Statusline() abort
 
   for job in values(s:jobs)
     if job.filename == fnameescape(expand("%:p"))
-      return printf("job [%d] running...", job.id)
+      return job.desc
     endif
   endfor
 
@@ -31,9 +32,10 @@ endfunction
 " a job is started a reference will be stored inside s:jobs. spawn changes the
 " GOPATH when g:go_autodetect_gopath is enabled. The job is started inside the
 " current files folder.
-function! s:spawn(name, args)
+function! s:spawn(desc, name, args)
   let job = { 
         \ 'name': a:name, 
+        \ 'desc': a:desc, 
         \ 'stderr' : [],
         \ 'stdout' : [],
         \ 'on_stdout': function('s:on_stdout'),

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -12,6 +12,15 @@ function! go#jobcontrol#Spawn(args)
   return job.id
 endfunction
 
+" Statusline returns the current status of the job
+function! go#jobcontrol#Statusline(id) abort
+  if empty(s:jobs)
+    return ''
+  endif
+  "TODO(arslan): change this according to the type of job
+  return "building ..."
+endfunction
+
 " spawn spawns a go subcommand with the name and arguments with jobstart. Once
 " a job is started a reference will be stored inside s:jobs. spawn changes the
 " GOPATH when g:go_autodetect_gopath is enabled. The job is started inside the
@@ -89,7 +98,6 @@ function! s:on_exit(job_id, data)
     call setqflist([])
     call go#util#Cwindow()
     call go#util#EchoSuccess(printf("[%s] SUCCESS", self.name))
-    return
   else
     call go#tool#ShowErrors(join(job.stderr, "\n"))
     let errors = getqflist()

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -1,81 +1,120 @@
-let GoCommandJob = {}
+let s:jobs = {}
 
-function GoCommandJob.on_stdout(job_id, data)
-	call extend(self.stdout, a:data)
+function! go#jobcontrol#Spawn(args)
+  let job = s:spawn(a:args[0], a:args)
+  return job.id
 endfunction
 
-function GoCommandJob.on_stderr(job_id, data)
-	call extend(self.stderr, a:data)
+function! s:spawn(name, args)
+  let job = { 
+        \ 'name': a:name, 
+        \ 'stderr' : [],
+        \ 'stdout' : [],
+        \ 'on_stdout': function('s:on_stdout'),
+        \ 'on_stderr': function('s:on_stderr'),
+        \ 'on_exit' : function('s:on_exit'),
+        \ }
+
+  " abort previous running jobs
+  " call self.abort(a:name)
+
+  " modify GOPATH if needed
+  let old_gopath = $GOPATH
+  let $GOPATH = go#path#Detect()
+
+  " execute go build in the files directory
+  let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
+  let dir = getcwd()
+  try
+    execute cd . fnameescape(expand("%:p:h"))
+
+    " append the subcommand, such as 'build'
+    let argv = ['go'] + a:args
+    " call extend(argv, a:args) 
+
+    " run, forrest, run!
+    let id = jobstart(argv, job)
+    let job.id = id
+    let s:jobs[id] = job
+  finally
+    execute cd . fnameescape(dir)
+  endtry
+
+  " restore back GOPATH
+  let $GOPATH = old_gopath
+  return job
 endfunction
 
-function GoCommandJob.on_exit(job_id, data)
-	call self.update_quickfix()
-	call self.show_quickfix()
+function! s:on_stdout(job_id, data)
+  if !has_key(s:jobs, a:job_id)
+    return
+  endif
+  let job = s:jobs[a:job_id]
+
+  call extend(job.stdout, a:data)
 endfunction
 
-function GoCommandJob.show_quickfix()
-	let errors = getqflist()
-	call go#util#Cwindow(len(errors))
-	if !empty(errors)
-		cc 1 "jump to first error if there is any
-    else
-        redraws! | echon "vim-go: " | echohl Function | echon printf("[%s] SUCCESS", self.name) | echohl None
-	endif
+function! s:on_stderr(job_id, data)
+  if !has_key(s:jobs, a:job_id)
+    return
+  endif
+  let job = s:jobs[a:job_id]
+
+  call extend(job.stderr, a:data)
 endfunction
 
-function GoCommandJob.update_quickfix()
-    if empty(self.stderr)
-        call setqflist([])
-        call go#util#Cwindow()
-    else
-        redraws! | echon "vim-go: " | echohl ErrorMsg | echon printf("[%s] FAILED", self.name)| echohl None
-	    call go#tool#ShowErrors(join(self.stderr, "\n"))
+function! s:on_exit(job_id, data)
+  if !has_key(s:jobs, a:job_id)
+    return
+  endif
+  let job = s:jobs[a:job_id]
+
+  if empty(job.stderr)
+    call setqflist([])
+    call go#util#Cwindow()
+    redraws! | echon "vim-go: " | echohl Function | echon printf("[%s] SUCCESS", self.name) | echohl None
+    return
+  else
+    redraws! | echon "vim-go: " | echohl ErrorMsg | echon printf("[%s] FAILED", self.name)| echohl None
+    call go#tool#ShowErrors(join(job.stderr, "\n"))
+    let errors = getqflist()
+    call go#util#Cwindow(len(errors))
+    if !empty(errors)
+      cc 1 "jump to first error if there is any
     endif
+  endif
+
+  " do not keep anything when we are finished
+  unlet s:jobs[a:job_id]
 endfunction
 
-function GoCommandJob.cmd(args)
-	let argv = ['go']
-	call extend(argv, a:args) " append the subcommand, such as 'build'
+function! s:abort_all()
+  if empty(s:jobs)
+    return
+  endif
 
-	" each Go instance has these local fields.
-	" name: defines the subcommand
-	" stderr: stores the stderr
-	" stdout: stores the stdout
-	let fields = {
-				\ 'name': a:args[0],  
-				\ 'stderr':[], 
-				\ 'stdout':[]
-				\ }
+  for id in keys(s:jobs)
+    if id > 0
+      silent! call jobstop(id)
+    endif
+  endfor
 
-	" populate the instace with on_stdout, on_stderr ... functions. These are
-	" needed by jobstart.
-	let instance = extend(copy(g:GoCommandJob), fields)
-
-	" modify GOPATH if needed
-	let old_gopath = $GOPATH
-	let $GOPATH = go#path#Detect()
-
-	" execute go build in the files directory
-	let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
-	let dir = getcwd()
-	try
-		execute cd . fnameescape(expand("%:p:h"))
-		" run, forrest, run!
-		let instance.id = jobstart(argv, instance)
-	finally
-		execute cd . fnameescape(dir)
-	endtry
-
-	" restore back GOPATH
-	let $GOPATH = old_gopath
-
-	return instance
+  let s:jobs = {}
 endfunction
 
-function! go#jobcontrol#Run(args)
-	let job1 = g:GoCommandJob.cmd(a:args)
-	return job1.id
+function! s:abort(name)
+  if empty(s:jobs)
+    return
+  endif
+
+  for job in values(s:jobs)
+    if job.name == name && job.id > 0
+      silent! call jobstop(job.id)
+      unlet s:jobs['job.id']
+      redraws! | echon "vim-go: " | echohl WarningMsg | echon printf("[%s] ABORTED", a:name) | echohl None
+
+    endif
+  endfor
 endfunction
 
-
-" vim:ts=4:sw=4:et
+" vim:ts=2:sw=2:et

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -9,20 +9,24 @@ function GoCommandJob.on_stderr(job_id, data)
 endfunction
 
 function GoCommandJob.on_exit(job_id, data)
-	call self.set_quickfix()
+	call self.update_quickfix()
 	call self.show_quickfix()
 endfunction
 
 function GoCommandJob.show_quickfix()
 	let errors = getqflist()
 	call go#util#Cwindow(len(errors))
-	if !empty(errors)
-		cc 1 "jump to first error if there is any
-	endif
+    " redraws! | echon "vim-go: " | echohl Function | echon printf("[%s] SUCCESS", self.name) | echohl None
 endfunction
 
-function GoCommandJob.set_quickfix()
-	call go#tool#ShowErrors(join(self.stderr, "\n"))
+function GoCommandJob.update_quickfix()
+    if empty(self.stderr)
+        call setqflist([])
+        call go#util#Cwindow()
+    else
+        " redraws! | echon "vim-go: " | echohl ErrorMsg | echon printf("[%s] FAILED", self.name)| echohl None
+	    call go#tool#ShowErrors(join(self.stderr, "\n"))
+    endif
 endfunction
 
 function GoCommandJob.cmd(args)

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -36,6 +36,10 @@ function! go#list#Populate(items)
 	call setloclist(0, a:items, 'r')
 endfunction
 
+function! go#list#PopulateWin(winnr, items)
+	call setloclist(a:winnr, a:items, 'r')
+endfunction
+
 " Parse parses the given items based on the specified errorformat nad
 " populates the location list.
 function! go#list#ParseFormat(errformat, items)

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -1,4 +1,4 @@
-function! go#term#new(cmd)
+function! go#term#vsplit()
   execute 'vertical new'
 	" setlocal filetype=vimgo
 	" setlocal bufhidden=delete
@@ -7,10 +7,13 @@ function! go#term#new(cmd)
 	" setlocal nobuflisted
 	" setlocal winfixheight
 	setlocal cursorline " make it easy to distinguish
-	setlocal nomodifiable
+	" setlocal nomodifiable
   nnoremap <buffer> <C-d> :<C-u>close<CR>
+endfunction
 
+function! go#term#new(cmd)
   let id = termopen(a:cmd)
+	startinsert
 endfunction
 
 function! go#term#kill()

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -87,6 +87,7 @@ function! s:on_exit(job_id, data)
     call go#list#Window()
 	else
 		let errors = go#tool#ParseErrors(job.stdout)
+		let errors = go#tool#FilterValids(errors)
 		if !empty(errors)
 			" close terminal we don't need it
 			close 

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -83,21 +83,20 @@ function! s:on_exit(job_id, data)
 
 	" usually there is always output so never branch into this clause
 	if empty(job.stdout)
-		call setqflist([])
-		call go#util#Cwindow()
+    call go#list#Clean()
+    call go#list#Window()
 	else
 		let errors = go#tool#ParseErrors(job.stdout)
 		if !empty(errors)
 			" close terminal we don't need it
 			close 
 
-			call setqflist(errors, 'r')
-			call go#util#Cwindow(len(errors))
-			cc 1 "jump to first error if there is any
-
+      call go#list#Populate(errors)
+      call go#list#Window(len(errors))
+      call go#list#JumpToFirst()
 		else
-			call setqflist([])
-			call go#util#Cwindow()
+      call go#list#Clean()
+      call go#list#Window()
 		endif
 
 	endif

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -13,8 +13,12 @@ endfunction
 
 " new creates a new terminal with the given command and window mode.
 function! go#term#newmode(cmd, mode)
-	execute a:mode.' new'
+	let mode = a:mode
+	if empty(mode)
+		let mode = g:go_term_mode
+	endif
 
+	execute mode.' new'
 
   sil file `="[term]"`
 	setlocal bufhidden=delete
@@ -39,13 +43,14 @@ function! go#term#newmode(cmd, mode)
 	let width = get(g:, 'go_term_width', winwidth(0))
 
 	" we are careful how to resize. for example it's vertical we don't change
-	" the height
-	if a:mode == "vertical"
-		exe 'vertical resize ' . width
-	elseif a:mode == "split"
+	" the height. The below command resizes the buffer
+	if a:mode == "split"
 		exe 'resize ' . height
+	elseif a:mode == "vertical"
+		exe 'vertical resize ' . width
 	endif
 
+	" we also need to resize the pty, so there you go...
 	call jobresize(id, width, height)
 
   let s:jobs[id] = job

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -25,7 +25,6 @@ function! go#term#newmode(cmd, mode)
 	setlocal winfixheight
 	setlocal noswapfile
 	setlocal nobuflisted
-	setlocal cursorline		" makes it easy to distinguish
 
 	let job = { 
 		\ 'stderr' : [],

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -1,0 +1,23 @@
+function! go#term#new(cmd)
+  execute 'vertical new'
+	" setlocal filetype=vimgo
+	" setlocal bufhidden=delete
+	" setlocal buftype=nofile
+	" setlocal noswapfile
+	" setlocal nobuflisted
+	" setlocal winfixheight
+	setlocal cursorline " make it easy to distinguish
+	setlocal nomodifiable
+  nnoremap <buffer> <C-d> :<C-u>close<CR>
+
+  let id = termopen(a:cmd)
+endfunction
+
+function! go#term#kill()
+endfunction
+
+function! go#term#close()
+endfunction
+
+function! go#term#clear()
+endfunction

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -1,26 +1,41 @@
-function! go#term#vsplit()
-  execute 'vertical new'
-	" setlocal filetype=vimgo
-	" setlocal bufhidden=delete
-	" setlocal buftype=nofile
-	" setlocal noswapfile
-	" setlocal nobuflisted
-	" setlocal winfixheight
-	setlocal cursorline " make it easy to distinguish
-	" setlocal nomodifiable
-  nnoremap <buffer> <C-d> :<C-u>close<CR>
-endfunction
+" s:jobs is a global reference to all jobs started with new()
+let s:jobs = {}
 
-function! go#term#new(cmd)
-  let id = termopen(a:cmd)
+" new creates a new terminal with the given command
+function! go#term#new(cmd, mode)
+	execute a:mode.' new'
+  call s:init_view()
+
+  let job = { 
+        \ 'on_stdout': function('s:on_stdout'),
+        \ 'on_stderr': function('s:on_stderr'),
+        \ 'on_exit' : function('s:on_exit'),
+        \ }
+
+  let id = termopen(a:cmd, job)
+	let job.id = id
+  let s:jobs[id] = job
 	startinsert
+	return id
 endfunction
 
-function! go#term#kill()
+"init_view initializes the view for a new terminal buffer
+function! s:init_view()
+  sil file `="[term]"`
+	setlocal bufhidden=delete
+	setlocal buftype=nofile
+	setlocal winfixheight
+	setlocal noswapfile
+	setlocal nobuflisted
+	setlocal cursorline		" make it easy to distinguish
 endfunction
 
-function! go#term#close()
+function! s:on_stdout(job_id, data)
 endfunction
 
-function! go#term#clear()
+function! s:on_stderr(job_id, data)
+endfunction
+
+function! s:on_exit(job_id, data)
+  unlet s:jobs[a:job_id]
 endfunction

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -86,7 +86,6 @@ function! s:on_exit(job_id, data)
 	if empty(job.stdout)
 		call setqflist([])
 		call go#util#Cwindow()
-		call go#util#EchoSuccess(printf("[%s] SUCCESS", self.name))
 	else
 		let errors = go#tool#ParseErrors(job.stdout)
 		if !empty(errors)
@@ -97,7 +96,6 @@ function! s:on_exit(job_id, data)
 			call go#util#Cwindow(len(errors))
 			cc 1 "jump to first error if there is any
 
-			call go#util#EchoError(printf("[%s] FAILED", self.name))
 		else
 			call setqflist([])
 			call go#util#Cwindow()

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -1,8 +1,18 @@
+if has('nvim') && !exists("g:go_term_mode")
+    let g:go_term_mode = 'vsplit'
+endif
+
 " s:jobs is a global reference to all jobs started with new()
 let s:jobs = {}
 
-" new creates a new terminal with the given command
-function! go#term#new(cmd, mode)
+" new creates a new terminal with the given command. Mode is set based on the
+" global variable g:go_term_mode, which is by default set to :vsplit
+function! go#term#new(cmd)
+	call go#term#newmode(a:cmd, g:go_term_mode)
+endfunction
+
+" new creates a new terminal with the given command and window mode.
+function! go#term#newmode(cmd, mode)
 	execute a:mode.' new'
   call s:init_view()
 

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -28,12 +28,12 @@ function! go#term#newmode(cmd, mode)
 	setlocal cursorline		" makes it easy to distinguish
 
 	let job = { 
-				\ 'stderr' : [],
-				\ 'stdout' : [],
-				\ 'on_stdout': function('s:on_stdout'),
-				\ 'on_stderr': function('s:on_stderr'),
-				\ 'on_exit' : function('s:on_exit'),
-				\ }
+		\ 'stderr' : [],
+		\ 'stdout' : [],
+		\ 'on_stdout': function('s:on_stdout'),
+		\ 'on_stderr': function('s:on_stderr'),
+		\ 'on_exit' : function('s:on_exit'),
+		\ }
 
 	let id = termopen(a:cmd, job)
 	let job.id = id
@@ -105,3 +105,5 @@ function! s:on_exit(job_id, data)
 
 	unlet s:jobs[a:job_id]
 endfunction
+
+" vim:ts=2:sw=2:et

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -80,9 +80,13 @@ function! go#tool#FilterValids(items)
     let is_readable = {}
 
     for item in a:items
-        let filename = item.filename
         if has_key(item, 'bufnr')
             let filename = bufname(item.bufnr)
+        elseif has_key(item, 'filename')
+            let filename = item.filename
+        else
+            echohl Identifier | echon "no filename available" | echohl None
+            continue
         endif
 
         if !has_key(is_readable, filename)

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -50,13 +50,14 @@ function! go#tool#ParseErrors(lines)
         if !empty(fatalerrors)
             call add(errors, {"text": fatalerrors[1]})
         elseif !empty(tokens)
-
             " strip endlines of form ^M
             let out=substitute(tokens[3], '\r$', '', '')
 
-            call add(errors, {"filename" : fnamemodify(tokens[1], ':p'),
-                        \"lnum":     tokens[2],
-                        \"text":     out})
+            call add(errors, {
+                        \ "filename" : fnamemodify(tokens[1], ':p'),
+                        \ "lnum"     : tokens[2],
+                        \ "text"     : out,
+                        \ })
         elseif !empty(errors)
             " Preserve indented lines.
             " This comes up especially with multi-line test output.

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -53,9 +53,18 @@ endfunction
 function! go#util#Shelljoin(arglist, ...)
 	if a:0
 		return join(map(copy(a:arglist), 'shellescape(v:val, ' . a:1 . ')'), ' ')
-	else
-		return join(map(copy(a:arglist), 'shellescape(v:val)'), ' ')
 	endif
+
+	return join(map(copy(a:arglist), 'shellescape(v:val)'), ' ')
+endfunction
+
+" Shelljoin returns a shell-safe representation of the items in the given
+" arglist. The {special} argument of shellescape() may optionally be passed.
+function! go#util#Shelllist(arglist, ...)
+	if a:0
+		return map(copy(a:arglist), 'shellescape(v:val, ' . a:1 . ')')
+    endif
+	return map(copy(a:arglist), 'shellescape(v:val)')
 endfunction
 
 

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -86,4 +86,24 @@ function! go#util#Cwindow(...)
     exe 'copen '. height
 endfunction
 
+" TODO(arslan): I couldn't parameterize the highlight types. Check if we can
+" simplify the following functions
+
+function! go#util#EchoSuccess(msg)
+    redraws! | echon "vim-go: " | echohl Function | echon a:msg | echohl None
+endfunction
+
+function! go#util#EchoError(msg)
+    redraws! | echon "vim-go: " | echohl ErrorMsg | echon a:msg | echohl None
+endfunction
+
+function! go#util#EchoWarning(msg)
+    redraws! | echon "vim-go: " | echohl WarningMsg | echon a:msg | echohl None
+endfunction
+
+function! go#util#EchoProgress(msg)
+    redraws! | echon "vim-go: " | echohl Identifier | echon a:msg | echohl None
+endfunction
+
+
 " vim:ts=4:sw=4:et

--- a/ftplugin/go/mappings.vim
+++ b/ftplugin/go/mappings.vim
@@ -11,6 +11,13 @@ endif
 
 " Some handy plug mappings
 nnoremap <silent> <Plug>(go-run) :<C-u>call go#cmd#Run(!g:go_jump_to_error, '%')<CR>
+
+if has("nvim")
+	nnoremap <silent> <Plug>(go-run-vertical) :<C-u>call go#cmd#RunTerm('vsplit')<CR>
+	nnoremap <silent> <Plug>(go-run-split) :<C-u>call go#cmd#RunTerm('split')<CR>
+	nnoremap <silent> <Plug>(go-run-tab) :<C-u>call go#cmd#RunTerm('tab')<CR>
+endif
+
 nnoremap <silent> <Plug>(go-build) :<C-u>call go#cmd#Build(!g:go_jump_to_error)<CR>
 nnoremap <silent> <Plug>(go-generate) :<C-u>call go#cmd#Generate(!g:go_jump_to_error)<CR>
 nnoremap <silent> <Plug>(go-install) :<C-u>call go#cmd#Install(!g:go_jump_to_error)<CR>

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -133,6 +133,9 @@ augroup vim-go
         autocmd BufWritePre *.go call go#fmt#Format(-1)
     endif
 
+    if has('nvim')
+        autocmd WinEnter *.go call go#jobcontrol#DisplayLoclist()
+    endif
 augroup END
 
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -133,10 +133,6 @@ augroup vim-go
         autocmd BufWritePre *.go call go#fmt#Format(-1)
     endif
 
-    if has('nvim')
-        autocmd WinEnter *.go call go#jobcontrol#DisplayLoclist()
-    endif
-
     " run gometalinter on save
     if get(g:, "go_metalinter_autosave", 0)
         autocmd BufWritePost *.go call go#lint#Gometa(1)


### PR DESCRIPTION
This PR is going to add a proper initial Neovim integration (to make use of Neovim's advanced features). Nothing needs to be installed or to be done. The features will be active only if you use vim-go inside Neovim. 

Currently implemented features:

* An async launcher and base foundation was implemented for the `go` command. This will be used for all upcoming subcommands of the `go` tool.
* `:GoBuild` is now called asynchronously (it doesn't block the UI anymore). 
* A new `go#jobcontrol#Statusline()` can be used to plug into the statusline. This will show the status of the job running asynchronously
* `:GoRun` opens a new vertical terminal and runs the command there. The terminal mode can be changed with `g:go_term_mode`, which is by default `vsplit`. Current options are `vsplit, split or tab`
* Three new mappings to open `:GoRun` terminal in different modes: `<Plug>(go-run-vertical)`,  `<Plug>(go-run-split)` and  `<Plug>(go-run-tab)`: An example usage:
```viml
au FileType go nmap <leader>rt <Plug>(go-run-tab)
au FileType go nmap <Leader>rs <Plug>(go-run-split)
au FileType go nmap <Leader>rv <Plug>(go-run-vertical)
```
* We have two settings for terminal sizes: `g:go_term_height` and `g:go_term_width`. By default a vertical or horizontal is just split by vim automatically. However with these settings we can for example have a terminal with a smaller height when we split it horizontally.
* `:GoTest`, `:GoTestFunc` and `:GoTestCompile` opens and runs in a new terminal. The view mode(split,vertical, tab) is defined with `g:go_term_mode`. 
* If a command inside the term fails (such as `go run`, `go test` ...) we parse now the errors and list them inside in a qf window.
* A `g:go_term_enabled` setting is added to change the behavior of `:GoTest` .If set to `1`, it opens the test commands inside a terminal, if not it runs them in background just like  `:GoBuild` and displays the result in the statusline
* The status_line is improved to show the status per package instead of file. Assume you have three files open, all belonging to the same package, if the package build (`:GoBuild`) is successful, all statusline's will be empty (means SUCCESS), if you it fails all file's statusline will show `FAILED`. 

Please test all features both with Vim and Neovim if you can. Right now documentation, messages and co are just placeholders and will be suited and corrected once it's release ready. Please ask any question. Any feedback is welcome.