### PR TITLE
GoTest: Output original message on failure return code

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -195,6 +195,9 @@ function! go#cmd#Test(bang, compile, ...)
         call go#list#Window(len(errors))
         if !empty(errors) && !a:bang
             call go#list#JumpToFirst()
+        elseif empty(errors)
+            " failed to parse errors, output the original content
+            call go#util#EchoError(out)
         endif
         echon "vim-go: " | echohl ErrorMsg | echon "[test] FAIL" | echohl None
     else


### PR DESCRIPTION
When using jobcontrol, assume FAILED if return code is >0. Only prints the first line.

This one is a little messier than the GoRename fix. The non-jobcontrol semantics aren't identical, as it prints the entire output rather than just the first line (but it's more consistent with the GoRename fix).

Let me know if you'd like for me to change it to be consistent. The output on unexpected test failures is typically a panic/timeout, so it's quite big.