### PR TITLE
Generate table tests using gotests tool via :GoTableTests

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ disabled/enabled easily.
 * Integrated with the Neovim terminal, launch `:GoRun` and other go commands
   in their own new terminal. (beta)
 * Alternate between implementation and test code with `:GoAlternate`
+* Generate table tests using [gotests](https://github.com/cweill/gotests) with `:GoTableTests`
 
 ## Install
 
@@ -276,8 +277,8 @@ just a way to support vim-go's ongoing development directly. Thanks!
 ## Credits
 
 * Go Authors for official vim plugins
-* Gocode, Godef, Golint, Guru, Goimports, Gotags, Errcheck projects and
-  authors of those projects.
+* Gocode, Godef, Golint, Guru, Goimports, Gotags, Errcheck, Gotests projects
+  and authors of those projects.
 * Other vim-plugins, thanks for inspiration (vim-golang, go.vim, vim-gocode,
   vim-godef)
 * [Contributors](https://github.com/fatih/vim-go/graphs/contributors) of vim-go

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -1,0 +1,49 @@
+"
+" https://github.com/fatih/vim-go/issues/807
+" https://github.com/cweill/gotests
+" https://github.com/cweill/gotests/issues/20
+"
+
+if !exists("g:go_gotests_bin")
+    let g:go_gotests_bin = "gotests"
+endif
+
+" Append output of gotests to corresponding _test.go file
+function! go#test#TableTests(bang, ...)
+    let func = search('^func ', "bcnW")
+
+    if func == 0
+        echo "vim-go: no func found previous to cursor"
+        return
+    end
+
+    let line = getline(func)
+    let fname = split(split(line, " ")[1], "(")[0]
+
+    " Check if binary exists
+    let bin_path = go#path#CheckBinPath(g:go_gotests_bin)
+    if empty(bin_path)
+        return
+    endif
+
+    let file = expand('%')
+
+    " Shouldn't happen as this function shouldn't be registered
+    if empty(file)
+        call go#util#EchoError("vim-go: write go file to disk first")
+        return
+    endif
+
+    " Ensure changes are written to disk for tool to read updated version
+    if &modified
+        call go#util#EchoError("vim-go: unsaved changes in buffer")
+        return
+    endif
+
+    " Run gotests
+    let out = system(bin_path . ' -w -only ^' . shellescape(fname) . '$ ' . shellescape(file))
+
+    if v:shell_error
+        call go#util#EchoError("vim-go: gotests error: " . out)
+    endif
+endfunction

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -70,6 +70,8 @@ easily.
   * Integrated with the neovim terminal, launch `:GoRun` and other go commands
     in their own new terminal.
   * Alternate between implementation and test code with `:GoAlternate`
+  * Generate table tests using [gotests](https://github.com/cweill/gotests)
+    with `:GoTableTests`
 
 ===============================================================================
 INSTALL                                                           *go-install*
@@ -605,6 +607,12 @@ CTRL-t
     changed via |g:go_decls_includes|, which accepts a comma delimited list of
     definitions. By default set to: `"func,type"`. Possible options are:
     `{func,type}`
+
+                                                              *:GoTableTests*
+:GoTableTests
+
+    Generates table driven tests in the corresponding _test.go file based on
+    the function under the cursor using gotests tool.
 
 ===============================================================================
 MAPPINGS                                                        *go-mappings*
@@ -1258,8 +1266,8 @@ You'll see a more detailed error. If this works, vim-go will work too.
 CREDITS                                                         *go-credits*
 
 * Go Authors for official vim plugins
-* Gocode, Godef, Golint, Guru, Goimports, Errcheck projects and authors of
-  those projects.
+* Gocode, Godef, Golint, Guru, Goimports, Errcheck, Gotests projects and
+  authors of those projects.
 * Other vim-plugins, thanks for inspiration (vim-golang, go.vim, vim-gocode,
   vim-godef)
 * vim-go contributors: https://github.com/fatih/vim-go/graphs/contributors

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -71,4 +71,7 @@ if globpath(&rtp, 'plugin/ctrlp.vim') != ""
   command! -nargs=? -complete=dir GoDeclsDir call ctrlp#init(ctrlp#decls#cmd(1, <q-args>))
 endif
 
+" -- test
+command! -nargs=* GoTableTests call go#test#TableTests(0)
+
 " vim:ts=4:sw=4:et

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -19,6 +19,7 @@ let s:packages = [
             \ "github.com/klauspost/asmfmt/cmd/asmfmt",
             \ "github.com/fatih/motion",
             \ "github.com/zmb3/gogetdoc",
+            \ "github.com/cweill/gotests/gotests",
             \ ]
 
 " These commands are available on any filetypes


### PR DESCRIPTION
Extends vim-go to use https://github.com/cweill/gotests to generate table tests https://github.com/golang/go/wiki/TableDrivenTests as discussed in issue #807 (see also cweill/gotests#20)

Only supports generating table tests on the function under the cursor, i.e. does not add support for generating table tests for all selected functions when using visual mode.

Does not support refreshing buffers or tabs if the corresponding _test.go file is already open.

`:GoInstallBinaries` does not display the path `github.com/cweill/gotests/...` correctly when installing, which is the path gotests project expects you use to install it. Instead, this change references the path to the binary `github.com/cweill/gotests/gotests`. This should not be a problem and tested OK, but may need to be reconsidered if issues do arise.