### PR TITLE
Location list

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ disabled/enabled easily.
 * Go to symbol/declaration with `:GoDef`
 * Look up documentation with `:GoDoc` inside Vim or open it in browser
 * Automatically import packages via `:GoImport` or plug it into autosave
-* Compile your package with `:GoBuild`, install it with `:GoInstall`
+* Compile your package with `:GoBuild`, install it with `:GoInstall` or test
+  them with `:GoTest` (also supports running single tests via `:GoTestFunc`)
 * Quickly execute your current file/files with `:GoRun`
-* Run `:GoTest` and see any errors in the quickfix window
 * Automatic `GOPATH` detection based on the directory structure (i.e. `gb`
   projects, `godep` vendored projects)
 * Change or display `GOPATH` with `:GoPath`
@@ -41,6 +41,8 @@ disabled/enabled easily.
   your custom vim function.
 * Tagbar support to show tags of the source code in a sidebar with `gotags`
 * Custom vim text objects such as `a function` or `inner function`
+* All commands support collecting and displaying errors in Vim's location
+  list.
 
 ## Install
 

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -109,7 +109,7 @@ function! go#cmd#Run(bang, ...)
 
     for k in keys(filter(is_readable, '!v:val'))
         echo "vim-go: " | echohl Identifier | echon "[run] Dropped " | echohl Constant | echon  '"' . k . '"'
-        echohl Identifier | echon " from QuickFix list (nonvalid filename)" | echohl None
+        echohl Identifier | echon " from location list (nonvalid filename)" | echohl None
     endfor
 
     call go#list#Populate(errors)
@@ -123,8 +123,8 @@ function! go#cmd#Run(bang, ...)
 endfunction
 
 " Install installs the package by simple calling 'go install'. If any argument
-" is given(which are passed directly to 'go insta'') it tries to install those
-" packages. Errors are populated in the quickfix window.
+" is given(which are passed directly to 'go instal') it tries to install those
+" packages. Errors are populated in the location window.
 function! go#cmd#Install(bang, ...)
     let command = 'go install ' . go#util#Shelljoin(a:000)
     call go#cmd#autowrite()

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -1,5 +1,5 @@
 " Window opens the location list with the given height up to 10 lines maximum.
-" Otherwise g:go_location_height is used. If no or zero height is given it
+" Otherwise g:go_loclist_height is used. If no or zero height is given it
 " closes the window
 function! go#list#Window(...)
     " we don't use lwindow to close the location list as we need also the
@@ -12,7 +12,7 @@ function! go#list#Window(...)
         return
     endif
 
-    let height = get(g:, "go_location_height", 0)
+    let height = get(g:, "go_loclist_height", 0)
     if height == 0
         " prevent creating a large location height for a large set of numbers
         if a:1 > 10

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -36,6 +36,26 @@ function! go#list#Populate(items)
 	call setloclist(0, a:items, 'r')
 endfunction
 
+" Parse parses the given items based on the specified errorformat nad
+" populates the location list.
+function! go#list#ParseFormat(errformat, items)
+  " backup users errorformat, will be restored once we are finished
+  let old_errorformat = &errorformat
+
+	" parse and populate the location list
+  let &errorformat = a:errformat
+	lgetexpr a:items
+
+	"restore back
+  let &errorformat = old_errorformat
+endfunction
+
+" Parse parses the given items based on the global errorformat nad
+" populates the location list.
+function! go#list#Parse(items)
+	lgetexpr a:items
+endfunction
+
 " JumpToFirst jumps to the first item in the location list
 function! go#list#JumpToFirst()
   ll 1 

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -1,0 +1,47 @@
+" Window opens the location list with the given height up to 10 lines maximum.
+" Otherwise g:go_location_height is used. If no or zero height is given it
+" closes the window
+function! go#list#Window(...)
+    " we don't use lwindow to close the location list as we need also the
+    " ability to resize the window. So, we are going to use lopen and cclose
+    " for a better user experience. If the number of errors in a current
+    " location list increases/decreases, cwindow will not resize when a new
+    " updated height is passed. lopen in the other hand resizes the screen.
+    if !a:0 || a:1 == 0
+        lclose
+        return
+    endif
+
+    let height = get(g:, "go_location_height", 0)
+    if height == 0
+        " prevent creating a large location height for a large set of numbers
+        if a:1 > 10
+            let height = 10
+        else
+            let height = a:1
+        endif
+    endif
+
+    exe 'lopen '. height
+endfunction
+
+
+" Get returns the current list of items from the location list
+function! go#list#Get()
+  return getloclist(0)
+endfunction
+
+" Populate populate the location list with the given items
+function! go#list#Populate(items)
+	call setloclist(0, a:items, 'r')
+endfunction
+
+" JumpToFirst jumps to the first item in the location list
+function! go#list#JumpToFirst()
+  ll 1 
+endfunction
+
+" Clean cleans the location list
+function! go#list#Clean()
+	lex []
+endfunction

