### PR TITLE
:GoDef custom Tag Stack support (#667)

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -15,8 +15,8 @@ endf
 " modified and improved version of vim-godef
 function! go#def#Jump(...)
 	if !len(a:000)
-		" gives us the offset of the word, basicall the position of the word under
-		" he cursor
+		" gives us the offset of the word, basically the position of the word under
+		" the cursor
 		let arg = s:getOffset()
 	else
 		let arg = a:1

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -188,21 +188,14 @@ function! go#def#StackPrint()
     endif
 endfunction
 
-function! go#def#StackPop(numPop)
-    let newLevel = str2nr(w:go_stack_level) - str2nr(a:numPop)
-    if newLevel < 0
-        echohl ErrorMsg
-        echo "at bottom of godef stack"
-        echohl None
-        let newLevel = 0
+function! go#def#StackPop(...)
+    if !len(a:000)
+        let numPop = 1
+    else
+        let numPop = a:1
     endif
-    if w:go_stack_level > 0
-        let w:go_stack_level = newLevel
-        let target = w:go_stack[w:go_stack_level]
-
-        " jump
-        call s:goToFileLocation(target["file"], target["line"], target["col"])
-    endif
+    let newLevel = str2nr(w:go_stack_level) - str2nr(numPop)
+    call go#def#StackJump(newLevel + 1)
 endfunction
 
 function! go#def#StackJump(...)

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -214,6 +214,15 @@ function! go#def#StackJump(...)
 		let jumpTarget= a:1
 	endif
 
+    if jumpTarget !~ '^\d\+$'
+        if jumpTarget !~ '^\s*$'
+            echohl ErrorMsg
+            echo "location must be a number"
+            echohl None
+        endif
+        return
+    endif
+
     let jumpTarget=str2nr(jumpTarget) - 1
     if jumpTarget >= 0 && jumpTarget < len(w:go_stack)
         let w:go_stack_level = jumpTarget

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -144,7 +144,7 @@ function! s:godefJump(out, mode)
         endif
 
 		" increment the stack counter
-		let w:go_stack_level = w:go_stack_level + 1
+		let w:go_stack_level += 1
 
 		" push it on to the jumpstack
         call add(w:go_stack,

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -103,9 +103,7 @@ function! s:godefJump(out, mode)
 		echom gderr
 		" Don't jump if we're in a modified buffer
 	elseif getbufvar(bufnr('%'), "&mod")
-        echohl ErrorMsg
-		echo "No write since last change"
-        echohl None
+		call go#util#EchoError("No write since last change")
 	else
 		let parts = split(a:out[0], ':')
 
@@ -158,9 +156,7 @@ endfunction
 
 function! go#def#StackPrint()
     if len(w:go_stack) == 0
-        echohl ErrorMsg
-        echo "godef stack empty"
-        echohl None
+        call go#util#EchoError("godef stack empty")
         return
     endif
     let i = 0
@@ -200,9 +196,7 @@ endfunction
 
 function! go#def#StackJump(...)
     if len(w:go_stack) == 0
-        echohl ErrorMsg
-        echo "godef stack empty"
-        echohl None
+        call go#util#EchoError("godef stack empty")
         return
     endif
 	if !len(a:000)
@@ -216,9 +210,7 @@ function! go#def#StackJump(...)
 
     if jumpTarget !~ '^\d\+$'
         if jumpTarget !~ '^\s*$'
-            echohl ErrorMsg
-            echo "location must be a number"
-            echohl None
+            call go#util#EchoError("location must be a number")
         endif
         return
     endif
@@ -231,9 +223,7 @@ function! go#def#StackJump(...)
         " jump
         call s:goToFileLocation(target["file"], target["line"], target["col"])
     else
-        echohl ErrorMsg
-        echo "invalid godef stack location"
-        echohl None
+        call go#util#EchoError("invalid godef stack location")
     endif
 endfunction
 

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -185,6 +185,14 @@ function! go#def#StackPrint()
 endfunction
 
 function! go#def#StackPop(...)
+    if len(w:go_stack) == 0
+        call go#util#EchoError("godef stack empty")
+        return
+    endif
+    if w:go_stack_level == 0
+        call go#util#EchoError("at bottom of the godef stack")
+        return
+    endif
     if !len(a:000)
         let numPop = 1
     else
@@ -223,7 +231,7 @@ function! go#def#StackJump(...)
         " jump
         call s:goToFileLocation(target["file"], target["line"], target["col"])
     else
-        call go#util#EchoError("invalid godef stack location")
+        call go#util#EchoError("invalid godef stack location. Try :GoDefJump to see the list of valid entries")
     endif
 endfunction
 

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -58,7 +58,7 @@ function! go#def#JumpMode(mode)
 	let $GOPATH = go#path#Detect()
 
 	let fname = fnamemodify(expand("%"), ':p:gs?\\?/?')
-	let command = bin_path . " -f=" . shellescape(fname) . " -i " . shellescape(arg)
+	let command = bin_path . " -t -f=" . shellescape(fname) . " -i " . shellescape(arg)
 
 	" get output of godef
 	let out = s:system(command, join(getbufline(bufnr('%'), 1, '$'), go#util#LineEnding()))

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -100,7 +100,7 @@ function! s:godefJump(out, mode)
 	" Echo the godef error if we had one.
 	if location =~ 'godef: '
 		let gderr=substitute(location, go#util#LineEnding() . '$', '', '')
-		echom gderr
+        call go#util#EchoError(gderr)
 		" Don't jump if we're in a modified buffer
 	elseif getbufvar(bufnr('%'), "&mod")
 		call go#util#EchoError("No write since last change")

--- a/autoload/go/ui.vim
+++ b/autoload/go/ui.vim
@@ -1,7 +1,12 @@
 let s:buf_nr = -1
 
 "OpenWindow opens a new scratch window and put's the content into the window
-function! go#ui#OpenWindow(title, content)
+function! go#ui#OpenWindow(title, content, filetype)
+    " Ensure there's only one return window in this session/tabpage
+    call go#util#Windo("unlet! w:vim_go_return_window")
+    " Mark the window we're leaving as such
+    let w:vim_go_return_window = 1
+
     " reuse existing buffer window if it exists otherwise create a new one
     if !bufexists(s:buf_nr)
         execute 'botright new'
@@ -14,7 +19,6 @@ function! go#ui#OpenWindow(title, content)
         execute bufwinnr(s:buf_nr) . 'wincmd w'
     endif
 
-
     " Keep minimum height to 10, if there is more just increase it that it
     " occupies all results
     let buffer_height = 10
@@ -23,38 +27,63 @@ function! go#ui#OpenWindow(title, content)
     else
         exe 'resize ' . len(a:content)
     endif
-	
-		" some sane default values for a readonly buffer
-    setlocal filetype=vimgo
+
+    execute "setlocal filetype=".a:filetype
+
+    " some sane default values for a readonly buffer
     setlocal bufhidden=delete
     setlocal buftype=nofile
     setlocal noswapfile
     setlocal nobuflisted
     setlocal winfixheight
     setlocal cursorline " make it easy to distinguish
+    setlocal nonumber
+    setlocal norelativenumber
+    setlocal showbreak=""
 
     " we need this to purge the buffer content
     setlocal modifiable
 
     "delete everything first from the buffer
-    %delete _  
+    %delete _
 
     " add the content
     call append(0, a:content)
 
     " delete last line that comes from the append call
-    $delete _  
+    $delete _
 
     " set it back to non modifiable
     setlocal nomodifiable
 endfunction
 
+function! go#ui#GetReturnWindow()
+    for l:wn in range(1, winnr("$"))
+        if !empty(getwinvar(l:wn, "vim_go_return_window"))
+            return l:wn
+        endif
+    endfor
+endfunction
 
 " CloseWindow closes the current window
 function! go#ui#CloseWindow()
-    close
-    echo ""
+    " Close any window associated with the ui buffer, if it's there
+    if bufexists(s:buf_nr)
+        let ui_window_number = bufwinnr(s:buf_nr)
+        if ui_window_number != -1
+            execute ui_window_number . 'close'
+        endif
+    endif
+
+    "return to original window, if it's there
+    let l:rw = go#ui#GetReturnWindow()
+    if !empty(l:rw)
+        execute l:rw . 'wincmd w'
+        unlet! w:vim_go_return_window
+    endif
 endfunction
+
+" Find
 
 " OpenDefinition parses the current line and jumps to it by openening a new
 " tab
@@ -64,7 +93,7 @@ function! go#ui#OpenDefinition(filter)
     " don't touch our first line or any blank line
     if curline =~ a:filter || curline =~ "^$"
         " supress information about calling this function
-        echo "" 
+        echo ""
         return
     endif
 
@@ -83,7 +112,7 @@ function! go#ui#OpenDefinition(filter)
     tab split
     ll 1
 
-    " center the word 
-    norm! zz 
+    " center the word
+    norm! zz
 endfunction
 

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -79,6 +79,18 @@ function! go#util#Shelllist(arglist, ...)
     endtry
 endfunction
 
+" Windo is like the built-in :windo, only it returns to the window the command
+" was issued from
+function! go#util#Windo(command)
+    let s:currentWindow = winnr()
+    try
+        execute "windo " . a:command
+    finally
+        execute s:currentWindow. "wincmd w"
+        unlet s:currentWindow
+    endtry
+endfunction
+
 " TODO(arslan): I couldn't parameterize the highlight types. Check if we can
 " simplify the following functions
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -14,16 +14,15 @@
 ===============================================================================
 CONTENTS                                                          *go-contents*
 
-  1.  Intro........................................|go-intro|
-  2.  Install......................................|go-install|
-  3.  Commands.....................................|go-commands|
-  4.  GoDef Stack..................................|godef-stack|
-  5.  Mappings.....................................|go-mappings|
-  6.  Text Objects.................................|go-text-objects|
-  7.  Functions....................................|go-functions|
-  8.  Settings.....................................|go-settings|
-  9.  Troubleshooting..............................|go-troubleshooting|
-  10. Credits......................................|go-credits|
+  1. Intro........................................|go-intro|
+  2. Install......................................|go-install|
+  3. Commands.....................................|go-commands|
+  4. Mappings.....................................|go-mappings|
+  5. Text Objects.................................|go-text-objects|
+  6. Functions....................................|go-functions|
+  7. Settings.....................................|go-settings|
+  8. Troubleshooting..............................|go-troubleshooting|
+  9. Credits......................................|go-credits|
 
 ===============================================================================
 INTRO                                                                *go-intro*
@@ -221,8 +220,59 @@ CTRL-]
     identifier under the cursor. See |g:go_def_mapping_enabled| to disable them.
 
     vim-go also keeps a location stack, roughly analagous to how vim's internal
-    |tags| functionality works. This is pushed to every time a jump is made using
-    the GoDef functionality. See |godef-stack| for more information.
+    |tags| functionality works. This is pushed to every time a jump is made
+    using the GoDef functionality. In essence, this is a LIFO list of file
+    locations you have visited with :GoDef that is retained to help you navigate
+    software.
+
+                                                                *:GoDefStack*
+:GoDefStack
+
+    This command displays the entries in the GoDef stack.  Its output looks
+    like this:
+
+      1 /path/to/first/file.go|1187 col 16|AddThing func(t *Thing)
+    > 2 /path/to/thing/thing.go|624 col 19|String() string
+      3 /path/to/thing/thing.go|744 col 6|func Sprintln(a ...interface{}) string
+
+    This list shows the identifiers that you jumped to and the file and cursor
+    position before that jump.  The older jumps are at the top, the newer at the
+    bottom.
+
+    The '>' points to the active entry.  This entry and any newer entries below
+    it will be replaced if a jump is done from this location. The CTRL-t and
+    |:GoDefPop| command will use the position above the active entry.
+
+                                                                  *:GoDefPop*
+:GoDefPop [count]
+CTRL-t
+
+    Navigate to the [count] earlier entry in the jump stack, retaining the newer
+    entries. If no argument is given, it will jump to the next most recent entry
+    (`:GoDefPop 1`).  If [count] is greater than the number of prior entries,
+    the stack will bottom out at the first entry and print a message informing
+    you that you are at the bottom of the stack.
+
+    If you have used :GoDefPop to jump to an earlier location, and you issue
+    another :GoDef command, the current entry will be replaced, and all newer
+    entries will be removed, effectively resuming the stack at that location.
+
+    By default [count]CTRL-t is enabled to invoke :GoDefPop.  Similarly, hitting
+    CTRL-t without a prior count is equivalent to `:GoDefPop 1`.  See
+    |g:go_def_mapping_enabled| to disable this.
+
+                                                                 *:GoDefJump*
+:GoDefJump [number]
+
+    Jumps to a given location in the jump stack, retaining all other entries.
+    If no argument is given, it will print out an list of all items in the
+    stack, and you will be prompted to select one or hit <enter> to abort.
+
+    For details on the format of this list, see |:GoDefStack|.
+
+    Jumps to non-existent entries will print an informative message, but are
+    otherwise a noop.  As with |:GoDefPop|, any :GoDef command after a jump
+    will replace the current entry and remove all newer entries.
 
                                                                      *:GoRun*
 :GoRun[!] [expand]
@@ -510,65 +560,6 @@ CTRL-]
       autocmd Filetype go command! -bang AS call go#alternate#Switch(<bang>0, 'split')
     augroup END
 <
-
-===============================================================================
-GODEF STACK                                                     *godef-stack*
-vim-go keeps track of locations jumped to using the |:GoDef| command.  In
-essence, this is a LIFO list of file locations you have visited with :GoDef
-that is retained to help you navigate software.
-
-Entries in this list can be jumped to and browsed in much the same way as those
-provided by vim's native |tags| support, and special commands are provided to
-do this.
-
-                                                                  *:GoDefPop*
-:GoDefPop [count]
-CTRL-t
-
-    Navigate to the [count] earlier entry in the jump stack, retaining the newer
-    entries. If no argument is given, it will jump to the next most recent entry
-    (`:GoDefPop 1`).  If [count] is greater than the number of prior entries,
-    the stack will bottom out at the first entry and print a message informing
-    you that you are at the bottom of the stack.
-
-    If you have used :GoDefPop to jump to an earlier location, and you issue
-    another :GoDef command, the current entry will be replaced, and all newer
-    entries will be removed, effectively resuming the stack at that location.
-
-    By default [count]CTRL-t is enabled to invoke :GoDefPop.  Similarly, hitting
-    CTRL-t without a prior count is equivalent to `:GoDefPop 1`.  See
-    |g:go_def_mapping_enabled| to disable this.
-
-                                                                 *:GoDefJump*
-:GoDefJump [number]
-
-    Jumps to a given location in the jump stack, retaining all other entries.
-    If no argument is given, it will print out an list of all items in the
-    stack, and you will be prompted to select one or hit <enter> to abort.
-
-    For details on the format of this list, see |:GoDefStack|.
-
-    Jumps to non-existent entries will print an informative message, but are
-    otherwise a noop.  As with |:GoDefPop|, any :GoDef command after a jump
-    will replace the current entry and remove all newer entries.
-
-                                                                *:GoDefStack*
-:GoDefStack
-
-    This command displays the entries in the GoDef stack.  Its output looks
-    like this:
-
-      1 /path/to/first/file.go|1187 col 16|AddThing func(t *Thing)
-    > 2 /path/to/thing/thing.go|624 col 19|String() string
-      3 /path/to/thing/thing.go|744 col 6|func Sprintln(a ...interface{}) string
-
-    This list shows the identifiers that you jumped to and the file and cursor
-    position before that jump.  The older jumps are at the top, the newer at the
-    bottom.
-
-    The '>' points to the active entry.  This entry and any newer entries below
-    it will be replaced if a jump is done from this location. The CTRL-t and
-    |:GoDefPop| command will use the position above the active entry.
 
 ===============================================================================
 MAPPINGS                                                        *go-mappings*

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -219,11 +219,11 @@ CTRL-]
     CTRL-] key and the mapping `gd` are enabled to invoke :GoDef for the
     identifier under the cursor. See |g:go_def_mapping_enabled| to disable them.
 
-    vim-go also keeps a location stack, roughly analagous to how vim's internal
-    |tags| functionality works. This is pushed to every time a jump is made
-    using the GoDef functionality. In essence, this is a LIFO list of file
-    locations you have visited with :GoDef that is retained to help you navigate
-    software.
+    vim-go also keeps a per-window location stack, roughly analagous to how
+    vim's internal |tags| functionality works. This is pushed to every time a
+    jump is made using the GoDef functionality. In essence, this is a LIFO list
+    of file locations you have visited with :GoDef that is retained to help you
+    navigate software.
 
                                                                 *:GoDefStack*
 :GoDefStack
@@ -264,8 +264,8 @@ CTRL-t
 :GoDefJump [number]
 
     Jumps to a given location in the jump stack, retaining all other entries.
-    If no argument is given, it will print out an list of all items in the
-    stack, and you will be prompted to select one or hit <enter> to abort.
+    If no argument is given, it will print out an interactive list of all items
+    in the stack, from which you can select one, if you choose.
 
     For details on the format of this list, see |:GoDefStack|.
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -250,8 +250,7 @@ CTRL-t
     Navigate to the [count] earlier entry in the jump stack, retaining the newer
     entries. If no argument is given, it will jump to the next most recent entry
     (`:GoDefPop 1`).  If [count] is greater than the number of prior entries,
-    the stack will bottom out at the first entry and print a message informing
-    you that you are at the bottom of the stack.
+    an error will be printed and no jump will be performed.
 
     If you have used :GoDefPop to jump to an earlier location, and you issue
     another :GoDef command, the current entry will be replaced, and all newer

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -14,15 +14,16 @@
 ===============================================================================
 CONTENTS                                                          *go-contents*
 
-  1. Intro........................................|go-intro|
-  2. Install......................................|go-install|
-  3. Commands.....................................|go-commands|
-  4. Mappings.....................................|go-mappings|
-  5. Text Objects.................................|go-text-objects|
-  6. Functions....................................|go-functions|
-  7. Settings.....................................|go-settings|
-  8. Troubleshooting..............................|go-troubleshooting|
-  9. Credits......................................|go-credits|
+  1.  Intro........................................|go-intro|
+  2.  Install......................................|go-install|
+  3.  Commands.....................................|go-commands|
+  4.  GoDef Stack..................................|godef-stack|
+  5.  Mappings.....................................|go-mappings|
+  6.  Text Objects.................................|go-text-objects|
+  7.  Functions....................................|go-functions|
+  8.  Settings.....................................|go-settings|
+  9.  Troubleshooting..............................|go-troubleshooting|
+  10. Credits......................................|go-credits|
 
 ===============================================================================
 INTRO                                                                *go-intro*
@@ -211,11 +212,17 @@ COMMANDS                                                          *go-commands*
 
                                                                      *:GoDef*
 :GoDef [identifier]
+gd
+CTRL-]
 
     Goto declaration/definition for the given [identifier]. If no argument is
     given, it will jump to the declaration under the cursor. By default the
