### PR TITLE
Increase compatibility with tcsh

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -196,7 +196,7 @@ function! go#cmd#Test(bang, compile, ...)
 
     if a:0
         " expand all wildcards(i.e: '%' to the current file name)
-        let goargs = map(copy(a:000), "expand(v:val)")
+        let goargs = map(copy(a:000), "shellescape(expand(v:val))")
 
         call extend(args, goargs, 1)
     else

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -196,7 +196,8 @@ function! go#cmd#Test(bang, compile, ...)
 
     if a:0
         " expand all wildcards(i.e: '%' to the current file name)
-        let goargs = map(copy(a:000), "shellescape(expand(v:val))")
+        let goargs = map(copy(a:000), "expand(v:val)")
+        let goargs = go#util#Shelllist(goargs, 1)
 
         call extend(args, goargs, 1)
     else

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -85,8 +85,9 @@ function! go#doc#Open(newmode, mode, ...)
 
     let offset = go#util#OffsetCursor()
     let fname = expand("%:p")
+    let pos = shellescape(fname.':#'.offset)
 
-    let command = printf("%s -pos %s:#%s", bin_path, fname, offset)
+    let command = printf("%s -pos %s", bin_path, pos)
 
     let out = go#util#System(command)
     if go#util#ShellError() != 0

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -74,7 +74,8 @@ func! s:RunGuru(mode, format, selected, needs_scope) range abort
     endif
 
     " this is our final command
-    let command .= printf(' %s %s:%s', a:mode, shellescape(filename), pos)
+    let filename .= ':'.pos
+    let command .= printf(' %s %s', a:mode, shellescape(filename))
 
     let old_gopath = $GOPATH
     let $GOPATH = go#path#Detect()

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -13,7 +13,7 @@ function! go#tool#Deps()
     if go#util#IsWin()
         let format = '{{range $f := .Deps}}{{$f}}{{printf \"\n\"}}{{end}}'
     else
-        let format = "${{range $f := .Deps}}{{$f}}\n{{end}}"
+        let format = "{{range $f := .Deps}}{{$f}}\n{{end}}"
     endif
     let command = 'go list -f '.shellescape(format)
     let out = go#tool#ExecuteInDir(command)
@@ -25,7 +25,7 @@ function! go#tool#Imports()
     if go#util#IsWin()
         let format = '{{range $f := .Imports}}{{$f}}{{printf \"\n\"}}{{end}}'
     else
-        let format = "${{range $f := .Imports}}{{$f}}\n{{end}}"
+        let format = "{{range $f := .Imports}}{{$f}}{{printf \"\\n\"}}{{end}}"
     endif
     let command = 'go list -f '.shellescape(format)
     let out = go#tool#ExecuteInDir(command)
@@ -35,7 +35,7 @@ function! go#tool#Imports()
     endif
 
     for package_path in split(out, '\n')
-        let cmd = "go list -f {{.Name}} " . shellescape(package_path)
+        let cmd = "go list -f '{{.Name}}' " . shellescape(package_path)
         let package_name = substitute(go#tool#ExecuteInDir(cmd), '\n$', '', '')
         let imports[package_name] = package_path
     endfor

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -1,19 +1,21 @@
 function! go#tool#Files()
     if go#util#IsWin()
-        let command = 'go list -f "{{range $f := .GoFiles}}{{$.Dir}}\{{$f}}{{printf \"\n\"}}{{end}}{{range $f := .CgoFiles}}{{$.Dir}}\{{$f}}{{printf \"\n\"}}{{end}}"'
+        let format = '{{range $f := .GoFiles}}{{$.Dir}}\{{$f}}{{printf \"\n\"}}{{end}}{{range $f := .CgoFiles}}{{$.Dir}}\{{$f}}{{printf \"\n\"}}{{end}}'
     else
-        let command = "go list -f '{{range $f := .GoFiles}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}{{range $f := .CgoFiles}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}'"
+        let format = "{{range $f := .GoFiles}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}{{range $f := .CgoFiles}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}"
     endif
+    let command = 'go list -f '.shellescape(format)
     let out = go#tool#ExecuteInDir(command)
     return split(out, '\n')
 endfunction
 
 function! go#tool#Deps()
     if go#util#IsWin()
-        let command = 'go list -f "{{range $f := .Deps}}{{$f}}{{printf \"\n\"}}{{end}}"'
+        let format = '{{range $f := .Deps}}{{$f}}{{printf \"\n\"}}{{end}}'
     else
-        let command = "go list -f $'{{range $f := .Deps}}{{$f}}\n{{end}}'"
+        let format = "${{range $f := .Deps}}{{$f}}\n{{end}}"
     endif
+    let command = 'go list -f '.shellescape(format)
     let out = go#tool#ExecuteInDir(command)
     return split(out, '\n')
 endfunction
@@ -21,10 +23,11 @@ endfunction
 function! go#tool#Imports()
     let imports = {}
     if go#util#IsWin()
-        let command = 'go list -f "{{range $f := .Imports}}{{$f}}{{printf \"\n\"}}{{end}}"'
+        let format = '{{range $f := .Imports}}{{$f}}{{printf \"\n\"}}{{end}}'
     else
-        let command = "go list -f $'{{range $f := .Imports}}{{$f}}\n{{end}}'"
+        let format = "${{range $f := .Imports}}{{$f}}\n{{end}}"
     endif
+    let command = 'go list -f '.shellescape(format)
     let out = go#tool#ExecuteInDir(command)
     if go#util#ShellError() != 0
         echo out
@@ -32,7 +35,7 @@ function! go#tool#Imports()
     endif
 
     for package_path in split(out, '\n')
-        let cmd = "go list -f {{.Name}} " . package_path
+        let cmd = "go list -f {{.Name}} " . shellescape(package_path)
         let package_name = substitute(go#tool#ExecuteInDir(cmd), '\n$', '', '')
         let imports[package_name] = package_path
     endfor


### PR DESCRIPTION
Hi,

some of the `:Go*` commands report errors when tcsh is configured in Vim. This pull request aims to resolve these errors.
I tested the commands with tcsh and sh configured, and here it works fine. Maybe someone else can double check if everything still works smoothly with her/his shell.