### PR TITLE
support configurable list types

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ disabled/enabled easily.
 * Go asm formatting on save
 * Tagbar support to show tags of the source code in a sidebar with `gotags`
 * Custom vim text objects such as `a function` or `inner function`
-* All commands support collecting and displaying errors in Vim's location
   list.
 * A async launcher for the go command is implemented for Neovim, fully async
   building and testing (beta).
@@ -212,18 +211,6 @@ By default when `:GoInstallBinaries` is called, the binaries are installed to
 ```vim
 let g:go_bin_path = expand("~/.gotools")
 let g:go_bin_path = "/home/fatih/.mypath"      "or give absolute path
-```
-
-### Location list navigation
-
-All commands support collecting and displaying errors in Vim's location list.
-
-Quickly navigate through these location lists with `:lne` for next error and `:lp`
-for previous.  You can also bind these to keys, for example:
-
-```vim
-map <C-n> :lne<CR>
-map <C-m> :lp<CR>
 ```
 
 ### Using with Neovim (beta)

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -37,6 +37,7 @@ function! go#cmd#Build(bang, ...)
     let default_makeprg = &makeprg
     let &makeprg = "go " . join(args, ' ')
 
+    let l:quickfix = go#list#Type(1)
     " execute make inside the source folder so we can parse the errors
     " correctly
     let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
@@ -46,20 +47,22 @@ function! go#cmd#Build(bang, ...)
         if g:go_dispatch_enabled && exists(':Make') == 2
             call go#util#EchoProgress("building dispatched ...")
             silent! exe 'Make'
-        else
+        elseif l:quickfix == 0
             silent! exe 'lmake!'
+        else
+            silent! exe 'make!'
         endif
         redraw!
     finally
         execute cd . fnameescape(dir)
     endtry
 
-    let errors = go#list#Get()
-    call go#list#Window(len(errors))
+    let errors = go#list#Get(l:quickfix)
+    call go#list#Window(l:quickfix, len(errors))
 
     if !empty(errors)
         if !a:bang
-            call go#list#JumpToFirst()
+            call go#list#JumpToFirst(l:quickfix)
         endif
     else
         call go#util#EchoSuccess("[build] SUCCESS")
@@ -109,19 +112,23 @@ function! go#cmd#Run(bang, ...)
         let &makeprg = "go run " . go#util#Shelljoin(map(copy(a:000), "expand(v:val)"), 1)
     endif
 
+    let l:quickfix = go#list#Type(1)
+
     if g:go_dispatch_enabled && exists(':Make') == 2
         silent! exe 'Make'
+    elseif l:quickfix == 0
+        silent! exe 'lmake!'
     else
-        exe 'lmake!'
+        silent! exe 'make!'
     endif
 
-    let items = go#list#Get()
+    let items = go#list#Get(l:quickfix)
     let errors = go#tool#FilterValids(items)
 
-    call go#list#Populate(errors)
-    call go#list#Window(len(errors))
+    call go#list#Populate(l:quickfix, errors)
+    call go#list#Window(l:quickfix, len(errors))
     if !empty(errors) && !a:bang
-        call go#list#JumpToFirst()
+        call go#list#JumpToFirst(l:quickfix)
     endif
 
     let $GOPATH = old_gopath
@@ -138,6 +145,7 @@ function! go#cmd#Install(bang, ...)
     let goargs = go#util#Shelljoin(map(copy(a:000), "expand(v:val)"), 1)
     let &makeprg = "go install " . goargs
 
+    let l:quickfix = go#list#Type(1)
     " execute make inside the source folder so we can parse the errors
     " correctly
     let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
@@ -147,19 +155,21 @@ function! go#cmd#Install(bang, ...)
         if g:go_dispatch_enabled && exists(':Make') == 2
             call go#util#EchoProgress("building dispatched ...")
             silent! exe 'Make'
-        else
+        elseif l:quickfix == 0
             silent! exe 'lmake!'
+        else
+            silent! exe 'make!'
         endif
         redraw!
     finally
         execute cd . fnameescape(dir)
     endtry
 
-    let errors = go#list#Get()
-    call go#list#Window(len(errors))
+    let errors = go#list#Get(l:quickfix)
+    call go#list#Window(l:quickfix, len(errors))
     if !empty(errors)
         if !a:bang
-            call go#list#JumpToFirst()
+            call go#list#JumpToFirst(l:quickfix)
         endif
     else
         redraws! | echon "vim-go: " | echohl Function | echon "installed to ". $GOPATH | echohl None
@@ -213,6 +223,8 @@ function! go#cmd#Test(bang, compile, ...)
 
     let out = go#tool#ExecuteInDir(command)
 
+    let l:quickfix = 1
+
     if v:shell_error
         let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
         let dir = getcwd()
@@ -224,18 +236,18 @@ function! go#cmd#Test(bang, compile, ...)
             execute cd . fnameescape(dir)
         endtry
 
-        call go#list#Populate(errors)
-        call go#list#Window(len(errors))
+        call go#list#Populate(l:quickfix, errors)
+        call go#list#Window(l:quickfix, len(errors))
         if !empty(errors) && !a:bang
-            call go#list#JumpToFirst()
+            call go#list#JumpToFirst(l:quickfix)
         elseif empty(errors)
             " failed to parse errors, output the original content
             call go#util#EchoError(out)
         endif
         echon "vim-go: " | echohl ErrorMsg | echon "[test] FAIL" | echohl None
     else
-        call go#list#Clean()
-        call go#list#Window()
+        call go#list#Clean(l:quickfix)
+        call go#list#Window(l:quickfix)
 
         if a:compile
             echon "vim-go: " | echohl Function | echon "[test] SUCCESS" | echohl None
@@ -281,19 +293,21 @@ function! go#cmd#Coverage(bang, ...)
 
     let command = "go test -coverprofile=" . l:tmpname . ' ' . go#util#Shelljoin(a:000)
 
+
+    let l:quickfix = 1
     call go#cmd#autowrite()
     let out = go#tool#ExecuteInDir(command)
     if v:shell_error
         let errors = go#tool#ParseErrors(split(out, '\n'))
-        call go#list#Populate(errors)
-        call go#list#Window(len(errors))
+        call go#list#Populate(l:quickfix, errors)
+        call go#list#Window(l:quickfix, len(errors))
         if !empty(errors) && !a:bang
