### PR TITLE
escape #

### DIFF
--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -171,10 +171,10 @@ function! go#tool#OpenBrowser(url)
         return
     endif
     if cmd =~ '^!'
-        let cmd = substitute(cmd, '%URL%', '\=shellescape(a:url)', 'g')
+        let cmd = substitute(cmd, '%URL%', '\=escape(shellescape(a:url),"#")', 'g')
         silent! exec cmd
     elseif cmd =~ '^:[A-Z]'
-        let cmd = substitute(cmd, '%URL%', '\=a:url', 'g')
+        let cmd = substitute(cmd, '%URL%', '\=escape(a:url,"#")', 'g')
         exec cmd
     else
         let cmd = substitute(cmd, '%URL%', '\=shellescape(a:url)', 'g')


### PR DESCRIPTION
`#` is handled as alternative file on command-line of vim.