--- a/autoload/go/oracle.vim
+++ b/autoload/go/oracle.vim
@@ -10,9 +10,9 @@ if !exists("g:go_oracle_bin")
 endif
 
 " Parses (via regex) Oracle's 'plain' format output and puts them into a
-" quickfix list.
-func! s:qflist(output)
-    let qflist = []
+" location list
+func! s:loclist(output)
+    let llist = []
     " Parse GNU-style 'file:line.col-line.col: message' format.
     let mx = '^\(\a:[\\/][^:]\+\|[^:]\+\):\(\d\+\):\(\d\+\):\(.*\)$'
     for line in split(a:output, "\n")
@@ -33,17 +33,17 @@ func! s:qflist(output)
         if bnr != -1
             let item['bufnr'] = bnr
         endif
-        call add(qflist, item)
+        call add(llist, item)
     endfor
-    call setqflist(qflist)
-    call go#util#Cwindow(len(qflist))
+    call go#list#Populate(llist)
+    call go#list#Window(len(llist))
 endfun
 
 " This uses Vim's errorformat to parse the output from Oracle's 'plain output
-" and put it into quickfix list. I believe using errorformat is much more
+" and put it into location list. I believe using errorformat is much more
 " easier to use. If we need more power we can always switch back to parse it
 " via regex.
-func! s:qflistSecond(output)
+func! s:loclistSecond(output)
     " backup users errorformat, will be restored once we are finished
     let old_errorformat = &errorformat
 
@@ -53,16 +53,13 @@ func! s:qflistSecond(output)
     "   'file:line:col: message'
     "
     " We discard line2 and col2 for the first errorformat, because it's not
-    " useful and quickfix only has the ability to show one line and column
+    " useful and location only has the ability to show one line and column
     " number
-    let &errorformat = "%f:%l.%c-%[%^:]%#:\ %m,%f:%l:%c:\ %m"
+    let errformat = "%f:%l.%c-%[%^:]%#:\ %m,%f:%l:%c:\ %m"
+    call go#list#ParseFormat(errformat, split(a:output, "\n"))
 
-    " create the quickfix list and open it
-    cgetexpr split(a:output, "\n")
-    let errors = getqflist()
-    call go#util#Cwindow(len(errors))
-
-    let &errorformat = old_errorformat
+    let errors = go#list#Get()
+    call go#list#Window(len(errors))
 endfun
 
 func! s:getpos(l, c)
@@ -186,31 +183,31 @@ endfunction
 " Show 'implements' relation for selected package
 function! go#oracle#Implements(selected)
     let out = s:RunOracle('implements', a:selected, 0)
-    call s:qflistSecond(out)
+    call s:loclistSecond(out)
 endfunction
 
 " Describe selected syntax: definition, methods, etc
 function! go#oracle#Describe(selected)
     let out = s:RunOracle('describe', a:selected, 0)
-    call s:qflistSecond(out)
+    call s:loclistSecond(out)
 endfunction
 
 " Show possible targets of selected function call
 function! go#oracle#Callees(selected)
     let out = s:RunOracle('callees', a:selected, 1)
