### PR TITLE
Fix empty key when GoRun.

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -99,6 +99,9 @@ function! go#cmd#Run(bang, ...)
 
     for item in items
         let filename = bufname(item.bufnr)
+        if filename == ''
+            continue
+        endif
         if !has_key(is_readable, filename)
             let is_readable[filename] = filereadable(filename)
         endif


### PR DESCRIPTION
This will prevent "Cannot use empty key for Dictionary." error

I encounter this when running GoRun cmd.