-            call go#list#JumpToFirst()
+            call go#list#JumpToFirst(l:quickfix)
         endif
     else
         " clear previous location list 
-        call go#list#Clean()
-        call go#list#Window()
+        call go#list#Clean(l:quickfix)
+        call go#list#Window(l:quickfix)
 
         let openHTML = 'go tool cover -html='.l:tmpname
         call go#tool#ExecuteInDir(openHTML)
@@ -318,19 +332,23 @@ function! go#cmd#Generate(bang, ...)
         let &makeprg = "go generate " . goargs . ' ' . gofiles
     endif
 
+    let l:quickfix = go#list#Type(1)
+
     echon "vim-go: " | echohl Identifier | echon "generating ..."| echohl None
     if g:go_dispatch_enabled && exists(':Make') == 2
         silent! exe 'Make'
-    else
+    elseif l:quickfix == 0
         silent! exe 'lmake!'
+    else
+        silent! exe 'make!'
     endif
     redraw!
 
-    let errors = go#list#Get()
-    call go#list#Window(len(errors))
+    let errors = go#list#Get(l:quickfix)
+    call go#list#Window(l:quickfix, len(errors))
     if !empty(errors) 
         if !a:bang
-            call go#list#JumpToFirst()
+            call go#list#JumpToFirst(l:quickfix)
         endif
     else
         redraws! | echon "vim-go: " | echohl Function | echon "[generate] SUCCESS"| echohl None

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -37,7 +37,7 @@ function! go#cmd#Build(bang, ...)
     let default_makeprg = &makeprg
     let &makeprg = "go " . join(args, ' ')
 
-    let l:quickfix = go#list#Type(1)
+    let l:listtype = go#list#Type("quickfix")
     " execute make inside the source folder so we can parse the errors
     " correctly
     let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
@@ -47,7 +47,7 @@ function! go#cmd#Build(bang, ...)
         if g:go_dispatch_enabled && exists(':Make') == 2
             call go#util#EchoProgress("building dispatched ...")
             silent! exe 'Make'
-        elseif l:quickfix == 0
+        elseif l:listtype == "locationlist"
             silent! exe 'lmake!'
         else
             silent! exe 'make!'
@@ -57,12 +57,12 @@ function! go#cmd#Build(bang, ...)
         execute cd . fnameescape(dir)
     endtry
 
-    let errors = go#list#Get(l:quickfix)
-    call go#list#Window(l:quickfix, len(errors))
+    let errors = go#list#Get(l:listtype)
+    call go#list#Window(l:listtype, len(errors))
 
     if !empty(errors)
         if !a:bang
-            call go#list#JumpToFirst(l:quickfix)
+            call go#list#JumpToFirst(l:listtype)
         endif
     else
         call go#util#EchoSuccess("[build] SUCCESS")
@@ -112,23 +112,23 @@ function! go#cmd#Run(bang, ...)
         let &makeprg = "go run " . go#util#Shelljoin(map(copy(a:000), "expand(v:val)"), 1)
     endif
 
-    let l:quickfix = go#list#Type(1)
+    let l:listtype = go#list#Type("quickfix")
 
     if g:go_dispatch_enabled && exists(':Make') == 2
         silent! exe 'Make'
-    elseif l:quickfix == 0
+    elseif l:listtype == "locationlist"
         silent! exe 'lmake!'
     else
         silent! exe 'make!'
     endif
 
-    let items = go#list#Get(l:quickfix)
+    let items = go#list#Get(l:listtype)
     let errors = go#tool#FilterValids(items)
 
-    call go#list#Populate(l:quickfix, errors)
-    call go#list#Window(l:quickfix, len(errors))
+    call go#list#Populate(l:listtype, errors)
+    call go#list#Window(l:listtype, len(errors))
     if !empty(errors) && !a:bang
-        call go#list#JumpToFirst(l:quickfix)
+        call go#list#JumpToFirst(l:listtype)
     endif
 
     let $GOPATH = old_gopath
@@ -145,7 +145,7 @@ function! go#cmd#Install(bang, ...)
     let goargs = go#util#Shelljoin(map(copy(a:000), "expand(v:val)"), 1)
     let &makeprg = "go install " . goargs
 
-    let l:quickfix = go#list#Type(1)
+    let l:listtype = go#list#Type("quickfix")
     " execute make inside the source folder so we can parse the errors
     " correctly
     let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
@@ -155,7 +155,7 @@ function! go#cmd#Install(bang, ...)
         if g:go_dispatch_enabled && exists(':Make') == 2
             call go#util#EchoProgress("building dispatched ...")
             silent! exe 'Make'
-        elseif l:quickfix == 0
+        elseif l:listtype == "locationlist"
             silent! exe 'lmake!'
         else
             silent! exe 'make!'
@@ -165,11 +165,11 @@ function! go#cmd#Install(bang, ...)
         execute cd . fnameescape(dir)
     endtry
 
-    let errors = go#list#Get(l:quickfix)
-    call go#list#Window(l:quickfix, len(errors))
+    let errors = go#list#Get(l:listtype)
+    call go#list#Window(l:listtype, len(errors))
     if !empty(errors)
         if !a:bang
-            call go#list#JumpToFirst(l:quickfix)
+            call go#list#JumpToFirst(l:listtype)
         endif
     else
         redraws! | echon "vim-go: " | echohl Function | echon "installed to ". $GOPATH | echohl None
@@ -223,7 +223,7 @@ function! go#cmd#Test(bang, compile, ...)
 
     let out = go#tool#ExecuteInDir(command)
 
-    let l:quickfix = 1
+    let l:listtype = "quickfix"
 
     if v:shell_error
         let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
@@ -236,18 +236,18 @@ function! go#cmd#Test(bang, compile, ...)
             execute cd . fnameescape(dir)
         endtry
 
-        call go#list#Populate(l:quickfix, errors)
-        call go#list#Window(l:quickfix, len(errors))
+        call go#list#Populate(l:listtype, errors)
+        call go#list#Window(l:listtype, len(errors))
         if !empty(errors) && !a:bang
-            call go#list#JumpToFirst(l:quickfix)
+            call go#list#JumpToFirst(l:listtype)
         elseif empty(errors)
             " failed to parse errors, output the original content
             call go#util#EchoError(out)
         endif
         echon "vim-go: " | echohl ErrorMsg | echon "[test] FAIL" | echohl None
     else
