### PR TITLE
allow auto features to be disabled without restarting Vim

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -143,44 +143,64 @@ function! s:echo_go_info()
   redraws! | echo "vim-go: " | echohl Function | echon item.info | echohl None
 endfunction
 
+function! s:auto_sameids()
+  " GoSameId automatic update
+  if get(g:, "go_auto_sameids", 0)
+    call go#guru#SameIds(-1)
+  endif
+endfunction
+
+function! s:auto_type_info()
+  " GoInfo automatic update
+  if get(g:, "go_auto_type_info", 0)
+    call go#complete#Info(1)
+  endif
+endfunction
+
+function! s:fmt_autosave()
+  " Go code formatting on save
+  if get(g:, "go_fmt_autosave", 1)
+    call go#fmt#Format(-1)
+  endif
+endfunction
+
+function! s:asmfmt_autosave()
+  " Go asm formatting on save
+  if get(g:, "go_asmfmt_autosave", 1)
+    call go#asmfmt#Format()
+  endif
+endfunction
+
+function! s:metalinter_autosave()
+  " run gometalinter on save
+  if get(g:, "go_metalinter_autosave", 0)
+    call go#lint#Gometa(1)
+  endif
+endfunction
+
+function! s:template_autocreate()
+  " create new template from scratch
+  if get(g:, "go_template_autocreate", 1)
+    call go#template#create()
+  endif
+endfunction
+
 augroup vim-go
   autocmd!
 
-  " GoInfo automatic update
-  if get(g:, "go_auto_type_info", 0)
-    autocmd CursorHold *.go nested call go#complete#Info(1)
-  endif
-
-  " GoSameId automatic update
-  if get(g:, "go_auto_sameids", 0)
-    autocmd CursorMoved *.go nested call go#guru#SameIds(-1)
-  endif
+  autocmd CursorHold *.go call s:auto_type_info()
+  autocmd CursorMoved *.go call s:auto_sameids()
 
   " Echo the identifier information when completion is done. Useful to see
   " the signature of a function, etc...
   if exists('##CompleteDone')
-    autocmd CompleteDone *.go nested call s:echo_go_info()
+    autocmd CompleteDone *.go call s:echo_go_info()
   endif
 
-  " Go code formatting on save
-  if get(g:, "go_fmt_autosave", 1)
-    autocmd BufWritePre *.go call go#fmt#Format(-1)
-  endif
-
-  " Go asm formatting on save
-  if get(g:, "go_asmfmt_autosave", 1)
-    autocmd BufWritePre *.s call go#asmfmt#Format()
-  endif
-
-  " run gometalinter on save
-  if get(g:, "go_metalinter_autosave", 0)
-    autocmd BufWritePost *.go call go#lint#Gometa(1)
-  endif
-
-  " create new template from scratch
-  if get(g:, "go_template_autocreate", 1)
-    autocmd BufNewFile *.go call go#template#create()
-  endif
+  autocmd BufWritePre *.go call s:fmt_autosave()
+  autocmd BufWritePre *.s call s:asmfmt_autosave()
+  autocmd BufWritePost *.go call s:metalinter_autosave()
+  autocmd BufNewFile *.go call s:template_autocreate()
 augroup END
 
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
I find sometimes want to change the settings of vim-go that control whether or not some actions happen in response to events (e.g. formatting, linting, etc.). This change allows the settings to be changed at runtime instead of having to restart Vim to pick up the changes.

There were a couple of `autocmd` entries where I removed the `nested` argument, because it didn't seem to be necessary.