### PR TITLE
add nnoremap <buffer> <silent> <C-w><C-]> :<C-u>call go#def#Jump(spli…

### DIFF
--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -33,6 +33,7 @@ if get(g:, "go_def_mapping_enabled", 1)
     " useful again for Go source code
     nnoremap <buffer> <silent> gd :GoDef<cr>
     nnoremap <buffer> <silent> <C-]> :GoDef<cr>
+    nnoremap <buffer> <silent> <C-w><C-]> :<C-u>call go#def#Jump("split")<CR>
     nnoremap <buffer> <silent> <C-t> :<C-U>call go#def#StackPop(v:count1)<cr>
 endif
 

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -34,6 +34,7 @@ if get(g:, "go_def_mapping_enabled", 1)
     nnoremap <buffer> <silent> gd :GoDef<cr>
     nnoremap <buffer> <silent> <C-]> :GoDef<cr>
     nnoremap <buffer> <silent> <C-w><C-]> :<C-u>call go#def#Jump("split")<CR>
+    nnoremap <buffer> <silent> <C-w>] :<C-u>call go#def#Jump("split")<CR>
     nnoremap <buffer> <silent> <C-t> :<C-U>call go#def#StackPop(v:count1)<cr>
 endif
 


### PR DESCRIPTION
vim-go has already map the `<C-]>` key, and shoud also map the `<C-w><C-]>` key, which is opening tag in a split window in vim.