### PR TITLE
coverage: fix running coverage for neovim

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -198,7 +198,9 @@ function! go#cmd#Test(bang, compile, ...)
     if a:0
         " expand all wildcards(i.e: '%' to the current file name)
         let goargs = map(copy(a:000), "expand(v:val)")
-        let goargs = go#util#Shelllist(goargs, 1)
+        if !has('nvim')
+            let goargs = go#util#Shelllist(goargs, 1)
+        endif
 
         call extend(args, goargs, 1)
     else


### PR DESCRIPTION
Neovim didn't like escaping it. Just disable it.

Closes #899