### PR TITLE
Add ToggleSameIds

### DIFF
--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -346,4 +346,12 @@ function! go#guru#ClearSameIds()
   endfor
 endfunction
 
+function! go#guru#ToggleSameIds(selected)
+  if len(getmatches()) != 0 
+    call go#guru#ClearSameIds()
+  else
+    call go#guru#SameIds(a:selected)
+  endif
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -14,6 +14,7 @@ command! -range=% GoReferrers call go#guru#Referrers(<count>)
 command! -nargs=? GoGuruTags call go#guru#Tags(<f-args>)
 command! -range=% GoSameIds call go#guru#SameIds(<count>)
 command! -range=0 GoSameIdsClear call go#guru#ClearSameIds()
+command! -range=% GoToggleSameIds call go#guru#ToggleSameIds(<count>)
 
 " -- tool
 command! -nargs=0 GoFiles echo go#tool#Files()

--- a/ftplugin/go/mappings.vim
+++ b/ftplugin/go/mappings.vim
@@ -44,6 +44,7 @@ xnoremap <silent> <Plug>(go-freevars) :<C-u>call go#guru#Freevars(0)<CR>
 nnoremap <silent> <Plug>(go-channelpeers) :<C-u>call go#guru#ChannelPeers(-1)<CR>
 nnoremap <silent> <Plug>(go-referrers) :<C-u>call go#guru#Referrers(-1)<CR>
 nnoremap <silent> <Plug>(go-sameids) :<C-u>call go#guru#SameIds(-1)<CR>
+nnoremap <silent> <Plug>(go-toggle-sameids) :<C-u>call go#guru#ToggleSameIds(-1)<CR>
 
 nnoremap <silent> <Plug>(go-rename) :<C-u>call go#rename#Rename(!g:go_jump_to_error)<CR>
 


### PR DESCRIPTION
Auto sameIds is cool, but it doesn't behave nicely in large files, where scolling the screen causes the cursor to move and therefore change the identifier that's being matched. This change allows me to quickly turn on and off same-id highlighting, and have the highlighting stay in effect as I scroll through the file. 