### PR TITLE
Adding in go_highlight_interfaces option, to provide the same highlig…

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ To change it:
 let g:go_highlight_functions = 1
 let g:go_highlight_methods = 1
 let g:go_highlight_structs = 1
+let g:go_highlight_interfaces = 1
 let g:go_highlight_operators = 1
 let g:go_highlight_build_constraints = 1
 ```

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -833,6 +833,12 @@ Highlights struct names. By default it's disabled. >
 
 	let g:go_highlight_structs = 0
 <
+                                               *'g:go_highlight_interfaces'*
+
+Highlights interface names. By default it's disabled. >
+
+  let g:go_highlight_interfaces = 0
+<
                                         *'g:go_highlight_build_constraints'*
 
 Highlights build constraints. By default it's disabled. >

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -69,6 +69,10 @@ if !exists("g:go_highlight_structs")
   let g:go_highlight_structs = 0
 endif
 
+if !exists("g:go_highlight_interfaces")
+  let g:go_highlight_interfaces = 0
+endif
+
 if !exists("g:go_highlight_build_constraints")
   let g:go_highlight_build_constraints = 0
 endif
@@ -290,6 +294,14 @@ if g:go_highlight_structs != 0
 endif
 hi def link     goStruct            Function
 hi def link     goStructDef         Function
+
+" Interfaces;
+if g:go_highlight_interfaces != 0
+  syn match goInterface             /\(.\)\@<=\w\+\({\)\@=/
+  syn match goInterfaceDef          /\(type\s\+\)\@<=\w\+\(\s\+interface\s\+{\)\@=/
+endif
+hi def link     goInterface         Function
+hi def link     goInterfaceDef      Function
 
 " Build Constraints
 if g:go_highlight_build_constraints != 0


### PR DESCRIPTION
…hting option that structs have

I need to add documentation updates, but this is basically just applying the same approach as structs, but for interfaces. It highlights them the same color as structs - open to suggestions on that, but I had no strong opinion on it.

Tested locally using NeoBundle pointed at my branch.