### PR TITLE
Add deoplete source

### DIFF
--- a/rplugin/python3/deoplete/sources/go.py
+++ b/rplugin/python3/deoplete/sources/go.py
@@ -1,0 +1,20 @@
+import deoplete.util
+
+from .base import Base
+
+class Source(Base):
+    def __init__(self, vim):
+        Base.__init__(self, vim)
+
+        self.name = 'go'
+        self.mark = '[go]'
+        self.filetypes = ['go']
+        self.rank = 100
+        self.min_pattern_length = 0
+        self.is_bytepos = True
+
+    def get_complete_position(self, context):
+        return self.vim.call('go#complete#Complete', 1, 0)
+
+    def gather_candidates(self, context, **kwargs):
+        return self.vim.call('go#complete#Complete', 0, 0)


### PR DESCRIPTION
Add python file for deoplete.nvim.

deoplete is, 

> Dark powered asynchronous completion framework for neovim

https://github.com/Shougo/deoplete.nvim/

It will display the completion list faster than parse `omnifunc`.

===

FYI, Now it will be override completion list in omnifunc by the implementation of deoplete.
but, If this PR is merged, @Shougo takes care of editing the deoplete side.