### PR TITLE
rename: reload all files to reflect the new changes

### DIFF
--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -36,6 +36,15 @@ function! go#rename#Rename(bang, ...)
 
     let out = go#tool#ExecuteInDir(cmd)
 
+    " reload all files to reflect the new changes. We explicitly call
+    " checktime to trigger a reload of all files. See
+    " http://www.mail-archive.com/vim@vim.org/msg05900.html for more info
+    " about the autoread bug
+    let current_autoread = &autoread
+    set autoread
+    silent! checktime
+    let &autoread = current_autoread
+
     " strip out newline on the end that gorename puts. If we don't remove, it
     " will trigger the 'Hit ENTER to continue' prompt
     let clean = split(out, '\n')


### PR DESCRIPTION
After a long time I had now some time to look at it. So first this can
be solved easily with

```
set autoread
```

But this is problematic and doesn't work well in Vim. Here is a mailing
list post (yeah I know it's 10 years old but hey it still applies!:
http://www.mail-archive.com/vim@vim.org/msg05900.html)

That's why people add additionaly an autocmd in form of:

```
set autoread
autocmd BufEnter *.go silent! checktime
```

This triggers automatically checktime, which triggers to reload any
other file that was changed outside Vim. This works perfectly for
`:GoRename`.

But we don't need the autocmd, that would otherwise call checktime for
every single buffer we enter. Instead we only call it explicitly if
`:GoRename` is being called.

Closes #351