-        call go#list#Clean(l:quickfix)
-        call go#list#Window(l:quickfix)
+        call go#list#Clean(l:listtype)
+        call go#list#Window(l:listtype)
 
         if a:compile
             echon "vim-go: " | echohl Function | echon "[test] SUCCESS" | echohl None
@@ -294,20 +294,20 @@ function! go#cmd#Coverage(bang, ...)
     let command = "go test -coverprofile=" . l:tmpname . ' ' . go#util#Shelljoin(a:000)
 
 
-    let l:quickfix = 1
+    let l:listtype = "quickfix"
     call go#cmd#autowrite()
     let out = go#tool#ExecuteInDir(command)
     if v:shell_error
         let errors = go#tool#ParseErrors(split(out, '\n'))
-        call go#list#Populate(l:quickfix, errors)
-        call go#list#Window(l:quickfix, len(errors))
+        call go#list#Populate(l:listtype, errors)
+        call go#list#Window(l:listtype, len(errors))
         if !empty(errors) && !a:bang
-            call go#list#JumpToFirst(l:quickfix)
+            call go#list#JumpToFirst(l:listtype)
         endif
     else
         " clear previous location list 
-        call go#list#Clean(l:quickfix)
-        call go#list#Window(l:quickfix)
+        call go#list#Clean(l:listtype)
+        call go#list#Window(l:listtype)
 
         let openHTML = 'go tool cover -html='.l:tmpname
         call go#tool#ExecuteInDir(openHTML)
@@ -332,23 +332,23 @@ function! go#cmd#Generate(bang, ...)
         let &makeprg = "go generate " . goargs . ' ' . gofiles
     endif
 
-    let l:quickfix = go#list#Type(1)
+    let l:listtype = go#list#Type("quickfix")
 
     echon "vim-go: " | echohl Identifier | echon "generating ..."| echohl None
     if g:go_dispatch_enabled && exists(':Make') == 2
         silent! exe 'Make'
-    elseif l:quickfix == 0
+    elseif l:listtype == "locationlist"
         silent! exe 'lmake!'
     else
         silent! exe 'make!'
     endif
     redraw!
 
-    let errors = go#list#Get(l:quickfix)
-    call go#list#Window(l:quickfix, len(errors))
+    let errors = go#list#Get(l:listtype)
+    call go#list#Window(l:listtype, len(errors))
     if !empty(errors) 
         if !a:bang
-            call go#list#JumpToFirst(l:quickfix)
+            call go#list#JumpToFirst(l:listtype)
         endif
     else
         redraws! | echon "vim-go: " | echohl Function | echon "[generate] SUCCESS"| echohl None

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -105,6 +105,7 @@ function! go#fmt#Format(withGoimport)
         let $GOPATH = old_gopath
     endif
 
+    let l:quickfix = 0
     "if there is no error on the temp file replace the output with the current
     "file (if this fails, we can always check the outputs first line with:
     "splitted =~ 'package \w\+')
@@ -122,8 +123,8 @@ function! go#fmt#Format(withGoimport)
         " clean up previous location list, but only if it's due fmt
         if s:got_fmt_error 
             let s:got_fmt_error = 0
-            call go#list#Clean()
-            call go#list#Window()
+            call go#list#Clean(l:quickfix)
+            call go#list#Window(l:quickfix)
         endif
     elseif g:go_fmt_fail_silently == 0 
         let splitted = split(out, '\n')
@@ -142,12 +143,12 @@ function! go#fmt#Format(withGoimport)
             % | " Couldn't detect gofmt error format, output errors
         endif
         if !empty(errors)
-            call go#list#Populate(errors)
+            call go#list#Populate(l:quickfix, errors)
             echohl Error | echomsg "Gofmt returned error" | echohl None
         endif
 
         let s:got_fmt_error = 1
-        call go#list#Window(len(errors))
+        call go#list#Window(l:quickfix, len(errors))
 
         " We didn't use the temp file, so clean up
         call delete(l:tmpname)

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -105,7 +105,7 @@ function! go#fmt#Format(withGoimport)
         let $GOPATH = old_gopath
     endif
 
-    let l:quickfix = 0
+    let l:listtype = "locationlist"
     "if there is no error on the temp file replace the output with the current
     "file (if this fails, we can always check the outputs first line with:
     "splitted =~ 'package \w\+')
@@ -123,8 +123,8 @@ function! go#fmt#Format(withGoimport)
         " clean up previous location list, but only if it's due fmt
         if s:got_fmt_error 
             let s:got_fmt_error = 0
-            call go#list#Clean(l:quickfix)
-            call go#list#Window(l:quickfix)
+            call go#list#Clean(l:listtype)
+            call go#list#Window(l:listtype)
         endif
     elseif g:go_fmt_fail_silently == 0 
         let splitted = split(out, '\n')
@@ -143,12 +143,12 @@ function! go#fmt#Format(withGoimport)
             % | " Couldn't detect gofmt error format, output errors
         endif
         if !empty(errors)
-            call go#list#Populate(l:quickfix, errors)
+            call go#list#Populate(l:listtype, errors)
             echohl Error | echomsg "Gofmt returned error" | echohl None
         endif
 
         let s:got_fmt_error = 1
-        call go#list#Window(l:quickfix, len(errors))
+        call go#list#Window(l:listtype, len(errors))
 
         " We didn't use the temp file, so clean up
         call delete(l:tmpname)

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -96,8 +96,8 @@ endfunction
 function! s:on_exit(job_id, exit_status)
   let std_combined = self.stderr + self.stdout
   if a:exit_status == 0
-    call go#list#Clean()
-    call go#list#Window()
+    call go#list#Clean(0)
+    call go#list#Window(0)
 
     let self.state = "SUCCESS"
     call go#util#EchoSuccess("SUCCESS")
@@ -125,10 +125,11 @@ function! s:on_exit(job_id, exit_status)
 
   " if we are still in the same windows show the list
   if self.winnr == winnr()
-    call go#list#Populate(errors)
-    call go#list#Window(len(errors))
+    let l:quickfix = 0
+    call go#list#Populate(l:quickfix, errors)
+    call go#list#Window(l:quickfix, len(errors))
     if !empty(errors) && !self.bang