-    mapping `gd` is enabled to invoke GoDef for the identifier under the cursor.
-    See |g:go_def_mapping_enabled| to disable it.
+    CTRL-] key and the mapping `gd` are enabled to invoke :GoDef for the
+    identifier under the cursor. See |g:go_def_mapping_enabled| to disable them.
+
+    vim-go also keeps a location stack, roughly analagous to how vim's internal
+    |tags| functionality works. This is pushed to every time a jump is made using
+    the GoDef functionality. See |godef-stack| for more information.
 
                                                                      *:GoRun*
 :GoRun[!] [expand]
@@ -503,6 +510,65 @@ COMMANDS                                                          *go-commands*
       autocmd Filetype go command! -bang AS call go#alternate#Switch(<bang>0, 'split')
     augroup END
 <
+
+===============================================================================
+GODEF STACK                                                     *godef-stack*
+vim-go keeps track of locations jumped to using the |:GoDef| command.  In
+essence, this is a LIFO list of file locations you have visited with :GoDef
+that is retained to help you navigate software.
+
+Entries in this list can be jumped to and browsed in much the same way as those
+provided by vim's native |tags| support, and special commands are provided to
+do this.
+
+                                                                  *:GoDefPop*
+:GoDefPop [count]
+CTRL-t
+
+    Navigate to the [count] earlier entry in the jump stack, retaining the newer
+    entries. If no argument is given, it will jump to the next most recent entry
+    (`:GoDefPop 1`).  If [count] is greater than the number of prior entries,
+    the stack will bottom out at the first entry and print a message informing
+    you that you are at the bottom of the stack.
+
+    If you have used :GoDefPop to jump to an earlier location, and you issue
+    another :GoDef command, the current entry will be replaced, and all newer
+    entries will be removed, effectively resuming the stack at that location.
+
+    By default [count]CTRL-t is enabled to invoke :GoDefPop.  Similarly, hitting
+    CTRL-t without a prior count is equivalent to `:GoDefPop 1`.  See
+    |g:go_def_mapping_enabled| to disable this.
+
+                                                                 *:GoDefJump*
+:GoDefJump [number]
+
+    Jumps to a given location in the jump stack, retaining all other entries.
+    If no argument is given, it will print out an list of all items in the
+    stack, and you will be prompted to select one or hit <enter> to abort.
+
+    For details on the format of this list, see |:GoDefStack|.
+
+    Jumps to non-existent entries will print an informative message, but are
+    otherwise a noop.  As with |:GoDefPop|, any :GoDef command after a jump
+    will replace the current entry and remove all newer entries.
+
+                                                                *:GoDefStack*
+:GoDefStack
+
+    This command displays the entries in the GoDef stack.  Its output looks
+    like this:
+
+      1 /path/to/first/file.go|1187 col 16|AddThing func(t *Thing)
+    > 2 /path/to/thing/thing.go|624 col 19|String() string
+      3 /path/to/thing/thing.go|744 col 6|func Sprintln(a ...interface{}) string
+
+    This list shows the identifiers that you jumped to and the file and cursor
+    position before that jump.  The older jumps are at the top, the newer at the
+    bottom.
+
+    The '>' points to the active entry.  This entry and any newer entries below
+    it will be replaced if a jump is done from this location. The CTRL-t and
+    |:GoDefPop| command will use the position above the active entry.
 
 ===============================================================================
 MAPPINGS                                                        *go-mappings*
