### PR TITLE
Add Blocks support in vim-go

### DIFF
--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -39,6 +39,12 @@ if get(g:, "go_textobj_enabled", 1)
     xnoremap <buffer> <silent> af :<c-u>call go#textobj#Function('a')<cr>
     xnoremap <buffer> <silent> if :<c-u>call go#textobj#Function('i')<cr>
 
+    onoremap <buffer> <silent> ab :<c-u>call go#textobj#Block('a')<cr>
+    onoremap <buffer> <silent> ib :<c-u>call go#textobj#Block('i')<cr>
+
+    xnoremap <buffer> <silent> ab :<c-u>call go#textobj#Block('a')<cr>
+    xnoremap <buffer> <silent> ib :<c-u>call go#textobj#Block('i')<cr>
+
     " Remap ]] and [[ to jump betweeen functions as they are useless in Go
     nnoremap <buffer> <silent> ]] :<c-u>call go#textobj#FunctionJump('n', 'next')<cr>
     nnoremap <buffer> <silent> [[ :<c-u>call go#textobj#FunctionJump('n', 'prev')<cr>


### PR DESCRIPTION
This PR links to https://github.com/fatih/motion/pull/1, which enables to select block statements in Go code via `vab` or `vib` actions.