### PR TITLE
allow goSameId highlight group to be overridden

### DIFF
--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -327,8 +327,6 @@ function! go#guru#SameIds(selected)
     return
   endif
 
-  hi goSameId term=bold cterm=bold ctermbg=white ctermfg=black
-
   let same_ids = result['sameids']
   " highlight the lines
   for item in same_ids

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -366,7 +366,7 @@ if g:go_highlight_build_constraints != 0
   hi def link goPackageComment    Comment
 endif
 
-hi def link goSameId IncSearch
+hi def goSameId term=bold cterm=bold ctermbg=white ctermfg=black
 
 " Search backwards for a global declaration to start processing the syntax.
 "syn sync match goSync grouphere NONE /^\(const\|var\|type\|func\)\>/


### PR DESCRIPTION
Move the modification of the goSameId highlight group from
autoload/go/guru.vim to a proper definition in syntax/go.vim so that
users can customize it.