### PR TITLE
go#fmt#Format fails on new unsaved files

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -155,7 +155,7 @@ function! go#fmt#Format(withGoimport)
     endif
     call rename(l:tmpname, expand('%'))
     " restore old file permissions
-    if exists("*setfperm")
+    if exists("*setfperm") && original_fperm != ''
       call setfperm(expand('%'), original_fperm)
     endif
     silent edit!


### PR DESCRIPTION
make sure that we pass a valid parameter to setfperm function.