### PR TITLE
Document using quickfix list for syntastic

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,15 @@ let g:syntastic_go_checkers = ['golint', 'govet', 'errcheck']
 let g:syntastic_mode_map = { 'mode': 'active', 'passive_filetypes': ['go'] }
 ```
 
+Another issue with `vim-go` and `syntastic` is that the location list window
+that the output of commands such as `:GoBuild` and `:GoTest` might not appear.
+To resolve this:
+
+```vim
+let g:go_list_type = "quickfix"
+```
+
+
 ## More info
 
 Check out the [Wiki](https://github.com/fatih/vim-go/wiki) page for more

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ let g:syntastic_mode_map = { 'mode': 'active', 'passive_filetypes': ['go'] }
 ```
 
 Another issue with `vim-go` and `syntastic` is that the location list window
-that the output of commands such as `:GoBuild` and `:GoTest` might not appear.
+that contains the output of commands such as `:GoBuild` and `:GoTest` might not appear.
 To resolve this:
 
 ```vim


### PR DESCRIPTION
Add a note in the readme about using quickfix lists to work around an issue when
using syntastic.

For details, see #814 and https://github.com/scrooloose/syntastic/issues/1650