### PR TITLE
add support for goimports -srcdir in Format

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -100,6 +100,17 @@ function! go#fmt#Format(withGoimport)
     if a:withGoimport  != 1 
         let command  = command . g:go_fmt_options
     endif
+    if fmt_command == "goimports"
+        let out = system("goimports --help")
+        if out !~ "-srcdir"
+            echohl WarningMsg
+            echomsg "vim-go: goimports does not support srcdir."
+            echomsg "  update with: :GoUpdateBinaries"
+            echohl None
+        else
+            let command  = command . '-srcdir ' . fnameescape(expand("%:p:h"))
+        endif
+    endif
 
     " execute our command...
     let out = system(command . " " . l:tmpname)


### PR DESCRIPTION
"goimports -srcdir" fixes problems with vendoring.