@@ -810,8 +876,9 @@ In Go, using `godoc` is more idiomatic. Default is enabled. >
 <
                                                  *'g:go_def_mapping_enabled'*
 
-Use this option to enable/disable the default mapping of (`gd`) for GoDef.
-Disabling it allows you to map something else to `gd`. Default is enabled. >
+Use this option to enable/disable the default mapping of CTRL-] and (`gd`) for
+GoDef and CTRL-t for :GoDefPop. Disabling it allows you to map something else to
+these keys or mappings. Default is enabled. >
 
   let g:go_def_mapping_enabled = 1
 <

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -30,6 +30,8 @@ endif
 
 if get(g:, "go_def_mapping_enabled", 1)
    nnoremap <buffer> <silent> gd :GoDef<cr>
+   nnoremap <buffer> <silent> <C-]> :GoDef<cr>
+   nnoremap <buffer> <silent> <C-t> :<C-U>call go#def#StackPop(v:count1)<cr>
 endif
 
 if get(g:, "go_textobj_enabled", 1)

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -33,6 +33,9 @@ command! -nargs=0 -range=% GoPlay call go#play#Share(<count>, <line1>, <line2>)
 
 " -- def
 command! -nargs=* -range GoDef :call go#def#Jump(<f-args>)
+command! -nargs=0 GoDefStack :call go#def#StackPrint()
+command! -nargs=1 GoDefPop :call go#def#StackPop(<f-args>)
+command! -nargs=? GoDefJump :call go#def#StackJump(<f-args>)
 
 " -- doc
 command! -nargs=* -range -complete=customlist,go#package#Complete GoDoc call go#doc#Open('new', 'split', <f-args>)

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -34,7 +34,7 @@ command! -nargs=0 -range=% GoPlay call go#play#Share(<count>, <line1>, <line2>)
 " -- def
 command! -nargs=* -range GoDef :call go#def#Jump(<f-args>)
 command! -nargs=0 GoDefStack :call go#def#StackPrint()