-    call s:qflistSecond(out)
+    call s:loclistSecond(out)
 endfunction
 
 " Show possible callers of selected function
 function! go#oracle#Callers(selected)
     let out = s:RunOracle('callers', a:selected, 1)
-    call s:qflistSecond(out)
+    call s:loclistSecond(out)
 endfunction
 
 " Show path from callgraph root to selected function
 function! go#oracle#Callstack(selected)
     let out = s:RunOracle('callstack', a:selected, 1)
-    call s:qflistSecond(out)
+    call s:loclistSecond(out)
 endfunction
 
 " Show free variables of selection
@@ -222,19 +219,19 @@ function! go#oracle#Freevars(selected)
     endif
 
     let out = s:RunOracle('freevars', a:selected, 0)
-    call s:qflistSecond(out)
+    call s:loclistSecond(out)
 endfunction
 
 " Show send/receive corresponding to selected channel op
 function! go#oracle#ChannelPeers(selected)
     let out = s:RunOracle('peers', a:selected, 1)
-    call s:qflistSecond(out)
+    call s:loclistSecond(out)
 endfunction
 
 " Show all refs to entity denoted by selected identifier
 function! go#oracle#Referrers(selected)
     let out = s:RunOracle('referrers', a:selected, 0)
-    call s:qflistSecond(out)
+    call s:loclistSecond(out)
 endfunction
 
 " vim:ts=4:sw=4:et

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -13,7 +13,6 @@ function! go#rename#Rename(bang, ...)
         let to = a:1
     endif
 
-
     "return with a warning if the bin doesn't exist
     let bin_path = go#path#CheckBinPath(g:go_gorename_bin) 
     if empty(bin_path) 
@@ -31,20 +30,23 @@ function! go#rename#Rename(bang, ...)
     let clean = split(out, '\n')
 
     if v:shell_error
-        call go#tool#ShowErrors(out)
-        let errors = getqflist()
-        call go#util#Cwindow(len(errors))
+        let errors = go#tool#ParseErrors(split(out, '\n'))
+        call go#list#Populate(errors)
+        call go#list#Window(len(errors))
         if !empty(errors) && !a:bang
-            cc 1 "jump to first error if there is any
+            call go#list#JumpToFirst()
         endif
         return
     else
-        call setqflist([])
-        call go#util#Cwindow()
+        call go#list#Clean()
+        call go#list#Window()
         redraw | echon "vim-go: " | echohl Function | echon clean[0] | echohl None
     endif
 
     " refresh the buffer so we can see the new content
+    " TODO(arslan): also find all other buffers and refresh them too. For this
+    " we need a way to get the list of changes from gorename upon an success
+    " change.
     silent execute ":e"
 endfunction
 

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -65,33 +65,6 @@ function! go#tool#ParseErrors(lines)
     return errors
 endfunction
 
-
-function! go#tool#ShowErrors(out)
-    " cd into the current files directory. This is important so fnamemodify
-    " does create a full path for outputs when the token is only a single file
-    " name (such as for a go test output, i.e.: 'demo_test.go'). For other
-    " outputs, such as 'go install' we already get an absolute path (i.e.:
-    " '../foo/foo.go') and fnamemodify successfuly creates the full path.
-    let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
-    let current_dir = getcwd()
-    execute cd . fnameescape(expand("%:p:h"))
-
-    let errors = go#tool#ParseErrors(split(a:out, '\n'))
-
-    " return back to old dir once we are finished with populating the errors
-    execute cd . fnameescape(current_dir)
-
-    if !empty(errors)
-        call setqflist(errors, 'r')
-        return
-    endif
-
-    if empty(errors)
-        " Couldn't detect error format, output errors
-        echo a:out
-    endif
-endfunction
-
 function! go#tool#ExecuteInDir(cmd) abort
     let old_gopath = $GOPATH
     let $GOPATH = go#path#Detect()

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -40,19 +40,10 @@ function! go#tool#Imports()
     return imports
 endfunction
 
