### PR TITLE
Fix issue #595 - fileformat changed by gofmt

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -115,8 +115,8 @@ function! go#fmt#Format(withGoimport)
         try | silent undojoin | catch | endtry
 
         " Replace current file with temp file, then reload buffer
-        call rename(l:tmpname, expand('%'))
         let old_fileformat = &fileformat
+        call rename(l:tmpname, expand('%'))
         silent edit!
         let &fileformat = old_fileformat
         let &syntax = &syntax

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -116,7 +116,9 @@ function! go#fmt#Format(withGoimport)
 
         " Replace current file with temp file, then reload buffer
         call rename(l:tmpname, expand('%'))
+        let old_fileformat = &fileformat
         silent edit!
+        let &fileformat = old_fileformat
         let &syntax = &syntax
 
         " only clear quickfix if it was previously set, this prevents closing


### PR DESCRIPTION
A simple fix for issue #595.

When :GoFmt is called from within Vim, it runs the gofmt command with the -w parameter, which modifies the source file (actually, it modifies a temp file, which is then swapped in, but you get the idea). One effect of this is that all line endings are changed to lf. When the current buffer is reloaded, vim detects the fileformat as 'unix' due to the lf line endings, even if the fileformat was previously 'dos'. This makes it impossible to maintain windows-style line endings (crlf), if you want them.

Prior to this recent commit: 01578fd8632870f8285266b93c1e219df19c4002, this did not occur. I believe it has to do with the fact that the lines output from gofmt were previously split and inserted line-by-line via Vim itself, which respected the existing fileformat variable. However, in the this commit, the behavior was changed so that gofmt takes care of modifying the file externally, outside of vim (via the -w flag). As a result, the fileformat variable is no longer respected, and is actually changed upon reloading the buffer.

I'm not sure if you'll want to merge this pull-request, or simply accept unix-style line endings as the only valid line-endings for a Go file (this seems to be the convention adopted by the authors of Go: https://github.com/golang/go/issues/3961). In any case, I thought I'd bring it to your attention, because I, at least, wanted to keep using windows-style line endings on my windows machine (I let git do the conversion for me), and I expect that other people might want the same.

Thanks!