### PR TITLE
impl: add vim-go-impl

### DIFF
--- a/autoload/go/impl.vim
+++ b/autoload/go/impl.vim
@@ -1,0 +1,124 @@
+function! go#impl#Impl(...)
+    let binpath = go#path#CheckBinPath('impl')
+    if empty(binpath)
+        return
+    endif
+
+    let recv = ""
+    let iface = ""
+
+    if a:0 == 0
+        " user didn't passed anything,  just called ':GoImpl'
+        let receiveType = expand("<cword>")
+        let recv = printf("%s *%s", tolower(receiveType)[0], receiveType)
+        let iface = input("vim-go: interface to be generated: ")
+        redraw!
+        if empty(iface)
+            call go#util#EchoError('usage: interface type is not provided')
+            return
+        endif
+    elseif a:0 == 1
+        " we assume the user only passed the interface type, 
+        " i.e: ':GoImpl io.Writer'
+        let receiveType = expand("<cword>")
+        let recv = printf("%s *%s", tolower(receiveType)[0], receiveType)
+        let iface = a:1
+    elseif a:0 > 2
+        " user passed receiver and interface type both,
+        " i.e: 'GoImpl f *Foo io.Writer'
+        let recv = join(a:000[:-2], ' ')
+        let iface = a:000[-1]
+    else
+        call go#util#EchoError('usage: GoImpl {receiver} {interface}')
+        return
+    endif
+
+    let result = go#util#System(printf("%s '%s' '%s'", binpath, recv, iface))
+    if go#util#ShellError() != 0
+        call go#util#EchoError(result)
+        return
+    endif
+
+    if result ==# ''
+        return
+    end
+
+    let pos = getpos('.')
+    put ='' 
+    put =result
+    call setpos('.', pos)
+endfunction
+
+if exists('*uniq')
+    function! s:uniq(list)
+        return uniq(a:list)
+    endfunction
+else
+    " Note: Believe that the list is sorted
+    function! s:uniq(list)
+        let i = len(a:list) - 1
+        while 0 < i
+            if a:list[i-1] ==# a:list[i]
+                call remove(a:list, i)
+                let i -= 2
+            else
+                let i -= 1
+            endif
+        endwhile
+        return a:list
+    endfunction
+endif
+
+function! s:root_dirs()
+    let dirs = []
+    let root = go#util#GOROOT()
+    if root !=# '' && isdirectory(root)
+        call add(dirs, root)
+    endif
+
+    let paths = map(split(go#util#GOPATH(), go#util#PathListSep()), "substitute(v:val, '\\\\', '/', 'g')")
+    if go#util#ShellError()
+        return []
+    endif
+
+    if !empty(filter(paths, 'isdirectory(v:val)'))
+        call extend(dirs, paths)
+    endif
+
+    return dirs
+endfunction
+
+function! s:go_packages(dirs)
+    let pkgs = []
+    for d in a:dirs
+        let pkg_root = expand(d . '/pkg/' . go#util#OSARCH())
+        call extend(pkgs, split(globpath(pkg_root, '**/*.a', 1), "\n"))
+    endfor
+    return map(pkgs, "fnamemodify(v:val, ':t:r')")
+endfunction
+
+function! s:interface_list(pkg)
+    let contents = split(go#util#System('go doc ' . a:pkg), "\n")
+    if go#util#ShellError()
+        return []
+    endif
+
+    call filter(contents, 'v:val =~# ''^type\s\+\h\w*\s\+interface''')
+    return map(contents, 'a:pkg . "." . matchstr(v:val, ''^type\s\+\zs\h\w*\ze\s\+interface'')')
+endfunction
+
+" Complete package and interface for {interface}
+function! go#impl#Complete(arglead, cmdline, cursorpos)
+    let words = split(a:cmdline, '\s\+', 1)
+    if words[-1] ==# ''
+        return s:uniq(sort(s:go_packages(s:root_dirs())))
+    elseif words[-1] =~# '^\h\w*$'
+        return s:uniq(sort(filter(s:go_packages(s:root_dirs()), 'stridx(v:val, words[-1]) == 0')))
+    elseif words[-1] =~# '^\h\w*\.\%(\h\w*\)\=$'
+        let [pkg, interface] = split(words[-1], '\.', 1)
+        echomsg pkg
+        return s:uniq(sort(filter(s:interface_list(pkg), 'v:val =~? words[-1]')))
+    else
+        return []
+    endif
+endfunction

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -37,6 +37,27 @@ function! go#util#IsWin()
     return 0
 endfunction
 
+function! go#util#GOARCH()
+    return substitute(go#util#System('go env GOARCH'), '\n', '', 'g')
+endfunction
+
+function! go#util#GOOS()
+    return substitute(go#util#System('go env GOOS'), '\n', '', 'g')
+endfunction
+
+function! go#util#GOROOT()
+    return substitute(go#util#System('go env GOROOT'), '\n', '', 'g')
+endfunction
+
+function! go#util#GOPATH()
+    return substitute(go#util#System('go env GOPATH'), '\n', '', 'g')
+endfunction
+
+function! go#util#OSARCH()
+    return go#util#GOOS() . '_' . go#util#GOARCH()
+endfunction
+
+
 "Check if has vimproc
 function! s:has_vimproc()
     if !exists('g:go#use_vimproc')

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -619,6 +619,18 @@ CTRL-t
     definitions. By default set to: `"func,type"`. Possible options are:
     `{func,type}`
 
+                                                              *:GoImpl*
+:GoImpl [receiver] [interface]
+
+    Generates method stubs for implementing an interface. If no arguments is
+    passed it takes the identifier under the cursor to be the receiver and
+    asks for the interface type to be generated. If used with arguments, the
+    receiver and the interface needs to be specified. Example usages:
+>
+      :GoImpl f *Foo io.Writer
+      :GoImpl T io.ReadWriteCloser
+<
+
 ===============================================================================
 MAPPINGS                                                        *go-mappings*
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -1,7 +1,7 @@
-" gorename
+" -- gorename
 command! -nargs=? GoRename call go#rename#Rename(<bang>0,<f-args>)
 
-" guru
+" -- guru
 command! -nargs=* -complete=customlist,go#package#Complete GoGuruScope call go#guru#Scope(<f-args>)
 command! -range=% GoImplements call go#guru#Implements(<count>)
 command! -range=% GoCallees call go#guru#Callees(<count>)
@@ -16,12 +16,12 @@ command! -nargs=? GoGuruTags call go#guru#Tags(<f-args>)
 " TODO(arslan): enable this once the function is implemented
 " command! -range=% GoSameIds call go#guru#SameIds(<count>)
 
-" tool
+" -- tool
 command! -nargs=0 GoFiles echo go#tool#Files()
 command! -nargs=0 GoDeps echo go#tool#Deps()
 command! -nargs=* GoInfo call go#complete#Info(0)
 
-" cmd
+" -- cmd
 command! -nargs=* -bang GoBuild call go#cmd#Build(<bang>0,<f-args>)
 command! -nargs=* -bang GoGenerate call go#cmd#Generate(<bang>0,<f-args>)
 command! -nargs=* -bang -complete=file GoRun call go#cmd#Run(<bang>0,<f-args>)
@@ -72,5 +72,8 @@ if globpath(&rtp, 'plugin/ctrlp.vim') != ""
   command! -nargs=? -complete=file GoDecls call ctrlp#init(ctrlp#decls#cmd(0, <q-args>))
   command! -nargs=? -complete=dir GoDeclsDir call ctrlp#init(ctrlp#decls#cmd(1, <q-args>))
 endif
+
+" -- impl
+command! -nargs=* -buffer -complete=customlist,go#impl#Complete GoImpl call go#impl#Impl(<f-args>)
 
 " vim:ts=4:sw=4:et

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -4,7 +4,6 @@ if exists("g:go_loaded_install")
 endif
 let g:go_loaded_install = 1
 
-
 " these packages are used by vim-go and can be automatically installed if
 " needed by the user with GoInstallBinaries
 let s:packages = [
@@ -19,6 +18,7 @@ let s:packages = [
             \ "github.com/klauspost/asmfmt/cmd/asmfmt",
             \ "github.com/fatih/motion",
             \ "github.com/zmb3/gogetdoc",
+            \ "github.com/josharian/impl",
             \ ]
 
 " These commands are available on any filetypes


### PR DESCRIPTION
This adds the plugin https://github.com/rhysd/vim-go-impl with the
following changes/improvements:

* `:GoImpl` can be now called without any arguments, in this case it
  assumes the identifier under the cursor to be the receiver type
* `:GoImpl io.Writer` is a valid usage now, in this case it assumes the
  identifier under the cursor is the receiver type
* Removed the restriction for completion that there needs to be at least
  three words. This is neede because `:GoImpl io.Writer` is now a valid
  expression.
* We use now `go doc` for the auto completion. This allows for example
  the following usage as well `:GoImpl json.`, in this case you can now
  complete to json.Unmarshaller, whereas `godoc` is not capable of doing
  it.
* There is a newline prependend before we put the generated method stubs
* Refactored to use internal functions of vim-go
* Moved to `autoload` and load it lazily
* Added docs to `docs/vim-go.txt`

Closes #122

Demo:
![screen recording 2016-05-10 at 12 32 pm](https://cloud.githubusercontent.com/assets/438920/15144378/b31a5e6e-16b7-11e6-99bd-7d0cba4ac7e7.gif)

/cc @rhysd