### PR TITLE
don't default to binaries in the PATH

### DIFF
--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -138,14 +138,16 @@ endfunction
 function! go#path#CheckBinPath(binpath)
     " remove whitespaces if user applied something like 'goimports   '
     let binpath = substitute(a:binpath, '^\s*\(.\{-}\)\s*$', '\1', '')
+    " save off original path
+    let old_path = $PATH
 
     " check if we have an appropriate bin_path
     let go_bin_path = go#path#BinPath()
-
-    " append our GOBIN and GOPATH paths and be sure they can be found there...
-    " let us search in our GOBIN and GOPATH paths
-    let old_path = $PATH
-    let $PATH = go_bin_path . go#util#PathListSep() . $PATH
+    if empty(go_bin_path)
+        " append our GOBIN and GOPATH paths and be sure they can be found there...
+        " let us search in our GOBIN and GOPATH paths
+        let $PATH = go_bin_path . go#util#PathListSep() . $PATH
+    endif
 
     " if it's in PATH just return it
     if executable(binpath)
@@ -155,13 +157,6 @@ function! go#path#CheckBinPath(binpath)
 
     " just get the basename
     let basename = fnamemodify(binpath, ":t")
-
-    if empty(go_bin_path)
-        let $PATH = old_path
-        echo "vim-go: could not find '" . basename . "'. Run :GoInstallBinaries to fix it."
-        return ""
-    endif
-
     if !executable(basename)
         echo "vim-go: could not find '" . basename . "'. Run :GoInstallBinaries to fix it."
         " restore back!

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -143,7 +143,7 @@ function! go#path#CheckBinPath(binpath)
 
     " check if we have an appropriate bin_path
     let go_bin_path = go#path#BinPath()
-    if empty(go_bin_path)
+    if !empty(go_bin_path)
         " append our GOBIN and GOPATH paths and be sure they can be found there...
         " let us search in our GOBIN and GOPATH paths
         let $PATH = go_bin_path . go#util#PathListSep() . $PATH

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -139,6 +139,9 @@ function! go#path#CheckBinPath(binpath)
     " remove whitespaces if user applied something like 'goimports   '
     let binpath = substitute(a:binpath, '^\s*\(.\{-}\)\s*$', '\1', '')
 
+    " check if we have an appropriate bin_path
+    let go_bin_path = go#path#BinPath()
+
     " append our GOBIN and GOPATH paths and be sure they can be found there...
     " let us search in our GOBIN and GOPATH paths
     let old_path = $PATH
@@ -153,8 +156,6 @@ function! go#path#CheckBinPath(binpath)
     " just get the basename
     let basename = fnamemodify(binpath, ":t")
 
-    " check if we have an appropriate bin_path
-    let go_bin_path = go#path#BinPath()
     if empty(go_bin_path)
         let $PATH = old_path
         echo "vim-go: could not find '" . basename . "'. Run :GoInstallBinaries to fix it."

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -139,20 +139,27 @@ function! go#path#CheckBinPath(binpath)
     " remove whitespaces if user applied something like 'goimports   '
     let binpath = substitute(a:binpath, '^\s*\(.\{-}\)\s*$', '\1', '')
 
+    " append our GOBIN and GOPATH paths and be sure they can be found there...
+    " let us search in our GOBIN and GOPATH paths
+    let old_path = $PATH
+    let $PATH = go_bin_path . go#util#PathListSep() . $PATH
+
+    " if it's in PATH just return it
+    if executable(binpath)
+        let $PATH = old_path
+        return exepath(binpath)
+    endif
+
     " just get the basename
     let basename = fnamemodify(binpath, ":t")
 
     " check if we have an appropriate bin_path
     let go_bin_path = go#path#BinPath()
     if empty(go_bin_path)
+        let $PATH = old_path
         echo "vim-go: could not find '" . basename . "'. Run :GoInstallBinaries to fix it."
         return ""
     endif
-
-    " append our GOBIN and GOPATH paths and be sure they can be found there...
-    " let us search in our GOBIN and GOPATH paths
-    let old_path = $PATH
-    let $PATH = go_bin_path . go#util#PathListSep() . $PATH
 
     if !executable(basename)
         echo "vim-go: could not find '" . basename . "'. Run :GoInstallBinaries to fix it."

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -139,11 +139,6 @@ function! go#path#CheckBinPath(binpath)
     " remove whitespaces if user applied something like 'goimports   '
     let binpath = substitute(a:binpath, '^\s*\(.\{-}\)\s*$', '\1', '')
 
-    " if it's in PATH just return it
-    if executable(binpath) 
-        return binpath
-    endif
-
     " just get the basename
     let basename = fnamemodify(binpath, ":t")
 
@@ -157,7 +152,7 @@ function! go#path#CheckBinPath(binpath)
     " append our GOBIN and GOPATH paths and be sure they can be found there...
     " let us search in our GOBIN and GOPATH paths
     let old_path = $PATH
-    let $PATH = $PATH . go#util#PathListSep() .go_bin_path
+    let $PATH = go_bin_path . go#util#PathListSep() . $PATH
 
     if !executable(basename)
         echo "vim-go: could not find '" . basename . "'. Run :GoInstallBinaries to fix it."

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -53,7 +53,7 @@ function! s:GoInstallBinaries(updateBinaries)
     let old_path = $PATH
 
     " vim's executable path is looking in PATH so add our go_bin path to it
-    let $PATH = $PATH . go#util#PathListSep() .go_bin_path
+    let $PATH = go_bin_path . go#util#PathListSep() . $PATH
 
     " when shellslash is set on MS-* systems, shellescape puts single quotes
     " around the output string. cmd on Windows does not handle single quotes


### PR DESCRIPTION
I asked this on #188 but since that's a closed PR I feel like it's less likely to receive attention so I'm creating a new issue instead.

I have to start this with the question: is there any particular reason for append instead of prepend? This is causing issues if people have some other binary in their path with a colliding name, because appending makes our gobin the last lookup path rather than the first.

I'm getting several reports of people hitting this issue because they had tools compiled on 1.6 and were hanging out in their `$GOPATH/bin` and now that we're using `g:go_bin_path` that is not getting updated, short term fix for us is just removing those stale binaries but seems like a prepend to the `$PATH` would be appropriate.

I made this as a PR because this may be the right solution. I didn't think through all the edge cases here because I wanted to just get opinions on this first. It seems like surprising behavior to me that when I configure `g:go_bin_path` the `$PATH` still overrides it.

Thoughts?