### PR TITLE
go#package#Paths more efficient at getting GOROOT

### DIFF
--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -31,17 +31,19 @@ endif
 function! go#package#Paths()
     let dirs = []
 
-    if executable('go')
-        let goroot = substitute(system('go env GOROOT'), '\n', '', 'g')
-        if v:shell_error
-            echomsg '''go env GOROOT'' failed'
+    if !exists("s:goroot")
+        if executable('go')
+            let s:goroot = substitute(system('go env GOROOT'), '\n', '', 'g')
+            if v:shell_error
+                echomsg '''go env GOROOT'' failed'
+            endif
+        else
+            let s:goroot = $GOROOT
         endif
-    else
-        let goroot = $GOROOT
     endif
 
-    if len(goroot) != 0 && isdirectory(goroot)
-        let dirs += [goroot]
+    if len(s:goroot) != 0 && isdirectory(s:goroot)
+        let dirs += [s:goroot]
     endif
 
     let workspaces = split($GOPATH, go#util#PathListSep())


### PR DESCRIPTION
go#package#Paths for some reason would call go env GOROOT every single
time it needed the GOROOT. In #697 the problem was that it was calling
go to get the GOROOT every single time the statusline needed an update
which resulted in the flashing cursor. Now it only calls it once and
stores it in a script local variable.