### PR TITLE
Use vimproc#get_last_status() instead of v:shell_error if using vimproc.

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -19,12 +19,20 @@ fu! s:gocodeCurrentBuffer()
     return file
 endf
 
-
 if go#vimproc#has_vimproc()
     let s:vim_system = get(g:, 'gocomplete#system_function', 'vimproc#system2')
+    let s:vim_shell_error = get(g:, 'gocomplete#shell_error_function', 'vimproc#get_last_status')
 else
     let s:vim_system = get(g:, 'gocomplete#system_function', 'system')
+    let s:vim_shell_error = ''
 endif
+
+fu! s:shell_error()
+    let empty(s:vim_shell_error)
+        return v:shell_error
+    endif
+    return call(s:vim_shell_error, [])
+endf
 
 fu! s:system(str, ...)
     return call(s:vim_system, [a:str] + a:000)
@@ -65,7 +73,7 @@ fu! s:gocodeCommand(cmd, preargs, args)
 
     let $GOPATH = old_gopath
 
-    if v:shell_error != 0
+    if s:shell_error() != 0
         return "[\"0\", []]"
     else
         if &encoding != 'utf-8'


### PR DESCRIPTION
v:shell_error is readonly variable. So vimproc provide way to get last error. Use it instead of v:shell_error.