-      call go#list#JumpToFirst()
+      call go#list#JumpToFirst(l:quickfix)
     endif
   endif
 endfunction

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -125,11 +125,11 @@ function! s:on_exit(job_id, exit_status)
 
   " if we are still in the same windows show the list
   if self.winnr == winnr()
-    let l:quickfix = 0
-    call go#list#Populate(l:quickfix, errors)
-    call go#list#Window(l:quickfix, len(errors))
+    let l:listtype = "locationlist"
+    call go#list#Populate(l:listtype, errors)
+    call go#list#Window(l:listtype, len(errors))
     if !empty(errors) && !self.bang
-      call go#list#JumpToFirst(l:quickfix)
+      call go#list#JumpToFirst(l:listtype)
     endif
   endif
 endfunction

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -63,10 +63,11 @@ function! go#lint#Gometa(autosave, ...) abort
 
     let out = go#tool#ExecuteInDir(meta_command)
 
+    let l:quickfix = 1
     if v:shell_error == 0
         redraw | echo
-        call go#list#Clean()
-        call go#list#Window()
+        call go#list#Clean(l:quickfix)
+        call go#list#Window(l:quickfix)
         echon "vim-go: " | echohl Function | echon "[metalinter] PASS" | echohl None
     else
         " GoMetaLinter can output one of the two, so we look for both:
@@ -76,13 +77,13 @@ function! go#lint#Gometa(autosave, ...) abort
         let errformat = "%f:%l:%c:%t%*[^:]:\ %m,%f:%l::%t%*[^:]:\ %m"
 
         " Parse and populate our location list
-        call go#list#ParseFormat(errformat, split(out, "\n"))
+        call go#list#ParseFormat(l:quickfix, errformat, split(out, "\n"))
 
-        let errors = go#list#Get()
-        call go#list#Window(len(errors))
+        let errors = go#list#Get(l:quickfix)
+        call go#list#Window(l:quickfix, len(errors))
 
         if !a:autosave
-            call go#list#JumpToFirst()
+            call go#list#JumpToFirst(l:quickfix)
         endif
     endif
 endfunction
@@ -107,10 +108,11 @@ function! go#lint#Golint(...) abort
         return
     endif
 
-    call go#list#Parse(out)
-    let errors = go#list#Get()
-    call go#list#Window(len(errors))
-    call go#list#JumpToFirst()
+    let l:quickfix = 1
+    call go#list#Parse(l:quickfix, out)
+    let errors = go#list#Get(l:quickfix)
+    call go#list#Window(l:quickfix, len(errors))
+    call go#list#JumpToFirst(l:quickfix)
 endfunction
 
 " Vet calls 'go vet' on the current directory. Any warnings are populated in
@@ -123,17 +125,19 @@ function! go#lint#Vet(bang, ...)
     else
         let out = go#tool#ExecuteInDir('go tool vet ' . go#util#Shelljoin(a:000))
     endif
+
+    let l:quickfix = 1
     if v:shell_error
         let errors = go#tool#ParseErrors(split(out, '\n'))
-        call go#list#Populate(errors)
-        call go#list#Window(len(errors))
+        call go#list#Populate(l:quickfix, errors)
+        call go#list#Window(l:quickfix, len(errors))
         if !empty(errors) && !a:bang
-            call go#list#JumpToFirst()
+            call go#list#JumpToFirst(l:quickfix)
         endif
         echon "vim-go: " | echohl ErrorMsg | echon "[vet] FAIL" | echohl None
     else
-        call go#list#Clean()
-        call go#list#Window()
+        call go#list#Clean(l:quickfix)
+        call go#list#Window(l:quickfix)
         redraw | echon "vim-go: " | echohl Function | echon "[vet] PASS" | echohl None
     endif
 endfunction
@@ -162,13 +166,14 @@ function! go#lint#Errcheck(...) abort
     let command = bin_path . ' -abspath ' . goargs
     let out = go#tool#ExecuteInDir(command)
 
+    let l:quickfix = 1
     if v:shell_error
         let errformat = "%f:%l:%c:\ %m, %f:%l:%c\ %#%m"
 
         " Parse and populate our location list
-        call go#list#ParseFormat(errformat, split(out, "\n"))
+        call go#list#ParseFormat(l:quickfix, errformat, split(out, "\n"))
 
-        let errors = go#list#Get()
+        let errors = go#list#Get(l:quickfix)
 
         if empty(errors)
             echohl Error | echomsg "GoErrCheck returned error" | echohl None
@@ -177,15 +182,15 @@ function! go#lint#Errcheck(...) abort
         endif
 
         if !empty(errors)
-            call go#list#Populate(errors)
-            call go#list#Window(len(errors))
+            call go#list#Populate(l:quickfix, errors)
+            call go#list#Window(l:quickfix, len(errors))
             if !empty(errors)
-                call go#list#JumpToFirst()
+                call go#list#JumpToFirst(l:quickfix)
             endif
         endif
     else
-        call go#list#Clean()
-        call go#list#Window()
+        call go#list#Clean(l:quickfix)
+        call go#list#Window(l:quickfix)
         echon "vim-go: " | echohl Function | echon "[errcheck] PASS" | echohl None
     endif
 

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -63,11 +63,11 @@ function! go#lint#Gometa(autosave, ...) abort
 
     let out = go#tool#ExecuteInDir(meta_command)
 
-    let l:quickfix = 1
+    let l:listtype = "quickfix"
     if v:shell_error == 0
         redraw | echo
-        call go#list#Clean(l:quickfix)
-        call go#list#Window(l:quickfix)
+        call go#list#Clean(l:listtype)
+        call go#list#Window(l:listtype)
         echon "vim-go: " | echohl Function | echon "[metalinter] PASS" | echohl None
     else
         " GoMetaLinter can output one of the two, so we look for both:
@@ -77,13 +77,13 @@ function! go#lint#Gometa(autosave, ...) abort
         let errformat = "%f:%l:%c:%t%*[^:]:\ %m,%f:%l::%t%*[^:]:\ %m"
 
         " Parse and populate our location list
-        call go#list#ParseFormat(l:quickfix, errformat, split(out, "\n"))
+        call go#list#ParseFormat(l:listtype, errformat, split(out, "\n"))
 
-        let errors = go#list#Get(l:quickfix)
-        call go#list#Window(l:quickfix, len(errors))
+        let errors = go#list#Get(l:listtype)
+        call go#list#Window(l:listtype, len(errors))
 
         if !a:autosave
-            call go#list#JumpToFirst(l:quickfix)
+            call go#list#JumpToFirst(l:listtype)
         endif
     endif
 endfunction
@@ -108,11 +108,11 @@ function! go#lint#Golint(...) abort
         return
     endif
 
-    let l:quickfix = 1
-    call go#list#Parse(l:quickfix, out)
-    let errors = go#list#Get(l:quickfix)
-    call go#list#Window(l:quickfix, len(errors))
-    call go#list#JumpToFirst(l:quickfix)
+    let l:listtype = "quickfix"
+    call go#list#Parse(l:listtype, out)
+    let errors = go#list#Get(l:listtype)
+    call go#list#Window(l:listtype, len(errors))
+    call go#list#JumpToFirst(l:listtype)
 endfunction
 
 " Vet calls 'go vet' on the current directory. Any warnings are populated in
@@ -126,18 +126,18 @@ function! go#lint#Vet(bang, ...)
         let out = go#tool#ExecuteInDir('go tool vet ' . go#util#Shelljoin(a:000))
     endif
 
-    let l:quickfix = 1
+    let l:listtype = "quickfix"
     if v:shell_error
         let errors = go#tool#ParseErrors(split(out, '\n'))
-        call go#list#Populate(l:quickfix, errors)
-        call go#list#Window(l:quickfix, len(errors))
+        call go#list#Populate(l:listtype, errors)
+        call go#list#Window(l:listtype, len(errors))
         if !empty(errors) && !a:bang
-            call go#list#JumpToFirst(l:quickfix)
+            call go#list#JumpToFirst(l:listtype)
         endif
         echon "vim-go: " | echohl ErrorMsg | echon "[vet] FAIL" | echohl None
     else
-        call go#list#Clean(l:quickfix)
-        call go#list#Window(l:quickfix)
+        call go#list#Clean(l:listtype)
+        call go#list#Window(l:listtype)
         redraw | echon "vim-go: " | echohl Function | echon "[vet] PASS" | echohl None
     endif
 endfunction
@@ -166,14 +166,14 @@ function! go#lint#Errcheck(...) abort
     let command = bin_path . ' -abspath ' . goargs
     let out = go#tool#ExecuteInDir(command)
 
-    let l:quickfix = 1
+    let l:listtype = "quickfix"
     if v:shell_error
         let errformat = "%f:%l:%c:\ %m, %f:%l:%c\ %#%m"
 
         " Parse and populate our location list
-        call go#list#ParseFormat(l:quickfix, errformat, split(out, "\n"))
+        call go#list#ParseFormat(l:listtype, errformat, split(out, "\n"))
 
-        let errors = go#list#Get(l:quickfix)
+        let errors = go#list#Get(l:listtype)
 
         if empty(errors)
             echohl Error | echomsg "GoErrCheck returned error" | echohl None
@@ -182,15 +182,15 @@ function! go#lint#Errcheck(...) abort
         endif
 
         if !empty(errors)
-            call go#list#Populate(l:quickfix, errors)
-            call go#list#Window(l:quickfix, len(errors))
+            call go#list#Populate(l:listtype, errors)
+            call go#list#Window(l:listtype, len(errors))
             if !empty(errors)
-                call go#list#JumpToFirst(l:quickfix)
+                call go#list#JumpToFirst(l:listtype)
             endif
         endif
     else
-        call go#list#Clean(l:quickfix)
-        call go#list#Window(l:quickfix)
+        call go#list#Clean(l:listtype)
+        call go#list#Window(l:listtype)
         echon "vim-go: " | echohl Function | echon "[errcheck] PASS" | echohl None
     endif
 

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -5,15 +5,15 @@ endif
 " Window opens the list with the given height up to 10 lines maximum.
 " Otherwise g:go_loclist_height is used. If no or zero height is given it
 " closes the window
-function! go#list#Window(quickfix, ...)
-    let l:quickfix = go#list#Type(a:quickfix)
+function! go#list#Window(listtype, ...)
+    let l:listtype = go#list#Type(a:listtype)
     " we don't use lwindow to close the location list as we need also the
     " ability to resize the window. So, we are going to use lopen and lclose
     " for a better user experience. If the number of errors in a current
     " location list increases/decreases, cwindow will not resize when a new
     " updated height is passed. lopen in the other hand resizes the screen.
     if !a:0 || a:1 == 0
-        if l:quickfix == 0
+        if l:listtype == "locationlist"
             lclose
         else
             cclose
@@ -31,7 +31,7 @@ function! go#list#Window(quickfix, ...)
         endif
     endif
 
-    if l:quickfix == 0
+    if l:listtype == "locationlist"
       exe 'lopen ' . height
     else
       exe 'copen ' . height
@@ -40,9 +40,9 @@ endfunction
 
 
 " Get returns the current list of items from the location list
-function! go#list#Get(quickfix)
-    let l:quickfix = go#list#Type(a:quickfix)
-    if l:quickfix == 0
+function! go#list#Get(listtype)
+    let l:listtype = go#list#Type(a:listtype)
+    if l:listtype == "locationlist"
         return getloclist(0)
     else
         return getqflist()
@@ -50,9 +50,9 @@ function! go#list#Get(quickfix)
 endfunction
 
 " Populate populate the location list with the given items
-function! go#list#Populate(quickfix, items)
-    let l:quickfix = go#list#Type(a:quickfix)
-    if l:quickfix == 0
+function! go#list#Populate(listtype, items)
+    let l:listtype = go#list#Type(a:listtype)
+    if l:listtype == "locationlist"
         call setloclist(0, a:items, 'r')
     else
         call setqflist(a:items, 'r')
@@ -65,14 +65,14 @@ endfunction
 
 " Parse parses the given items based on the specified errorformat nad
 " populates the location list.
-function! go#list#ParseFormat(quickfix, errformat, items)
-    let l:quickfix = go#list#Type(a:quickfix)
+function! go#list#ParseFormat(listtype, errformat, items)
+    let l:listtype = go#list#Type(a:listtype)
     " backup users errorformat, will be restored once we are finished
     let old_errorformat = &errorformat
 
     " parse and populate the location list
     let &errorformat = a:errformat
-    if l:quickfix == 0
+    if l:listtype == "locationlist"
         lgetexpr a:items
     else
         cgetexpr a:items
