### PR TITLE
Add additional metalinter options

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -864,7 +864,20 @@ Adds custom text objects. By default it's enabled. >
 
 	let g:go_textobj_enabled = 1
 <
+                                                 *'g:go_metalinter_autosave'*
 
+Use this option to auto |:GoMetaLinter| on save. Only linter messages for
+the active buffer will be shown. By default it's disabled >
+
+  let g:go_metalinter_autosave = 0
+<
+                                         *'g:go_metalinter_autosave_enabled'*
+
+Specifies the enabled linters for auto |GoMetaLinter| on save. By
+default it's using `vet` and `golint`
+>
+  let g:go_metalinter_autosave_enabled = ['vet', 'golint']
+<
                                                   *'g:go_metalinter_enabled'*
 
 Specifies the currently enabled linters for the |GoMetaLinter| command. By

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -48,7 +48,7 @@ command! -nargs=1 -bang -complete=customlist,go#package#Complete GoImport call g
 command! -nargs=* -bang -complete=customlist,go#package#Complete GoImportAs call go#import#SwitchImport(1, <f-args>, '<bang>')
 
 " -- linters
-command! -nargs=* GoMetaLinter call go#lint#Gometa(<f-args>)
+command! -nargs=* GoMetaLinter call go#lint#Gometa(0, <f-args>)
 command! -nargs=* GoLint call go#lint#Golint(<f-args>)
 command! -nargs=* -bang GoVet call go#lint#Vet(<bang>0, <f-args>)
 command! -nargs=* -complete=customlist,go#package#Complete GoErrCheck call go#lint#Errcheck(<f-args>)

--- a/ftplugin/go/mappings.vim
+++ b/ftplugin/go/mappings.vim
@@ -46,7 +46,7 @@ nnoremap <silent> <Plug>(go-doc-vertical) :<C-u>call go#doc#Open("vnew", "vsplit
 nnoremap <silent> <Plug>(go-doc-split) :<C-u>call go#doc#Open("new", "split")<CR>
 nnoremap <silent> <Plug>(go-doc-browser) :<C-u>call go#doc#OpenBrowser()<CR>
 
-nnoremap <silent> <Plug>(go-metalinter) :<C-u>call go#lint#Gometa('')<CR>
+nnoremap <silent> <Plug>(go-metalinter) :<C-u>call go#lint#Gometa(0)<CR>
 nnoremap <silent> <Plug>(go-vet) :<C-u>call go#lint#Vet(!g:go_jump_to_error)<CR>
 
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -133,6 +133,11 @@ augroup vim-go
         autocmd BufWritePre *.go call go#fmt#Format(-1)
     endif
 
+    " run gometalinter on save
+    if get(g:, "go_metalinter_autosave", 0)
+        autocmd BufWritePost *.go call go#lint#Gometa(1)
+    endif
+
 augroup END
 
 


### PR DESCRIPTION
1. Add the option to run the metalinter on save
2. Add the option to limit the output to the currently active buffer

There is a outstanding PR with the `gometalinter` repo to add some needed logic for this: https://github.com/alecthomas/gometalinter/pull/71 So I assume this PR should not be merged before that one is merged.

Also this the first vimscript code I’ve ever written, so I guess this could be done a little cleaner. Especially the implementation of the `go#lint#GometaAutoSave` func doesn’t feel all that clean to me, but I’m not sure how to do this in a different/better way. So if you have any pointers, I’ll be happy to take them :wink: