### PR TITLE
Neovim integration for GoCoverage

### DIFF
--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -2,6 +2,10 @@
 " internal function s:spawn
 let s:jobs = {}
 
+" s:handlers is a global event handlers for all jobs started with Spawn() or
+" with the internal function s:spawn
+let s:handlers = {}
+
 " Spawn is a wrapper around s:spawn. It can be executed by other files and
 " scripts if needed. Desc defines the description for printing the status
 " during the job execution (useful for statusline integration).
@@ -34,6 +38,22 @@ function! go#jobcontrol#Statusline() abort
   endfor
 
   return ''
+endfunction
+
+" AddHandler adds a on_exit callback handler and returns the id.
+function! go#jobcontrol#AddHandler(handler)
+  let i = len(s:handlers)
+  while has_key(s:handlers, string(i))
+    let i += 1
+    break
+  endwhile
+  let s:handlers[string(i)] = a:handler
+  return string(i)
+endfunction
+
+" RemoveHandler removes a callback handler by id.
+function! go#jobcontrol#RemoveHandler(id)
+  unlet s:handlers[a:id]
 endfunction
 
 " spawn spawns a go subcommand with the name and arguments with jobstart. Once
@@ -101,6 +121,7 @@ function! s:on_exit(job_id, exit_status)
 
     let self.state = "SUCCESS"
     call go#util#EchoSuccess("SUCCESS")
+    call s:callback_handlers_on_exit(s:jobs[a:job_id], a:exit_status, std_combined)
     return
   endif
 
@@ -120,6 +141,7 @@ function! s:on_exit(job_id, exit_status)
   if !len(errors)
     " failed to parse errors, output the original content
     call go#util#EchoError(std_combined[0])
+    call s:callback_handlers_on_exit(s:jobs[a:job_id], a:exit_status, std_combined)
     return
   endif
 
@@ -132,6 +154,18 @@ function! s:on_exit(job_id, exit_status)
       call go#list#JumpToFirst(l:listtype)
     endif
   endif
+  call s:callback_handlers_on_exit(s:jobs[a:job_id], a:exit_status, std_combined)
+endfunction
+
+" callback_handlers_on_exit runs all handlers for job on exit event.
+function! s:callback_handlers_on_exit(job, exit_status, data)
+  if empty(s:handlers)
+    return
+  endif
+
+  for s:handler in values(s:handlers)
+    call s:handler(a:job, a:exit_status, a:data)
+  endfor
 endfunction
 
 " on_stdout is the stdout handler for jobstart(). It collects the output of


### PR DESCRIPTION
Hi, I'm working on nvim integration of my coverage plugin: https://github.com/t-yuki/vim-go-coverlay
However, I've realized that go#cmd#GoCoverage is not integrated with nvim yet and several API changes are required for better integration.

Moreover, I guess that a recent change 579dd89f broke go#cmd#GoTestFunc because go#util#Shelllist also escapes "-run" flag.

So I want to include changes:

* cmd: fix GoTestFunc is not working
* cmd: show testing and test pass message in GoTest on neovim
* jobcontrol: add AddHandler and RemoveHandler API to catch on_exit callback for callers of caller
* cmd: add neovim integration for GoCoverage

However, I used ugly event handler method to track job status by go#cmd#GoTest and go#cmd#GoCoverage function. Another solution is welcome.

refs #607 