### PR TITLE
add commands to toggle settings that control auto behavior

### DIFF
--- a/autoload/go/asmfmt.vim
+++ b/autoload/go/asmfmt.vim
@@ -51,4 +51,15 @@ function! go#asmfmt#Format()
   call winrestview(l:curw)
 endfunction
 
+function! go#asmfmt#ToggleAsmFmtAutoSave()
+  if get(g:, "go_asmfmt_autosave", 1)
+    let g:go_asmfmt_autosave = 0
+    call go#util#EchoProgress("auto asmfmt disabled")
+    return
+  end
+
+  let g:go_asmfmt_autosave = 1
+  call go#util#EchoProgress("auto asmfmt enabled")
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -153,4 +153,16 @@ function! go#complete#Complete(findstart, base)
   endif
 endf
 
+function! go#complete#ToggleAutoTypeInfo()
+  if get(g:, "go_auto_type_info", 0)
+    let g:go_auto_type_info = 0
+    call go#util#EchoProgress("auto type info disabled")
+    return
+  end
+
+  let g:go_auto_type_info = 1
+  call go#util#EchoProgress("auto type info enabled")
+endfunction
+
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -207,4 +207,14 @@ function! go#fmt#Format(withGoimport)
   endif
 endfunction
 
+function! go#fmt#ToggleFmtAutoSave()
+  if get(g:, "go_fmt_autosave", 1)
+    let g:go_fmt_autosave = 0
+    call go#util#EchoProgress("auto fmt disabled")
+    return
+  end
+
+  let g:go_fmt_autosave = 1
+  call go#util#EchoProgress("auto fmt enabled")
+endfunction
 " vim: sw=2 ts=2 et

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -196,4 +196,15 @@ function! go#lint#Errcheck(...) abort
 
 endfunction
 
+function! go#lint#ToggleMetaLinterAutoSave()
+  if get(g:, "go_metalinter_autosave", 0)
+    let g:go_metalinter_autosave = 0
+    call go#util#EchoProgress("auto metalinter disabled")
+    return
+  end
+
+  let g:go_metalinter_autosave = 1
+  call go#util#EchoProgress("auto metalinter enabled")
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/template.vim
+++ b/autoload/go/template.vim
@@ -28,4 +28,15 @@ function! go#template#create()
   execute cd . fnameescape(dir)
 endfunction
 
+function! go#template#ToggleAutoCreate()
+  if get(g:, "go_template_autocreate", 1)
+    let g:go_template_autocreate = 0
+    call go#util#EchoProgress("auto template create disabled")
+    return
+  end
+
+  let g:go_template_autocreate = 1
+  call go#util#EchoProgress("auto template create enabled")
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -641,6 +641,7 @@ CTRL-t
 >
       :GoImpl f *Foo io.Writer
       :GoImpl T io.ReadWriteCloser
+<
 
                                                               *:GoToggleAutoTypeInfo*
 :GoToggleAutoTypeInfo

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -643,33 +643,28 @@ CTRL-t
       :GoImpl T io.ReadWriteCloser
 <
 
-                                                              *:GoToggleAutoTypeInfo*
-:GoToggleAutoTypeInfo
+                                                              *:GoAutoTypeInfoToggle*
+:GoAutoTypeInfoToggle
 
     Toggles |g:go_auto_type_info|.
 
-                                                              *:GoToggleAutoSameIds*
-:GoToggleAutoSameIds
-
-    Toggles |g:go_auto_sameids|.
-  
-                                                              *:GoToggleFmtAutoSave*
-:GoToggleFmtAutoSave
+                                                              *:GoFmtAutoSaveToggle*
+:GoFmtAutoSaveToggle
 
     Toggles |g:go_fmt_autosave|.
 
-                                                              *:GoToggleAsmFmtAutoSave*
-:GoToggleAsmFmtAutoSave
+                                                              *:GoAsmFmtAutoSaveToggle*
+:GoAsmFmtAutoSaveToggle
 
     Toggles |g:go_asmfmt_autosave|.
 
-                                                              *:GoToggleMetalinterAutoSave*
-:GoToggleMetalinterAutoSave
+                                                              *:GoMetalinterAutoSaveToggle*
+:GoMetalinterAutoSaveToggle
 
     Toggles |g:go_metalinter_autosave|.
 
