### PR TITLE
Allow GoRun to accept file arguments in neovim

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -74,8 +74,12 @@ endfunction
 
 
 " Run runs the current file (and their dependencies if any) in a new terminal.
-function! go#cmd#RunTerm(bang, mode)
-    let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
+function! go#cmd#RunTerm(bang, mode, files)
+    if empty(a:files)
+        let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
+    else
+        let cmd = "go run ".  go#util#Shelljoin(map(copy(a:files), "expand(v:val)"), 1)
+    endif
     call go#term#newmode(a:bang, cmd, a:mode)
 endfunction
 
@@ -85,7 +89,7 @@ endfunction
 " calling long running apps will block the whole UI.
 function! go#cmd#Run(bang, ...)
     if has('nvim')
-        call go#cmd#RunTerm(a:bang, '')
+        call go#cmd#RunTerm(a:bang, '', a:000)
         return
     endif
 

--- a/ftplugin/go/mappings.vim
+++ b/ftplugin/go/mappings.vim
@@ -12,9 +12,9 @@ endif
 nnoremap <silent> <Plug>(go-run) :<C-u>call go#cmd#Run(!g:go_jump_to_error)<CR>
 
 if has("nvim")
-	nnoremap <silent> <Plug>(go-run-vertical) :<C-u>call go#cmd#RunTerm(!g:go_jump_to_error, 'vsplit')<CR>
-	nnoremap <silent> <Plug>(go-run-split) :<C-u>call go#cmd#RunTerm(!g:go_jump_to_error, 'split')<CR>
-	nnoremap <silent> <Plug>(go-run-tab) :<C-u>call go#cmd#RunTerm(!g:go_jump_to_error, 'tabe')<CR>
+	nnoremap <silent> <Plug>(go-run-vertical) :<C-u>call go#cmd#RunTerm(!g:go_jump_to_error, 'vsplit', [])<CR>
+	nnoremap <silent> <Plug>(go-run-split) :<C-u>call go#cmd#RunTerm(!g:go_jump_to_error, 'split', [])<CR>
+	nnoremap <silent> <Plug>(go-run-tab) :<C-u>call go#cmd#RunTerm(!g:go_jump_to_error, 'tabe', [])<CR>
 endif
 
 nnoremap <silent> <Plug>(go-build) :<C-u>call go#cmd#Build(!g:go_jump_to_error)<CR>


### PR DESCRIPTION
For some reason, we forgot about this feature in neovim. In vim you can
run `:GoRun main.go` so that other files in the same directory do not
interfere. E.g. if I have the main function defined in another file, a
bunch of random c files etc.