### PR TITLE
:GoInstallBinaries now installs godoc as well.

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -9,6 +9,7 @@ let g:go_loaded_install = 1
 " needed by the user with GoInstallBinaries
 let s:packages = [
             \ "github.com/nsf/gocode",
+            \ "golang.org/x/tools/cmd/godoc",
             \ "github.com/alecthomas/gometalinter", 
             \ "golang.org/x/tools/cmd/goimports",
             \ "github.com/rogpeppe/godef",


### PR DESCRIPTION
Otherwise the built-in `:GoDoc` command doesn't work if you try to bootstrap the necessary Go packages *only* by using `:GoInstallBinaries` from inside Vim.