-function! go#tool#ShowErrors(out)
-    " cd into the current files directory. This is important so fnamemodify
-    " does create a full path for outputs when the token is only a single file
-    " name (such as for a go test output, i.e.: 'demo_test.go'). For other
-    " outputs, such as 'go install' we already get an absolute path (i.e.:
-    " '../foo/foo.go') and fnamemodify successfuly creates the full path.
-    let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
-    let current_dir = getcwd()
-    execute cd . fnameescape(expand("%:p:h"))
-
+function! go#tool#ParseErrors(lines)
     let errors = []
 
-    for line in split(a:out, '\n')
+    for line in a:lines
         let fatalerrors = matchlist(line, '^\(fatal error:.*\)$')
         let tokens = matchlist(line, '^\s*\(.\{-}\):\(\d\+\):\s*\(.*\)')
 
@@ -70,6 +61,22 @@ function! go#tool#ShowErrors(out)
             endif
         endif
     endfor
+
+    return errors
+endfunction
+
+
+function! go#tool#ShowErrors(out)
+    " cd into the current files directory. This is important so fnamemodify
+    " does create a full path for outputs when the token is only a single file
+    " name (such as for a go test output, i.e.: 'demo_test.go'). For other
+    " outputs, such as 'go install' we already get an absolute path (i.e.:
+    " '../foo/foo.go') and fnamemodify successfuly creates the full path.
+    let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
+    let current_dir = getcwd()
+    execute cd . fnameescape(expand("%:p:h"))
+
+    let errors = go#tool#ParseErrors(split(a:out, '\n'))
 
     " return back to old dir once we are finished with populating the errors
     execute cd . fnameescape(current_dir)

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -57,33 +57,3 @@ function! go#util#Shelljoin(arglist, ...)
 		return join(map(copy(a:arglist), 'shellescape(v:val)'), ' ')
 	endif
 endfunction
-
-
-" Cwindow opens the quickfix window with the given height up to 10 lines
-" maximum. Otherwise g:go_quickfix_height is used. If no or zero height is
-" given it closes the window
-function! go#util#Cwindow(...)
-    " we don't use cwindow to close the quickfix window as we need also the
-    " ability to resize the window. So, we are going to use copen and cclose
-    " for a better user experience. If the number of errors in a current
-    " quickfix list increases/decreases, cwindow will not resize when a new
-    " updated height is passed. copen in the other hand resizes the screen.
-    if !a:0 || a:1 == 0
-        cclose
-        return
-    endif
-
-    let height = get(g:, "go_quickfix_height", 0)
-    if height == 0
-        " prevent creating a large quickfix height for a large set of numbers
-        if a:1 > 10
-            let height = 10
-        else
-            let height = a:1
-        endif
-    endif
-
-    exe 'copen '. height
-endfunction
-
-" vim:ts=4:sw=4:et

--- a/compiler/go.vim
+++ b/compiler/go.vim
@@ -21,8 +21,12 @@ else
     CompilerSet makeprg=go\ build
 endif
 
-" Define the patterns that will be recognized by QuickFix when parsing the output of GoRun.
-" More information at http://vimdoc.sourceforge.net/htmldoc/quickfix.html#errorformat
+" Define the patterns that will be recognized by QuickFix when parsing the
+" output of Go command that use this errorforamt (when called make, cexpr or
+" lmake, lexpr). This is the global errorformat, however some command might
+" use a different output, for those we define them directly and modify the
+" errorformat ourselves. More information at:
+" http://vimdoc.sourceforge.net/htmldoc/quickfix.html#errorformat
 CompilerSet errorformat =%-G#\ %.%#                   " Ignore lines beginning with '#' ('# command-line-arguments' line sometimes appears?)
 CompilerSet errorformat+=%-G%.%#panic:\ %m            " Ignore lines containing 'panic: message'
 CompilerSet errorformat+=%Ecan\'t\ load\ package:\ %m " Start of multiline error string is 'can\'t load package'

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -887,14 +887,14 @@ seconds.
 >
   let g:go_metalinter_deadline = "5s"
 <
-                                                  *'g:go_location_height'*
+                                                  *'g:go_loclist_height'*
 
 Specifies the current location list height for all location lists. The default
 value (empty) sets automatically the height to the number of errors (maximum
 up to 10 errors to prevent large heights). Setting the value explicitly
 overrides this behavior. To get default Vim behavior set it to 10.
 >
-  let g:go_location_height = 0
+  let g:go_loclist_height = 0
 
 ===============================================================================
 TROUBLESHOOTING                                         *go-troubleshooting*

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -33,29 +33,38 @@ support, improved syntax highlighting, go toolchain commands, etc... It's
 highly customizable and each individual feature can be disabled/enabled
 easily.
 
-  * Improved Syntax highlighting, such as Functions, Operators, Methods..
+  * Improved Syntax highlighting with items such as Functions, Operators, Methods.
   * Auto completion support via `gocode`
-  * Better `gofmt` on save, keeps cursor position and doesn't break your undo
+  * Better `gofmt` on save, which keeps cursor position and doesn't break your undo
     history
-  * Go to symbol/declaration with `godef`
-  * Look up documentation with `godoc` inside Vim or open it in browser.
-  * Automatically import packages via `goimports`
-  * Compile and `go build` your package, install it with `go install`
-  * `go run` quickly your current file/files
-  * Run `go test` and see any errors in quickfix window
-  * Create a coverage profile and display annotated source code in browser to
-    see which functions are covered.
-  * Lint your code with `golint`
-  * Run your code trough `go vet` to catch static errors.
-  * Advanced source analysis tool with `oracle`
-  * Precise type-safe renaming of identifiers with `gorename`
+  * Go to symbol/declaration with `:GoDef`
+  * Look up documentation with `:GoDoc` inside Vim or open it in browser
+  * Automatically import packages via `:GoImport` or plug it into autosave
+  * Compile your package with `:GoBuild`, install it with `:GoInstall` or test
+    them with `:GoTest` (also supports running single tests via `:GoTestFunc`)
+  * Quickly execute your current file/files with `:GoRun`
+  * Automatic `GOPATH` detection based on the directory structure (i.e. `gb`
+    projects, `godep` vendored projects)
+  * Change or display `GOPATH` with `:GoPath`
+  * Create a coverage profile and display annotated source code in browser to see
+    which functions are covered with `:GoCoverage`
+  * Call `gometalinter` with `:GoMetaLinter`, which invokes all possible linters
+    (golint, vet, errcheck, deadcode, etc..) and shows the warnings/errors
+  * Lint your code with `:GoLint`
+  * Run your code through `:GoVet` to catch static errors
+  * Advanced source analysis tools utilizing oracle, such as `:GoImplements`,
+    `:GoCallees`, and `:GoReferrers`
+  * Precise type-safe renaming of identifiers with `:GoRename`
   * List all source files and dependencies
-  * Checking with `errcheck` for unchecked errors.
-  * Integrated and improved snippets. Supports `ultisnips` or `neosnippet`
-  * Share your current code to play.golang.org
-  * On-the-fly type information about the word under the cursor
+  * Unchecked error checking with `:GoErrCheck`
+  * Integrated and improved snippets, supporting `ultisnips` or `neosnippet`
+  * Share your current code to [play.golang.org](http://play.golang.org) with `:GoPlay`
+  * On-the-fly type information about the word under the cursor. Plug it into
+    your custom vim function.
   * Tagbar support to show tags of the source code in a sidebar with `gotags`
-  * Custom vim text objects, such a `a function` or `inner function`
+  * Custom vim text objects such as `a function` or `inner function`
+  * All commands support collecting and displaying errors in Vim's location
+  list.
 
 ===============================================================================
 INSTALL                                                           *go-install*
@@ -257,7 +266,7 @@ COMMANDS                                                          *go-commands*
 :GoTest[!] [expand]
 
     Run the tests on your _test.go files via in your current directory. Errors
-    are populated in quickfix window.  If an argument is passed, 'expand' is
+    are populated in location list.  If an argument is passed, 'expand' is
     used as file selector (useful for cases like `:GoTest ./...`).
 
     You may optionally pass any valid go test flags/options. For a full list
@@ -285,7 +294,7 @@ COMMANDS                                                          *go-commands*
 :GoTestCompile[!] [expand]
 
     Compile your _test.go files via in your current directory. Errors are
-    populated in quickfix window.  If an argument is passed, 'expand' is used
+    populated in location list.  If an argument is passed, 'expand' is used
     as file selector (useful for cases like `:GoTest ./...`). Useful to not
     run the tests and capture/fix errors before running the tests or to
     create test binary.
@@ -307,7 +316,7 @@ COMMANDS                                                          *go-commands*
 :GoErrCheck [options]
 
     Check for unchecked errors in you current package. Errors are populated in
-    quickfix window.
+    location list.
 
     You may optionally pass any valid errcheck flags/options. For a full list
     please see `errcheck -h`.
@@ -340,7 +349,7 @@ COMMANDS                                                          *go-commands*
 
     Show 'implements' relation for a selected package. A list of interfaces
     for the type that implements an interface under the cursor (or selected
-    package) is shown quickfix list.
+    package) is shown location list.
                                                                 *:GoRename*
 :GoRename[!] [to]
 