@@ -84,9 +84,9 @@ endfunction
 
 " Parse parses the given items based on the global errorformat and
 " populates the location list.
-function! go#list#Parse(quickfix, items)
-    let l:quickfix = go#list#Type(a:quickfix)
-    if l:quickfix == 0
+function! go#list#Parse(listtype, items)
+    let l:listtype = go#list#Type(a:listtype)
+    if l:listtype == "locationlist"
         lgetexpr a:items
     else
         cgetexpr a:items
@@ -94,9 +94,9 @@ function! go#list#Parse(quickfix, items)
 endfunction
 
 " JumpToFirst jumps to the first item in the location list
-function! go#list#JumpToFirst(quickfix)
-    let l:quickfix = go#list#Type(a:quickfix)
-    if l:quickfix == 0
+function! go#list#JumpToFirst(listtype)
+    let l:listtype = go#list#Type(a:listtype)
+    if l:listtype == "locationlist"
         ll 1
     else
         cc 1
@@ -104,22 +104,22 @@ function! go#list#JumpToFirst(quickfix)
 endfunction
 
 " Clean cleans the location list
-function! go#list#Clean(quickfix)
-    let l:quickfix = go#list#Type(a:quickfix)
-    if l:quickfix == 0
+function! go#list#Clean(listtype)
+    let l:listtype = go#list#Type(a:listtype)
+    if l:listtype == "locationlist"
         lex []
     else
         cex []
     endif
 endfunction
 
-function! go#list#Type(quickfix)
+function! go#list#Type(listtype)
     if g:go_list_type == "locationlist"
-        return 0
+        return "locationlist"
     elseif g:go_list_type == "quickfix"
-        return 1
+        return "quickfix" 
     else
-        return a:quickfix
+        return a:listtype
     endif
 endfunction
 

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -1,18 +1,27 @@
-" Window opens the location list with the given height up to 10 lines maximum.
+if !exists("g:go_list_type")
+    let g:go_list_type = ""
+endif
+
+" Window opens the list with the given height up to 10 lines maximum.
 " Otherwise g:go_loclist_height is used. If no or zero height is given it
 " closes the window
-function! go#list#Window(...)
+function! go#list#Window(quickfix, ...)
+    let l:quickfix = go#list#Type(a:quickfix)
     " we don't use lwindow to close the location list as we need also the
-    " ability to resize the window. So, we are going to use lopen and cclose
+    " ability to resize the window. So, we are going to use lopen and lclose
     " for a better user experience. If the number of errors in a current
     " location list increases/decreases, cwindow will not resize when a new
     " updated height is passed. lopen in the other hand resizes the screen.
     if !a:0 || a:1 == 0
-        lclose
+        if l:quickfix == 0
+            lclose
+        else
+            cclose
+        endif
         return
     endif
 
-    let height = get(g:, "go_loclist_height", 0)
+    let height = get(g:, "go_list_height", 0)
     if height == 0
         " prevent creating a large location height for a large set of numbers
         if a:1 > 10
@@ -22,50 +31,96 @@ function! go#list#Window(...)
         endif
     endif
 
-    exe 'lopen '. height
+    if l:quickfix == 0
+      exe 'lopen ' . height
+    else
+      exe 'copen ' . height
+    endif
 endfunction
 
 
 " Get returns the current list of items from the location list
-function! go#list#Get()
-  return getloclist(0)
+function! go#list#Get(quickfix)
+    let l:quickfix = go#list#Type(a:quickfix)
+    if l:quickfix == 0
+        return getloclist(0)
+    else
+        return getqflist()
+    endif
 endfunction
 
 " Populate populate the location list with the given items
-function! go#list#Populate(items)
-	call setloclist(0, a:items, 'r')
+function! go#list#Populate(quickfix, items)
+    let l:quickfix = go#list#Type(a:quickfix)
+    if l:quickfix == 0
+        call setloclist(0, a:items, 'r')
+    else
+        call setqflist(a:items, 'r')
+    endif
 endfunction
 
 function! go#list#PopulateWin(winnr, items)
-	call setloclist(a:winnr, a:items, 'r')
+    call setloclist(a:winnr, a:items, 'r')
 endfunction
 
 " Parse parses the given items based on the specified errorformat nad
 " populates the location list.
-function! go#list#ParseFormat(errformat, items)
-  " backup users errorformat, will be restored once we are finished
-  let old_errorformat = &errorformat
+function! go#list#ParseFormat(quickfix, errformat, items)
+    let l:quickfix = go#list#Type(a:quickfix)
+    " backup users errorformat, will be restored once we are finished
+    let old_errorformat = &errorformat
 
-	" parse and populate the location list
-  let &errorformat = a:errformat
-	lgetexpr a:items
+    " parse and populate the location list
+    let &errorformat = a:errformat
+    if l:quickfix == 0
+        lgetexpr a:items
+    else
+        cgetexpr a:items
+    endif
 
-	"restore back
-  let &errorformat = old_errorformat
+    "restore back
+    let &errorformat = old_errorformat
 endfunction
 
-" Parse parses the given items based on the global errorformat nad
+" Parse parses the given items based on the global errorformat and
 " populates the location list.
-function! go#list#Parse(items)
-	lgetexpr a:items
+function! go#list#Parse(quickfix, items)
+    let l:quickfix = go#list#Type(a:quickfix)
+    if l:quickfix == 0
+        lgetexpr a:items
+    else
+        cgetexpr a:items
+    endif
 endfunction
 
 " JumpToFirst jumps to the first item in the location list
-function! go#list#JumpToFirst()
-  ll 1 
+function! go#list#JumpToFirst(quickfix)
+    let l:quickfix = go#list#Type(a:quickfix)
+    if l:quickfix == 0
+        ll 1
+    else
+        cc 1
+    endif
 endfunction
 
 " Clean cleans the location list
-function! go#list#Clean()
-	lex []
+function! go#list#Clean(quickfix)
+    let l:quickfix = go#list#Type(a:quickfix)
+    if l:quickfix == 0
+        lex []
+    else
+        cex []
+    endif
 endfunction
+
+function! go#list#Type(quickfix)
+    if g:go_list_type == "locationlist"
+        return 0
+    elseif g:go_list_type == "quickfix"
+        return 1
+    else
+        return a:quickfix
+    endif
+endfunction
+
+" vim:ts=4:sw=4:et

