### PR TITLE
GoTestFunc: support testable examples

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -272,7 +272,7 @@ function! go#cmd#TestFunc(bang, ...)
     "
     " for the full list
     " :help search
-    let test = search("func Test", "bcnW")
+    let test = search('func \(Test\|Example\)', "bcnW")
 
     if test == 0
         echo "vim-go: [test] no test found immediate to cursor"


### PR DESCRIPTION
Support godoc example tests ([described here](https://golang.org/pkg/testing/#hdr-Examples)) in `go#cmd#TestFunc()`