-                                                              *:GoToggleTemplateAutoCreate*
-:GoToggleTemplateAutoCreate
+                                                              *:GoTemplateAutoCreateToggle*
+:GoTemplateAutoCreateToggle
 
     Toggles |g:go_template_autocreate|.
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -641,8 +641,36 @@ CTRL-t
 >
       :GoImpl f *Foo io.Writer
       :GoImpl T io.ReadWriteCloser
-<
+
+                                                              *:GoToggleAutoTypeInfo*
+:GoToggleAutoTypeInfo
+
+    Toggles |g:go_auto_type_info|.
+
+                                                              *:GoToggleAutoSameIds*
+:GoToggleAutoSameIds
+
+    Toggles |g:go_auto_sameids|.
   
+                                                              *:GoToggleFmtAutoSave*
+:GoToggleFmtAutoSave
+
+    Toggles |g:go_fmt_autosave|.
+
+                                                              *:GoToggleAsmFmtAutoSave*
+:GoToggleAsmFmtAutoSave
+
+    Toggles |g:go_asmfmt_autosave|.
+
+                                                              *:GoToggleMetalinterAutoSave*
+:GoToggleMetalinterAutoSave
+
+    Toggles |g:go_metalinter_autosave|.
+
+                                                              *:GoToggleTemplateAutoCreate*
+:GoToggleTemplateAutoCreate
+
+    Toggles |g:go_template_autocreate|.
 
 ===============================================================================
 MAPPINGS                                                        *go-mappings*

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -19,6 +19,7 @@ command! -range=0 GoSameIdsClear call go#guru#ClearSameIds()
 command! -nargs=0 GoFiles echo go#tool#Files()
 command! -nargs=0 GoDeps echo go#tool#Deps()
 command! -nargs=* GoInfo call go#complete#Info(0)
+command! -nargs=0 GoAutoTypeInfoToggle call go#complete#ToggleAutoTypeInfo()
 
 " -- cmd
 command! -nargs=* -bang GoBuild call go#cmd#Build(<bang>0,<f-args>)
@@ -50,7 +51,11 @@ command! -nargs=* -range -complete=customlist,go#package#Complete GoDocBrowser c
 
 " -- fmt
 command! -nargs=0 GoFmt call go#fmt#Format(-1)
+command! -nargs=0 GoFmtAutoSaveToggle call go#fmt#ToggleFmtAutoSave()
 command! -nargs=0 GoImports call go#fmt#Format(1)
+
+" -- asmfmt
+command! -nargs=0 GoAsmFmtAutoSaveToggle call go#asmfmt#ToggleAsmFmtAutoSave()
 
 " -- import
 command! -nargs=? -complete=customlist,go#package#Complete GoDrop call go#import#SwitchImport(0, '', <f-args>, '')
@@ -59,6 +64,7 @@ command! -nargs=* -bang -complete=customlist,go#package#Complete GoImportAs call
 
 " -- linters
 command! -nargs=* GoMetaLinter call go#lint#Gometa(0, <f-args>)
+command! -nargs=0 GoMetalinterAutoSaveToggle call go#lint#ToggleMetaLinterAutoSave()
 command! -nargs=* GoLint call go#lint#Golint(<f-args>)
 command! -nargs=* -bang GoVet call go#lint#Vet(<bang>0, <f-args>)
 command! -nargs=* -complete=customlist,go#package#Complete GoErrCheck call go#lint#Errcheck(<f-args>)
@@ -74,5 +80,8 @@ endif
 
 " -- impl
 command! -nargs=* -buffer -complete=customlist,go#impl#Complete GoImpl call go#impl#Impl(<f-args>)
+
+" -- template
+command! -nargs=0 GoTemplateAutoCreateToggle call go#template#ToggleAutoCreate()
 
 " vim: sw=2 ts=2 et

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -27,7 +27,6 @@ command! GoInstallBinaries call s:GoInstallBinaries(-1)
 command! GoUpdateBinaries call s:GoInstallBinaries(1)
 command! -nargs=? -complete=dir GoPath call go#path#GoPath(<f-args>)
 
-
 " GoInstallBinaries downloads and install all necessary binaries stated in the
 " packages variable. It uses by default $GOBIN or $GOPATH/bin as the binary
 " target install directory. GoInstallBinaries doesn't install binaries if they
