### PR TITLE
gorename: Output original error if error parsing fails.

### DIFF
--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -35,6 +35,9 @@ function! go#rename#Rename(bang, ...)
         call go#list#Window(len(errors))
         if !empty(errors) && !a:bang
             call go#list#JumpToFirst()
+        elseif empty(errors)
+            " failed to parse errors, output the original content
+            call go#util#EchoError(out)
         endif
         return
     else


### PR DESCRIPTION
Gorename errors were getting swallowed up if we failed to parse them.

Fixes #664.