### PR TITLE
Fix bad syntax of `redraw` in go/rename.vim

### DIFF
--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -16,7 +16,7 @@ function! go#rename#Rename(bang, ...)
         else
             let to = input(ask)
         endif
-        redraw!
+        redraw
         if empty(to)
             return
         endif


### PR DESCRIPTION
This issue is a regression caused by commit: accc895