### PR TITLE
snippet: make json field tag expansion smarter

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1044,6 +1044,28 @@ is used. Use "neosnippet" for neosnippet.vim: >
   let g:go_snippet_engine = "ultisnips"
 <
 
+                                                  *'g:go_snippet_case_type'*
+
+Use this option to define the default conversion type of snippet expansion for
+field tags. For the following case, if `snakecase` is used the `json` snippet
+will expand to:
+>
+  type T struct {
+    FooBarQuz string `json:"foo_bar_quz"
+  }
+<
+
+If "camelcase" is used:
+>
+  type T struct {
+    FooBarQuz string `json:"fooBarQuz"
+  }
+<
+By default "snakecase" is used. Current values are: ["snakecase", "camelcase"].
+>
+  let g:go_snippet_case_type = "snakecase"
+<
+
                                                          *'g:go_get_update'*
 
 Use this option to disable updating dependencies with |GoInstallBinaries|. By

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -186,7 +186,7 @@ endsnippet
 
 # json field tag
 snippet json "\`json:key\`"
-\`json:"${1:`!v  tolower(matchstr(getline("."), '\w\+'))`}"\`
+\`json:"${1:`!v  go#util#snippetcase(matchstr(getline("."), '\w\+'))`}"\`
 endsnippet
 
 # fallthrough


### PR DESCRIPTION
Now the `json` snippet expansion is much more smarter. It does the followings:

* The placeholder is pre populated according to the first word in the line
* It automatically converts it to either `snakecase` or `camelcase`

Demo:

![screen recording 2016-07-05 at 04 15 am](https://cloud.githubusercontent.com/assets/438920/16571548/23eede82-4267-11e6-9636-ebdda04027aa.gif)
