### PR TITLE
Clarify that mappings are enabled by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ After that just open the help page to see all commands:
 
     :help vim-go
 
-## Mappings
+## Example Mappings
 
 vim-go has several `<Plug>` mappings which can be used to create custom
-mappings. Below are some examples you might find useful:
+mappings. Unless otherwise specified, none of these mappings are enabled
+by default. Here some examples you might find useful:
 
 Run commands such as `go run` for the current file with `<leader>r` or `go
 build` and `go test` for the current package with `<leader>b` and `<leader>t`


### PR DESCRIPTION
This clarifies in the README that none of the mappings are enabled by default. I completely glanced over the "here are some examples" and assumed these mappings were enabled by default. I was wrong.

Great work on the plugin! Loving it so far :smile: 