### PR TITLE
complete: show identifier information after completion is done

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -87,7 +87,7 @@ fu! s:gocodeCurrentBufferOpt(filename)
     return '-in=' . a:filename
 endf
 
-fu! s:gocodeCursor()
+fu! go#complete#gocodeCursor()
     if &encoding != 'utf-8'
         let sep = &l:fileformat == 'dos' ? "\r\n" : "\n"
         let c = col('.')
@@ -95,6 +95,7 @@ fu! s:gocodeCursor()
         let buf .= c == 1 ? "" : getline('.')[:c-2]
         return printf('%d', len(iconv(buf, &encoding, "utf-8")))
     endif
+
     return printf('%d', line2byte(line('.')) + (col('.')-2))
 endf
 
@@ -102,16 +103,16 @@ fu! s:gocodeAutocomplete()
     let filename = s:gocodeCurrentBuffer()
     let result = s:gocodeCommand('autocomplete',
                 \ [s:gocodeCurrentBufferOpt(filename), '-f=vim'],
-                \ [expand('%:p'), s:gocodeCursor()])
+                \ [expand('%:p'), go#complete#gocodeCursor()])
     call delete(filename)
     return result
 endf
 
-function! go#complete#GetInfo()
+function! go#complete#GetInfoFromOffset(offset)
     let filename = s:gocodeCurrentBuffer()
     let result = s:gocodeCommand('autocomplete',
                 \ [s:gocodeCurrentBufferOpt(filename), '-f=godit'],
-                \ [expand('%:p'), s:gocodeCursor()])
+                \ [expand('%:p'), a:offset])
     call delete(filename)
 
     " first line is: Charcount,,NumberOfCandidates, i.e: 8,,1
@@ -145,6 +146,11 @@ function! go#complete#GetInfo()
     endif
 
     return ""
+endfunction
+
+function! go#complete#GetInfo()
+    let offset = go#complete#gocodeCursor()
+    return go#complete#GetInfoFromOffset(offset)
 endfunction
 
 function! go#complete#Info()

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -122,9 +122,16 @@ endfunction
 " ============================================================================
 "
 function! s:echo_go_info()
-    let offset = go#complete#gocodeCursor()
-    let result = go#complete#GetInfoFromOffset(offset-1)
-    redraws! | echo "vim-go: " | echohl Function | echon result | echohl None
+    if !exists('v:completed_item') || empty(v:completed_item)
+        return
+    endif
+    let item = v:completed_item
+
+    if !has_key(item, "info")
+        return
+    endif
+
+    redraws! | echo "vim-go: " | echohl Function | echon item.info | echohl None
 endfunction
 
 augroup vim-go
@@ -135,6 +142,8 @@ augroup vim-go
         autocmd CursorHold *.go nested call go#complete#Info()
     endif
 
+    " Echo the identifier information when completion is done. Useful to see
+    " the signature of a function, etc...
     autocmd CompleteDone *.go nested call s:echo_go_info()
 
     " Go code formatting on save

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -119,6 +119,12 @@ endfunction
 
 " Autocommands
 " ============================================================================
+"
+function! s:echo_go_info()
+    let offset = go#complete#gocodeCursor()
+    let result = go#complete#GetInfoFromOffset(offset-1)
+    echo "vim-go: " | echohl Function | echon result | echohl None
+endfunction
 
 augroup vim-go
     autocmd!
@@ -127,6 +133,8 @@ augroup vim-go
     if get(g:, "go_auto_type_info", 0)
         autocmd CursorHold *.go nested call go#complete#Info()
     endif
+
+    autocmd CompleteDone *.go nested call s:echo_go_info()
 
     " code formatting on save
     if get(g:, "go_fmt_autosave", 1)

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -144,7 +144,9 @@ augroup vim-go
 
     " Echo the identifier information when completion is done. Useful to see
     " the signature of a function, etc...
-    autocmd CompleteDone *.go nested call s:echo_go_info()
+    if exists('##CompleteDone')
+        autocmd CompleteDone *.go nested call s:echo_go_info()
+    endif
 
     " Go code formatting on save
     if get(g:, "go_fmt_autosave", 1)

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -123,7 +123,7 @@ endfunction
 function! s:echo_go_info()
     let offset = go#complete#gocodeCursor()
     let result = go#complete#GetInfoFromOffset(offset-1)
-    echo "vim-go: " | echohl Function | echon result | echohl None
+    redraws! | echo "vim-go: " | echohl Function | echon result | echohl None
 endfunction
 
 augroup vim-go


### PR DESCRIPTION
This is a new feature that prints the information of the completed identifier in statusline. This is experimental.


![](http://f.cl.ly/items/133V371j1d0G1V2z2V13/Screen%20Recording%202016-01-15%20at%2008.52%20PM.gif)


closes #663