--- a/autoload/go/oracle.vim
+++ b/autoload/go/oracle.vim
@@ -35,8 +35,8 @@ func! s:loclist(output)
         endif
         call add(llist, item)
     endfor
-    call go#list#Populate(llist)
-    call go#list#Window(len(llist))
+    call go#list#Populate(0, llist)
+    call go#list#Window(0, len(llist))
 endfun
 
 " This uses Vim's errorformat to parse the output from Oracle's 'plain output
@@ -56,10 +56,10 @@ func! s:loclistSecond(output)
     " useful and location only has the ability to show one line and column
     " number
     let errformat = "%f:%l.%c-%[%^:]%#:\ %m,%f:%l:%c:\ %m"
-    call go#list#ParseFormat(errformat, split(a:output, "\n"))
+    call go#list#ParseFormat(0, errformat, split(a:output, "\n"))
 
-    let errors = go#list#Get()
-    call go#list#Window(len(errors))
+    let errors = go#list#Get(0)
+    call go#list#Window(0, len(errors))
 endfun
 
 func! s:getpos(l, c)

--- a/autoload/go/oracle.vim
+++ b/autoload/go/oracle.vim
@@ -35,8 +35,8 @@ func! s:loclist(output)
         endif
         call add(llist, item)
     endfor
-    call go#list#Populate(0, llist)
-    call go#list#Window(0, len(llist))
+    call go#list#Populate("locationlist", llist)
+    call go#list#Window("locationlist", len(llist))
 endfun
 
 " This uses Vim's errorformat to parse the output from Oracle's 'plain output
@@ -56,10 +56,10 @@ func! s:loclistSecond(output)
     " useful and location only has the ability to show one line and column
     " number
     let errformat = "%f:%l.%c-%[%^:]%#:\ %m,%f:%l:%c:\ %m"
-    call go#list#ParseFormat(0, errformat, split(a:output, "\n"))
+    call go#list#ParseFormat("locationlist", errformat, split(a:output, "\n"))
 
-    let errors = go#list#Get(0)
-    call go#list#Window(0, len(errors))
+    let errors = go#list#Get("locationlist")
+    call go#list#Window("locationlist", len(errors))
 endfun
 
 func! s:getpos(l, c)

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -40,20 +40,21 @@ function! go#rename#Rename(bang, ...)
     " will trigger the 'Hit ENTER to continue' prompt
     let clean = split(out, '\n')
 
+    let l:quickfix = 1
     if v:shell_error
         let errors = go#tool#ParseErrors(split(out, '\n'))
-        call go#list#Populate(errors)
-        call go#list#Window(len(errors))
+        call go#list#Populate(l:quickfix, errors)
+        call go#list#Window(l:quickfix, len(errors))
         if !empty(errors) && !a:bang
-            call go#list#JumpToFirst()
+            call go#list#JumpToFirst(l:quickfix)
         elseif empty(errors)
             " failed to parse errors, output the original content
             call go#util#EchoError(out)
         endif
         return
     else
-        call go#list#Clean()
-        call go#list#Window()
+        call go#list#Clean(l:quickfix)
+        call go#list#Window(l:quickfix)
         redraw | echon "vim-go: " | echohl Function | echon clean[0] | echohl None
     endif
 

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -40,21 +40,21 @@ function! go#rename#Rename(bang, ...)
     " will trigger the 'Hit ENTER to continue' prompt
     let clean = split(out, '\n')
 
-    let l:quickfix = 1
+    let l:listtype = "quickfix"
     if v:shell_error
         let errors = go#tool#ParseErrors(split(out, '\n'))
-        call go#list#Populate(l:quickfix, errors)
-        call go#list#Window(l:quickfix, len(errors))
+        call go#list#Populate(l:listtype, errors)
+        call go#list#Window(l:listtype, len(errors))
         if !empty(errors) && !a:bang
-            call go#list#JumpToFirst(l:quickfix)
+            call go#list#JumpToFirst(l:listtype)
         elseif empty(errors)
             " failed to parse errors, output the original content
             call go#util#EchoError(out)
         endif
         return
     else
-        call go#list#Clean(l:quickfix)
-        call go#list#Window(l:quickfix)
+        call go#list#Clean(l:listtype)
+        call go#list#Window(l:listtype)
         redraw | echon "vim-go: " | echohl Function | echon clean[0] | echohl None
     endif
 

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -98,11 +98,11 @@ function! s:on_exit(job_id, data)
     endif
     let job = s:jobs[a:job_id]
 
-    let l:quickfix = 0
+    let l:listtype = "locationlist"
     " usually there is always output so never branch into this clause
     if empty(job.stdout)
-        call go#list#Clean(l:quickfix)
-        call go#list#Window(l:quickfix)
+        call go#list#Clean(l:listtype)
+        call go#list#Window(l:listtype)
     else
         let errors = go#tool#ParseErrors(job.stdout)
         let errors = go#tool#FilterValids(errors)
@@ -110,14 +110,14 @@ function! s:on_exit(job_id, data)
             " close terminal we don't need it
             close 
 
-            call go#list#Populate(l:quickfix, errors)
-            call go#list#Window(l:quickfix, len(errors))
+            call go#list#Populate(l:listtype, errors)
+            call go#list#Window(l:listtype, len(errors))
             if !self.bang
-                call go#list#JumpToFirst(l:quickfix)
+                call go#list#JumpToFirst(l:listtype)
             endif
         else
-            call go#list#Clean(l:quickfix)
-            call go#list#Window(l:quickfix)
+            call go#list#Clean(l:listtype)
+            call go#list#Window(l:listtype)
         endif
 
     endif

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -98,10 +98,11 @@ function! s:on_exit(job_id, data)
     endif
     let job = s:jobs[a:job_id]
 
+    let l:quickfix = 0
     " usually there is always output so never branch into this clause
     if empty(job.stdout)
-        call go#list#Clean()
-        call go#list#Window()
+        call go#list#Clean(l:quickfix)
+        call go#list#Window(l:quickfix)
     else
         let errors = go#tool#ParseErrors(job.stdout)
         let errors = go#tool#FilterValids(errors)
@@ -109,14 +110,14 @@ function! s:on_exit(job_id, data)
             " close terminal we don't need it
             close 
 