@@ -363,13 +372,13 @@ COMMANDS                                                          *go-commands*
 
     Show 'callees' relation for a selected package. A list of possible call
     targets for the type under the cursor (or selected package) is shown in a
-    quickfix list.
+    location list.
 
                                                               *:GoCallers*
 :GoCallers
 
     Show 'callers' relation for a selected function. A list of possible
-    callers for the selected function under the cursor is shown in a quickfix
+    callers for the selected function under the cursor is shown in a location
     list.
 
                                                               *:GoDescribe*
@@ -386,7 +395,7 @@ COMMANDS                                                          *go-commands*
 
     Shows 'callstack' relation for the selected function. An arbitrary path
     from the root of the callgraph to the selected function is showed in a
-    quickfix list. This may be useful to understand how the function is
+    location list. This may be useful to understand how the function is
     reached in a given program.
 
                                                               *:GoFreevars*
@@ -426,7 +435,7 @@ COMMANDS                                                          *go-commands*
 :GoMetaLinter [path]
 
     Calls the underlying `gometalinter` tool and displays all warnings and
-    errors in a quickfix window. By default the following linters are enabled:
+    errors in a location list. By default the following linters are enabled:
     "'vet', 'golint', 'errcheck'". This can be changed with the
     |g:go_metalinter_enabled| variable. To override the command completely use
     the variable |g:go_metalinter_command|. To override the maximum linters
@@ -681,7 +690,7 @@ is empty. >
 
                                                    *'g:go_fmt_fail_silently'*
 
-Use this option to disable showing a quickfix window when |g:go_fmt_command|
+Use this option to disable showing a location list when |g:go_fmt_command|
 fails. By default it's disabled. >
 
   let g:go_fmt_fail_silently = 0
@@ -878,14 +887,14 @@ seconds.
 >
   let g:go_metalinter_deadline = "5s"
 <
-                                                  *'g:go_quickfix_height'*
+                                                  *'g:go_location_height'*
 
-Specifies the current quickfix height for all quickfix windows. The default
+Specifies the current location list height for all location lists. The default
 value (empty) sets automatically the height to the number of errors (maximum
 up to 10 errors to prevent large heights). Setting the value explicitly
 overrides this behavior. To get default Vim behavior set it to 10.
 >
-  let g:go_quickfix_height = 0
+  let g:go_location_height = 0
 
 ===============================================================================
 TROUBLESHOOTING                                         *go-troubleshooting*


### PR DESCRIPTION
Add support for `location list` instead of using `quickfix window`. This allows us to let each window having it's own list of errors displaying. Below is an example of it:

![image 2015-11-26 at 7 04 03 pm](https://cloud.githubusercontent.com/assets/438920/11428147/f9bfb0f4-9470-11e5-8df6-e0ef21606edd.png)

Because of consistency, the previous setting: `go_quickfix_height` is renamed to `go_loclist_height`. (the single breaking change we have)

This is a feature I really like. I also refactored all error parsing, populating, displaying, etc.. functions into a single file to make maintaining much more easier in the future. 

