### PR TITLE
fmt: use shellescape instead of fnameescape

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -127,7 +127,10 @@ function! go#fmt#Format(withGoimport)
         endif
 
         if exists('b:goimports_vendor_compatible') && b:goimports_vendor_compatible
-            let command  = command . '-srcdir ' . fnameescape(expand("%:p:h"))
+            let ssl_save = &shellslash
+            set noshellslash
+            let command  = command . '-srcdir ' . shellescape(expand("%:p:h"))
+            let &shellslash = ssl_save
         endif
     endif
 


### PR DESCRIPTION
The system command would break when a path like '/test/path (0)/ok' was
escaped with fnameescape. The shellescape function seems to handle
these cases better.