### PR TITLE
Documentation for the traditional alternate commands

### DIFF
--- a/autoload/go/alternate.vim
+++ b/autoload/go/alternate.vim
@@ -6,7 +6,7 @@ endif
 " Test alternates between the implementation of code and the test code.
 function! go#alternate#Switch(bang, cmd)
   let l:file = go#alternate#Filename(fnameescape(expand("%")))
-  if !filereadable(l:file) && !a:bang
+  if !filereadable(l:file) && !bufexists(l:file) && !a:bang
     redraws! | echon "vim-go: " | echohl ErrorMsg | echon "couldn't find ".file | echohl None
     return
   elseif empty(a:cmd)

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -493,7 +493,16 @@ COMMANDS                                                          *go-commands*
 
     If [!] is given then it switches to the new file even if it does not exist.
 
-
+    If you would like to override the traditional commands for alternating, add
+    the following to your .vimrc:
+>
+    augroup go
+      autocmd!
+      autocmd Filetype go command! -bang A call go#alternate#Switch(<bang>0, 'edit')
+      autocmd Filetype go command! -bang AV call go#alternate#Switch(<bang>0, 'vsplit')
+      autocmd Filetype go command! -bang AS call go#alternate#Switch(<bang>0, 'split')
+    augroup END
+<
 
 ===============================================================================
 MAPPINGS                                                        *go-mappings*


### PR DESCRIPTION
I also fixed a small bug where if the alternate file was not on the disk
but a buffer it would not switch. Now it does.