### PR TITLE
Properly use exepath for CheckBinPath

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -87,7 +87,7 @@ function! go#fmt#Format(withGoimport)
 
     " get the command first so we can test it
     let fmt_command = g:go_fmt_command
-    if a:withGoimport  == 1 
+    if a:withGoimport  == 1
         let fmt_command  = g:go_goimports_bin
     endif
 
@@ -109,14 +109,13 @@ function! go#fmt#Format(withGoimport)
 
     " populate the final command with user based fmt options
     let command = fmt_command . ' -w '
-    if a:withGoimport  != 1 
+    if a:withGoimport  != 1
         let command  = command . g:go_fmt_options
     endif
 
     if fmt_command == "goimports"
         if !exists('b:goimports_vendor_compatible')
-            let binpath = go#path#CheckBinPath("goimports")
-            let out = go#util#System(binpath . " --help")
+            let out = go#util#System(bin_path . " --help")
             if out !~ "-srcdir"
                 echohl WarningMsg
                 echomsg "vim-go: goimports does not support srcdir."

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -115,7 +115,8 @@ function! go#fmt#Format(withGoimport)
 
     if fmt_command == "goimports"
         if !exists('b:goimports_vendor_compatible')
-            let out = go#util#System("goimports --help")
+            let binpath = go#path#CheckBinPath("goimports")
+            let out = go#util#System(binpath . " --help")
             if out !~ "-srcdir"
                 echohl WarningMsg
                 echomsg "vim-go: goimports does not support srcdir."

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -151,6 +151,7 @@ function! go#path#CheckBinPath(binpath)
 
     " if it's in PATH just return it
     if executable(binpath)
+        let binpath = exepath(binpath)
         let $PATH = old_path
         return binpath
     endif

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -151,7 +151,9 @@ function! go#path#CheckBinPath(binpath)
 
     " if it's in PATH just return it
     if executable(binpath)
-        let binpath = exepath(binpath)
+        if v:version == 704 && has('patch235')
+            let binpath = exepath(binpath)
+        endif
         let $PATH = old_path
         return binpath
     endif


### PR DESCRIPTION
 #823 added this the wrong way, it was reverted back on 9f0cf00f6e9a437b738959f629ca29658334c6b5 but still not achieving the right functionality.
 This uses it properly now, also adding it to how we lookup goimports for srcdir support.