### PR TITLE
add goField

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ To change it:
 ```vim
 let g:go_highlight_functions = 1
 let g:go_highlight_methods = 1
+let g:go_highlight_fields = 1
 let g:go_highlight_structs = 1
 let g:go_highlight_interfaces = 1
 let g:go_highlight_operators = 1

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1096,9 +1096,15 @@ Highlights method names. By default it's disabled. >
 <
                                                   *'g:go_highlight_structs'*
 
+Highlights field names. By default it's disabled. >
+
+  let go:go_highlight_fields = 0
+<
+                                                  *'go:go_highlight_fields'*
+
 Highlights struct names. By default it's disabled. >
 
-	let g:go_highlight_structs = 0
+  let g:go_highlight_structs = 0
 <
                                                *'g:go_highlight_interfaces'*
 

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -67,6 +67,10 @@ if !exists("g:go_highlight_methods")
   let g:go_highlight_methods = 0
 endif
 
+if !exists("go:go_highlight_fields")
+	let g:go_highlight_fields = 0
+endif
+
 if !exists("g:go_highlight_structs")
   let g:go_highlight_structs = 0
 endif
@@ -307,6 +311,12 @@ if g:go_highlight_methods != 0
   syn match goMethod                /\(\.\)\@<=\w\+\((\)\@=/
 endif
 hi def link     goMethod            Type
+
+" Fields;
+if g:go_highlight_fields != 0
+  syn match goField                 /\(\.\)\@<=\a\+\([\ \n\r\:\)]\)\@=/
+endif
+hi def link    goField              Type
 
 " Structs;
 if g:go_highlight_structs != 0


### PR DESCRIPTION
Adds the ability to differentiate `go.fields` & `go.methods()`.

## Matches
Parses out `bar`
### ==
`foo.bar`
`foo.bar =`
`foo.bar:`

### !=
`foo.bar()`

## note
I'm not sure what the default highlight should link to, so as of now it's `Type`, tho this should be change.