### PR TITLE
Handle windows paths

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -36,7 +36,11 @@ endfunction
 function! s:jump_to_declaration(out, mode)
 	" strip line ending
 	let out = split(a:out, go#util#LineEnding())[0]
-	let parts = split(out, ':')
+	if has('win32') || has('win64')
+		let parts = split(out, '\(^[a-zA-Z]\)\@<!:')
+	else
+		let parts = split(out, ':')
+	endif
 
 	let filename = parts[0]
 	let line = parts[1]

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -36,7 +36,7 @@ endfunction
 function! s:jump_to_declaration(out, mode)
 	" strip line ending
 	let out = split(a:out, go#util#LineEnding())[0]
-	if has('win32') || has('win64')
+	if go#util#IsWin()
 		let parts = split(out, '\(^[a-zA-Z]\)\@<!:')
 	else
 		let parts = split(out, ':')


### PR DESCRIPTION
When the line from godef is `C:\foo\bar\baz.go:123: descriptions`, `split(out, ":")` break the paths on windows.