### PR TITLE
Replace 'he=e-1' with '\ze'

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -306,7 +306,7 @@ hi def link     goFunction          Function
 
 " Methods;
 if g:go_highlight_methods != 0
-  syn match goMethod                /\.\w\+(/hs=s+1,he=e-1
+  syn match goMethod                /\.\w\+\ze(/hs=s+1
 endif
 hi def link     goMethod            Type
 


### PR DESCRIPTION
Replace 'he=e-1' with '\ze' to avoid conflicts with other highlight plugins (e.g. luochen1990/rainbow).