### PR TITLE
util: add go#util#env function

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -32,7 +32,9 @@ function! s:gocodeCommand(cmd, preargs, args)
   " we might hit cache problems, as gocode doesn't handle well different
   " GOPATHS: https://github.com/nsf/gocode/issues/239
   let old_gopath = $GOPATH
+  let old_goroot = $GOROOT
   let $GOPATH = go#path#Detect()
+  let $GOROOT = go#util#env("goroot")
 
   let socket_type = get(g:, 'go_gocode_socket_type', s:sock_type)
   let cmd = printf('%s -sock %s %s %s %s', 
@@ -45,6 +47,8 @@ function! s:gocodeCommand(cmd, preargs, args)
 
   let result = go#util#System(cmd)
   let $GOPATH = old_gopath
+  let $GOROOT = old_goroot
+
   if go#util#ShellError() != 0
     return "[\"0\", []]"
   else

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -121,7 +121,9 @@ endfunction
 
 function! go#tool#ExecuteInDir(cmd) abort
   let old_gopath = $GOPATH
+  let old_goroot = $GOROOT
   let $GOPATH = go#path#Detect()
+  let $GOROOT = go#util#env("goroot")
 
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
   let dir = getcwd()
@@ -132,6 +134,7 @@ function! go#tool#ExecuteInDir(cmd) abort
     execute cd . fnameescape(dir)
   endtry
 
+  let $GOROOT = old_goroot
   let $GOPATH = old_gopath
   return out
 endfunction

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -43,6 +43,31 @@ function! go#util#IsWin()
   return 0
 endfunction
 
+let s:env_cache = {}
+
+" env returns the go environment variable for the given key. Where key can be
+" GOARCH, GOOS, GOROOT, etc... It caches the result and returns the cached
+" version. 
+function! go#util#env(key)
+  let l:key = tolower(a:key)
+  if has_key(s:env_cache, l:key)
+    return s:env_cache[l:key]
+  endif
+
+  if executable('go')
+    let l:var = call('go#util#'.l:key, [])
+    if go#util#ShellError() != 0
+      call go#util#EchoError(printf("'go env %s' failed", toupper(l:key)))
+      return ''
+    endif
+  else
+    let l:var = eval("$".toupper(a:key))
+  endif
+
+  let s:env_cache[l:key] = l:var
+  return l:var
+endfunction
+
 function! go#util#goarch()
   return substitute(go#util#System('go env GOARCH'), '\n', '', 'g')
 endfunction


### PR DESCRIPTION
Add new function to return cached version of Go environment variables.
With that set GOROOT everytime we execute gocode. This will prevent
gocode using the internal embedded GOROOT and will use the GOROOT from
the latest installed Go version.

Fixes #901