### PR TITLE
make go get -u configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ disabled/enabled easily.
 
 ## Install
 
-Master branch is supposed to be a development branch. So stuff here can break and change. 
+Master branch is supposed to be a development branch. So stuff here can break and change.
 Please try use always the [latest release](https://github.com/fatih/vim-go/releases/latest)
 
 Vim-go follows the standard runtime path structure, so I highly recommend to
@@ -216,6 +216,11 @@ By default when `:GoInstallBinaries` is called, the binaries are installed to
 ```vim
 let g:go_bin_path = expand("~/.gotools")
 let g:go_bin_path = "/home/fatih/.mypath"      "or give absolute path
+```
+
+Disable updating dependencies when installing/updating binaries:
+```vim
+let g:go_get_update = 0
 ```
 
 ### Using with Neovim (beta)

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -439,7 +439,8 @@ CTRL-t
 :GoInstallBinaries
 
     Download and Install all necessary Go tool binaries such as `godef`,
-    `goimports`, `gocode`, etc.. under `g:go_bin_path`
+    `goimports`, `gocode`, etc.. under `g:go_bin_path`. Set |g:go_get_update|
+    to disable updating dependencies.
 
                                                           *:GoUpdateBinaries*
 :GoUpdateBinaries
@@ -1014,6 +1015,14 @@ Use this option to define the default snippet engine.  By default "ultisnips"
 is used. Use "neosnippet" for neosnippet.vim: >
 
   let g:go_snippet_engine = "ultisnips"
+<
+
+                                                         *'g:go_get_update'*
+
+Use this option to disable updating dependencies with |GoInstallBinaries|. By
+default this is enabled.
+>
+  let g:go_get_update = 1
 <
 
                                                          *'g:go_guru_scope'*

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -9,7 +9,7 @@ let g:go_loaded_install = 1
 " needed by the user with GoInstallBinaries
 let s:packages = [
             \ "github.com/nsf/gocode",
-            \ "github.com/alecthomas/gometalinter", 
+            \ "github.com/alecthomas/gometalinter",
             \ "golang.org/x/tools/cmd/goimports",
             \ "golang.org/x/tools/cmd/guru",
             \ "golang.org/x/tools/cmd/gorename",
@@ -65,13 +65,16 @@ function! s:GoInstallBinaries(updateBinaries)
         set noshellslash
     endif
 
-    let cmd = "go get -u -v "
+    let cmd = "go get -v "
+    if get(g:, "go_get_update", 1) != 0
+        let cmd .= "-u "
+    endif
 
     let s:go_version = matchstr(go#util#System("go version"), '\d.\d.\d')
 
     " https://github.com/golang/go/issues/10791
     if s:go_version > "1.4.0" && s:go_version < "1.5.0"
-        let cmd .= "-f " 
+        let cmd .= "-f "
     endif
 
     for pkg in s:packages


### PR DESCRIPTION
Not all GOPATHs are made equal and some don't work well with `go get -u`. This allows users to disable the `-u` for `go get`'s.

cc @si74