-command! -nargs=1 GoDefPop :call go#def#StackPop(<f-args>)
+command! -nargs=? GoDefPop :call go#def#StackPop(<f-args>)
 command! -nargs=? GoDefJump :call go#def#StackJump(<f-args>)
 
 " -- doc

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -33,7 +33,7 @@ command! -nargs=0 -range=% GoPlay call go#play#Share(<count>, <line1>, <line2>)
 
 " -- def
 command! -nargs=* -range GoDef :call go#def#Jump(<f-args>)
-command! -nargs=0 GoDefStack :call go#def#StackPrint()
+command! -nargs=0 GoDefStack :call go#def#StackUI(0)
 command! -nargs=? GoDefPop :call go#def#StackPop(<f-args>)
 command! -nargs=? GoDefJump :call go#def#StackJump(<f-args>)
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -166,6 +166,9 @@ augroup vim-go
     if get(g:, "go_metalinter_autosave", 0)
         autocmd BufWritePost *.go call go#lint#Gometa(1)
     endif
+
+    au BufReadPre,WinEnter *.go if !exists('w:go_stack') | let w:go_stack = [] | endif
+    au BufReadPre,WinEnter *.go if !exists('w:go_stack_level') | let w:go_stack_level = 0 | endif
 augroup END
 
 

--- a/syntax/godefstack.vim
+++ b/syntax/godefstack.vim
@@ -1,0 +1,18 @@
+if exists("b:current_syntax")
+    finish
+endif
+
+syn match godefStackComment             '^".*'
+syn match godefLinePrefix               '^[>\s]\s' nextgroup=godefStackEntryNumber contains=godefStackCurrentPosition
+syn match godefStackEntryNumber         '\d\+' nextgroup=godefStackFilename skipwhite
+syn match godefStackCurrentPosition     '>' contained
+syn match godefStackFilename            '[^|]\+' contained nextgroup=godefStackEntryLocation
+syn region godefStackEntryLocation      oneline start='|' end='|' contained contains=godefStackEntryLocationNumber
+syn match godefStackEntryLocationNumber '\d\+' contained display
+
+let b:current_syntax = "godefstack"
+
+hi def link godefStackComment           Comment
+hi def link godefStackCurrentPosition   Special
+hi def link godefStackFilename          Directory
+hi def link godefStackEntryLocationNumber LineNr


### PR DESCRIPTION
This PR adds a godef-driven jump stack to vim-go along with associated bindings and commands that are roughly analogous to the way vim's built in tags support works.  `:help :GoDef` and `:help godef-stack` for docs.