@@ -143,17 +142,17 @@ function! s:echo_go_info()
   redraws! | echo "vim-go: " | echohl Function | echon item.info | echohl None
 endfunction
 
-function! s:auto_sameids()
-  " GoSameId automatic update
-  if get(g:, "go_auto_sameids", 0)
-    call go#guru#SameIds(-1)
-  endif
-endfunction
-
 function! s:auto_type_info()
   " GoInfo automatic update
   if get(g:, "go_auto_type_info", 0)
     call go#complete#Info(1)
+  endif
+endfunction
+
+function! s:auto_sameids()
+  " GoSameId automatic update
+  if get(g:, "go_auto_sameids", 0)
+    call go#guru#SameIds(-1)
   endif
 endfunction
 
@@ -184,6 +183,32 @@ function! s:template_autocreate()
     call go#template#create()
   endif
 endfunction
+
+function! s:toggle_auto_type_info()
+  let g:go_auto_type_info = !get(g:, "go_auto_type_info, 0)
+endfunction
+function! s:toggle_auto_sameids()
+  let g:go_auto_sameids = !get(g:, "go_auto_sameids", 0)
+endfunction
+function! s:toggle_fmt_autosave()
+  let g:go_fmt_autosave = !get(g:, "go_fmt_autosave", 1)
+endfunction
+function! s:toggle_asmfmt_autosave()
+  let g:go_asmfmt_autosave = !get(g:, "go_asmfmt_autosave", 1)
+endfunction
+function! s:toggle_metalinter_autosave()
+  let g:go_metalinter_autosave = !get(g:, "go_metalinter_autosave", 0)
+endfunction
+function! s:toggle_template_autocreate()
+  let go:go_template_autocreate = !get(g:, "go_template_autocreate", 1)
+endfunction
+
+command! -nargs=0 GoToggleAutoTypeInfo call s:toggle_auto_type_info()
+command! -nargs=0 GoToggleAutoSameIds call s:toggle_auto_sameids()
+command! -nargs=0 GoToggleFmtAutoSave call s:toggle_fmt_autosave()
+command! -nargs=0 GoToggleAsmFmtAutoSave call s:toggle_asmfmt_autosave()
+command! -nargs=0 GoToggleMetalinterAutoSave call s:toggle_metalinter_autosave()
+command! -nargs=0 GoToggleTemplateAutoCreate call s:toggle_template_autocreate()
 
 augroup vim-go
   autocmd!

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -184,32 +184,6 @@ function! s:template_autocreate()
   endif
 endfunction
 
-function! s:toggle_auto_type_info()
-  let g:go_auto_type_info = !get(g:, "go_auto_type_info, 0)
-endfunction
-function! s:toggle_auto_sameids()
-  let g:go_auto_sameids = !get(g:, "go_auto_sameids", 0)
-endfunction
-function! s:toggle_fmt_autosave()
-  let g:go_fmt_autosave = !get(g:, "go_fmt_autosave", 1)
-endfunction
-function! s:toggle_asmfmt_autosave()
-  let g:go_asmfmt_autosave = !get(g:, "go_asmfmt_autosave", 1)
-endfunction
-function! s:toggle_metalinter_autosave()
-  let g:go_metalinter_autosave = !get(g:, "go_metalinter_autosave", 0)
-endfunction
-function! s:toggle_template_autocreate()
-  let go:go_template_autocreate = !get(g:, "go_template_autocreate", 1)
-endfunction
-
-command! -nargs=0 GoToggleAutoTypeInfo call s:toggle_auto_type_info()
-command! -nargs=0 GoToggleAutoSameIds call s:toggle_auto_sameids()
-command! -nargs=0 GoToggleFmtAutoSave call s:toggle_fmt_autosave()
-command! -nargs=0 GoToggleAsmFmtAutoSave call s:toggle_asmfmt_autosave()
-command! -nargs=0 GoToggleMetalinterAutoSave call s:toggle_metalinter_autosave()
-command! -nargs=0 GoToggleTemplateAutoCreate call s:toggle_template_autocreate()
-
 augroup vim-go
   autocmd!
 


### PR DESCRIPTION
Add commands to toggle settings that control automatic behaviors. All the new commands begin with `GoToggle`, and are suffixed with the name of the setting, but using PascalCase in place of snake_case.

Also moved one function so that all functions called by events and functions that control settings are in the same relative order as the respective events.