### PR TITLE
Indent code in Go HTML templates

### DIFF
--- a/indent/gohtmltmpl.vim
+++ b/indent/gohtmltmpl.vim
@@ -3,3 +3,42 @@ if exists("b:did_indent")
 endif
 
 runtime! indent/html.vim
+
+" Indent Golang HTML templates
+setlocal indentexpr=GetGoHTMLTmplIndent(v:lnum)
+setlocal indentkeys+==else,=end
+
+" Only define the function once.
+if exists("*GetGoHTMLTmplIndent")
+  finish
+endif
+
+function! GetGoHTMLTmplIndent(lnum)
+  " Get HTML indent
+  if exists('*HtmlIndent')
+    let ind = HtmlIndent()
+  else
+    let ind = HtmlIndentGet(a:lnum)
+  endif
+
+  " The value of a single shift-width
+  if exists('*shiftwidth')
+    let sw = shiftwidth()
+  else
+    let sw = &sw
+  endif
+
+  " If need to indent based on last line
+  let last_line = getline(a:lnum-1)
+  if last_line =~ '^\s*{{\s*\%(if\|else\|range\|with\|define\|block\).*}}'
+    let ind += sw
+  endif
+
+  " End of FuncMap block
+  let current_line = getline(a:lnum)
+  if current_line =~ '^\s*{{\s*\%(else\|end\).*}}'
+    let ind -= sw
+  endif
+
+  return ind
+endfunction


### PR DESCRIPTION
Before when write go code in templates, it is not indented correctly,  for example:

```
{{if true}}
hello world
{{end}}
```

I think this should be indented to:

```
{{if true}}
  hello world
{{end}}
```

This pull request did the job, fixed the indention for `if/else`, `range`, `with`, `block`, `define`