### PR TITLE
:GoAlternate and related documentation/mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ disabled/enabled easily.
   building and testing (beta).
 * Integrated with the Neovim terminal, launch `:GoRun` and other go commands
   in their own new terminal. (beta)
+* Alternate between implementation and test code with `:GoAlternate`
 
 ## Install
 
@@ -241,7 +242,7 @@ au FileType go nmap <Leader>rv <Plug>(go-run-vertical)
 By default new terminals are opened in a vertical split. To change it
 
 ```vim
-let g:go_term_mode = "split"                   "or set to tab
+let g:go_term_mode = "split"
 ```
 
 By default the testing commands run asynchronously in the background and

--- a/autoload/go/alternate.vim
+++ b/autoload/go/alternate.vim
@@ -1,0 +1,30 @@
+" By default use edit (current buffer view) to switch
+if !exists("g:go_alternate_mode")
+  let g:go_alternate_mode = "edit"
+endif
+
+" Test alternates between the implementation of code and the test code.
+function! go#alternate#Switch(bang, cmd)
+  let l:file = go#alternate#Filename(fnameescape(expand("%")))
+  if !filereadable(l:file) && !a:bang
+    redraws! | echon "vim-go: " | echohl ErrorMsg | echon "couldn't find ".file | echohl None
+    return
+  elseif empty(a:cmd)
+    execute ":" . g:go_alternate_mode . " " . file
+  else
+    execute ":" . a:cmd . " " . file
+  endif
+endfunction
+
+" Filename returns the name of the test file or implementation file
+" depending on the arguments
+function! go#alternate#Filename(path)
+  if empty(matchstr(a:path, "_test"))
+    let l:root = split(a:path, ".go$")[0]
+    let l:file = l:root . "_test.go"
+  else
+    let l:root = split(a:path, "_test.go$")[0]
+    let l:file = l:root . ".go"
+  endif
+  return l:file
+endfunction

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -71,6 +71,7 @@ easily.
     building and testing.
   * Integrated with the neovim terminal, launch `:GoRun` and other go commands
     in their own new terminal.
+  * Alternate between implementation and test code with `:GoAlternate`
 
 ===============================================================================
 INSTALL                                                           *go-install*
@@ -483,6 +484,16 @@ COMMANDS                                                          *go-commands*
     position and avoids replacing the buffer with stderr output.
 
 
+                                                                   *:GoAlternate*
+:GoAlternate[!]
+
+    Alternates between the implementation and test code. For example if in main.go,
+    switch to main_test.go. Uses the |g:go_alternate_mode| setting as the command
+    to open the file.
+
+    If [!] is given then it switches to the new file even if it does not exist.
+
+
 
 ===============================================================================
 MAPPINGS                                                        *go-mappings*
@@ -650,6 +661,18 @@ Show all refs to entity denoted by selected identifier
                                                             *(go-metalinter)*
 
 Calls `go-metalinter` for the current directory
+
+                                                        *(go-alternate-edit)*
+
+Alternates between the implementation and test code in the current window
+
+                                                      *(go-alternate-split)*
+
+Alternates between the implementation and test code in a new horizontal split
+
+                                                    *(go-alternate-vertical)*
+
+Alternates between the implementation and test code in a new vertical split
 
 ===============================================================================
 TEXT OBJECTS                                                 *go-text-objects*
@@ -986,9 +1009,9 @@ Use this option to auto |:AsmFmt| on save. By default it's enabled. >
 <
                                                        *g:go_term_mode*
 
-This option is neovim only. Use it to change the default terminal mode of
-go commands that run in a new terminal. The default is vsplit.
-Current options are vsplit, split or tab.
+This option is neovim only. Use it to change the default command used to
+open a new terminal for go commands such as |:GoRun|.
+The default is vsplit.
 >
   let g:go_term_mode = "vsplit"
 <
@@ -1015,6 +1038,14 @@ By default it is disabled.
 >
   let g:go_term_enabled = 0
 <
+                                                        *g:go_alternate_mode*
+
+Specifies the command that |:GoAlternate| uses to open the alternate file.
+It is by default set to edit.
+>
+  let g:go_alternate_mode = "edit"
+<
+
 
 ===============================================================================
 TROUBLESHOOTING                                         *go-troubleshooting*

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -53,4 +53,7 @@ command! -nargs=* GoLint call go#lint#Golint(<f-args>)
 command! -nargs=* -bang GoVet call go#lint#Vet(<bang>0, <f-args>)
 command! -nargs=* -complete=customlist,go#package#Complete GoErrCheck call go#lint#Errcheck(<f-args>)
 
+" -- alternate
+command! -bang GoAlternate call go#alternate#Switch(<bang>0, '')
+
 " vim:ts=4:sw=4:et

--- a/ftplugin/go/mappings.vim
+++ b/ftplugin/go/mappings.vim
@@ -8,7 +8,6 @@ if !exists("g:go_jump_to_error")
 	let g:go_jump_to_error = 1
 endif
 
-
 " Some handy plug mappings
 nnoremap <silent> <Plug>(go-run) :<C-u>call go#cmd#Run(!g:go_jump_to_error, '%')<CR>
 
@@ -56,4 +55,6 @@ nnoremap <silent> <Plug>(go-doc-browser) :<C-u>call go#doc#OpenBrowser()<CR>
 nnoremap <silent> <Plug>(go-metalinter) :<C-u>call go#lint#Gometa(0)<CR>
 nnoremap <silent> <Plug>(go-vet) :<C-u>call go#lint#Vet(!g:go_jump_to_error)<CR>
 
-
+nnoremap <silent> <Plug>(go-alternate-edit) :<C-u>call go#alternate#Switch(0, "edit")<CR>
+nnoremap <silent> <Plug>(go-alternate-vertical) :<C-u>call go#alternate#Switch(0, "vsplit")<CR>
+nnoremap <silent> <Plug>(go-alternate-split) :<C-u>call go#alternate#Switch(0, "split")<CR>

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -12,7 +12,7 @@
 "     let OPTION_NAME = 1
 "   to enable particular options.
 "   At present, all options default to on, except highlight of:
-"   functions, methods and structs.
+"   functions, methods, structs, operators, build constraints and interfaces.
 "
 "   - go_highlight_array_whitespace_error
 "     Highlights white space after "[]".


### PR DESCRIPTION
In #684 a golang alternate plugin was presented in which it was easy to
alternate between the implementation and testing code. This commit adds
support for that in vim-go. It also adds related documentation and mappings.