### PR TITLE
support for color verbs

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -181,7 +181,7 @@ else
 endif
 
 if g:go_highlight_format_strings != 0
-  syn match       goFormatSpecifier   /%[-#0 +]*\%(\*\|\d\+\)\=\%(\.\%(\*\|\d\+\)\)*[vTtbcdoqxXUeEfgGsp]/ contained containedin=goString
+  syn match       goFormatSpecifier   /%[-#0 +]*\%(\*\|\d\+\)\=\%(\.\%(\*\|\d\+\)\)*\%([vTtbcdoqxXUeEfgGspr]\|h\[[a-zA-Z0-9+]\+\]\)/ contained containedin=goString
   hi def link     goFormatSpecifier   goSpecialString
 endif
 


### PR DESCRIPTION
https://github.com/nhooyr/color uses `%h[...]` and `%r` as verbs for
highlighting text. This commit adds support to highlight them correctly
in strings.