### PR TITLE
tool: add back valid items to the filter

### DIFF
--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -85,7 +85,8 @@ function! go#tool#FilterValids(items)
         elseif has_key(item, 'filename')
             let filename = item.filename
         else
-            echohl Identifier | echon "no filename available" | echohl None
+            " nothing to do, add item back to the list
+            call add(filtered, item)
             continue
         endif
 


### PR DESCRIPTION
Lines without a filenames are actually valid, they belong to multiline
messages. Therefore just add them back as we assume they are a
continuation of the previous message.

fixes #650 