### PR TITLE
complete: fix ycm

### DIFF
--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -20,8 +20,12 @@ setlocal noexpandtab
 
 compiler go
 
-" Set gocode completion
-setlocal omnifunc=go#complete#Complete
+" Set gocode completion, but do not set if YCM exists, as it conflicts with
+" it. I wish they wouldn't implement their own omnifunc for Go from the
+" beginning.  Now everthing is a fcking mess.
+if globpath(&rtp, 'plugin/youcompleteme.vim') == ""
+    setlocal omnifunc=go#complete#Complete
+endif
 
 if get(g:, "go_doc_keywordprg_enabled", 1)
     " keywordprg doesn't allow to use vim commands, override it


### PR DESCRIPTION
Seems like YCM is setting it's own omnifunc and also started to use
gocode itself recently. This makes vim-go very slugish and also breaks
it. I really hate it as YCM tries to do a lot of things (such as
GoToDefinition). Now it's not compatible anymore with vim-go because it
tries to do the completion itself instead of letting the application do
it.