### PR TITLE
the cursor offset for goinfo has to be 1 greater than it currently is

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -149,7 +149,7 @@ function! go#complete#GetInfoFromOffset(offset)
 endfunction
 
 function! go#complete#GetInfo()
-    let offset = go#complete#gocodeCursor()
+    let offset = go#complete#gocodeCursor()+1
     return go#complete#GetInfoFromOffset(offset)
 endfunction
 


### PR DESCRIPTION
```go
package main

import (
	"log"
	"net/http"
)

type fileServer struct {
	*http.Server
}

func (s *fileServer) initializeTLS(cert, key string) {
	log.Print("hi")
}
```
Watch this short video for the explanation.

https://youtu.be/ruyVHQt9dUY

Sorry about the whispering, 5 in the morning.

This is just a quick fix, imo we need a different offset function for going as if I have my cursor on the `*` it gives me panics, the function should be smart enough to realize where the cursor should be for gocode to be successful.