-            call go#list#Populate(errors)
-            call go#list#Window(len(errors))
+            call go#list#Populate(l:quickfix, errors)
+            call go#list#Window(l:quickfix, len(errors))
             if !self.bang
-                call go#list#JumpToFirst()
+                call go#list#JumpToFirst(l:quickfix)
             endif
         else
-            call go#list#Clean()
-            call go#list#Window()
+            call go#list#Clean(l:quickfix)
+            call go#list#Window(l:quickfix)
         endif
 
     endif

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -65,8 +65,6 @@ easily.
   * Go asm formatting on save
   * Tagbar support to show tags of the source code in a sidebar with `gotags`
   * Custom vim text objects such as `a function` or `inner function`
-  * All commands support collecting and displaying errors in Vim's location
-    list
   * A async launcher for the go command is implemented for neovim, fully async
     building and testing.
   * Integrated with the neovim terminal, launch `:GoRun` and other go commands
@@ -237,9 +235,9 @@ COMMANDS                                                          *go-commands*
                                                                    *:GoBuild*
 :GoBuild[!] [expand]
 
-    Build your package with `go build`. Errors are populated inside the
-    location list. It automatically builds only the files that depends on the
-    current file. `:GoBuild` doesn't produce a result file.
+    Build your package with `go build`. Errors are populated in the quickfix
+    window. It automatically builds only the files that depends on the current
+    file. `:GoBuild` doesn't produce a result file.
     Use 'make' to create a result file.
 
     You may optionally pass any valid go build flags/options. For a full list
@@ -282,8 +280,8 @@ COMMANDS                                                          *go-commands*
 :GoTest[!] [expand]
 
     Run the tests on your _test.go files via in your current directory. Errors
-    are populated in location list.  If an argument is passed, 'expand' is
-    used as file selector (useful for cases like `:GoTest ./...`).
+    are populated in the quickfix window.  If an argument is passed, 'expand'
+    is used as file selector (useful for cases like `:GoTest ./...`).
 
     You may optionally pass any valid go test flags/options. For a full list
     please see `go help test`.
@@ -318,9 +316,9 @@ COMMANDS                                                          *go-commands*
 :GoTestCompile[!] [expand]
 
     Compile your _test.go files via in your current directory. Errors are
-    populated in location list.  If an argument is passed, 'expand' is used
-    as file selector (useful for cases like `:GoTest ./...`). Useful to not
-    run the tests and capture/fix errors before running the tests or to
+    populated in the quickfix window.  If an argument is passed, 'expand' is
+    used as file selector (useful for cases like `:GoTest ./...`). Useful to
+    not run the tests and capture/fix errors before running the tests or to
     create test binary.
 
     If [!] is not given the first error is jumped to.
@@ -344,7 +342,7 @@ COMMANDS                                                          *go-commands*
 :GoErrCheck [options]
 
     Check for unchecked errors in you current package. Errors are populated in
-    location list.
+    the quickfix window.
 
     You may optionally pass any valid errcheck flags/options. For a full list
     please see `errcheck -h`.
@@ -377,7 +375,7 @@ COMMANDS                                                          *go-commands*
 
     Show 'implements' relation for a selected package. A list of interfaces
     for the type that implements an interface under the cursor (or selected
-    package) is shown location list.
+    package) is shown in a location list.
                                                                 *:GoRename*
 :GoRename[!] [to]
 
@@ -422,7 +420,7 @@ COMMANDS                                                          *go-commands*
 :GoCallstack
 
     Shows 'callstack' relation for the selected function. An arbitrary path
-    from the root of the callgraph to the selected function is showed in a
+    from the root of the callgraph to the selected function is shown in a
     location list. This may be useful to understand how the function is
     reached in a given program.
 
@@ -463,8 +461,8 @@ COMMANDS                                                          *go-commands*
 :GoMetaLinter [path]
 
     Calls the underlying `gometalinter` tool and displays all warnings and
-    errors in a location list. By default the following linters are enabled:
-    "'vet', 'golint', 'errcheck'". This can be changed with the
+    errors in the quickfix window. By default the following linters are
+    enabled: "'vet', 'golint', 'errcheck'". This can be changed with the
     |g:go_metalinter_enabled| variable. To override the command completely use
     the variable |g:go_metalinter_command|. To override the maximum linters
     execution time use |g:go_metalinter_deadline| variable.
@@ -1000,14 +998,22 @@ seconds.
 >
   let g:go_metalinter_deadline = "5s"
 <
-                                                  *'g:go_loclist_height'*
+                                                  *'g:go_list_height'*
 
-Specifies the current location list height for all location lists. The default
-value (empty) automatically sets the height to the number of errors (maximum
-up to 10 errors to prevent large heights). Setting the value explicitly
-overrides this behavior. For standard Vim behavior, set it to 10.
+Specifies the window height for the quickfix and location list windows. The
+default value (empty) automatically sets the height to the number of items
+(maximum up to 10 items to prevent large heights). Setting the value
+explicitly overrides this behavior. For standard Vim behavior, set it to 10.
 >
-  let g:go_loclist_height = 0
+  let g:go_list_height = 0
+<
+                                                  *'g:go_list_type'*
+
+Specifies the type of list to use. The default value (empty) will use the
+appropriate kind of list for the command that was called. Supported values are
+"", "quickfix", and "locationlist". >
+
+  let g:go_list_type = ""
 <
                                                   *'g:go_asmfmt_autosave'*
 


### PR DESCRIPTION
* Prefer the quickfix window for commands whose output is considered to
  be errors for more than current buffer. e.g. :GoBuild.

* Prefer the location list window for commands whose output is related
  specifically to the current buffer only (e.g: :GoFmt and
  :GoImplements).

* Rename 'g:go_loclist_height' to 'g:go_list_height'.

* Add a new option, 'g:go_list_type', to configure whether to always use
  the quickfix window, a location list window, or to vary based on the
  preferred window as documented above.

@fatih I'm not sure if you'd want to keep the default as I've coded it. The default here is to vary the list by the command, but that changes the 1.4 behavior, and we'd talked about preserving the 1.4 behavior by default.

I tried to update the relevant documentation where the location list was referenced to be accurate according to the preferred windows that I described above, but please double check my work.

Consider this a start point - I realize you may have lots of feedback; I'm happy to do any rework that you find necessary.

Fixes #696