### PR TITLE
Add non-standard workspaces to package path list

### DIFF
--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -46,7 +46,7 @@ function! go#package#Paths()
         let dirs += [s:goroot]
     endif
 
-    let workspaces = split($GOPATH, go#util#PathListSep())
+    let workspaces = split(go#path#Detect(), go#util#PathListSep())
     if workspaces != []
         let dirs += workspaces
     endif


### PR DESCRIPTION
Allows guru tools to work with gb, godep, etc