### PR TITLE
Escape all template path special characters

### DIFF
--- a/autoload/go/template.vim
+++ b/autoload/go/template.vim
@@ -10,13 +10,13 @@ function! go#template#create()
   let l:package_name = go#tool#PackageName()
 
   " if we can't figure out any package name(no Go files or non Go package
-  " files) from the directory create the template 
+  " files) from the directory create the template
   if l:package_name == -1
     let l:template_file = get(g:, 'go_template_file', "hello_world.go")
     let l:template_path = go#util#Join(l:root_dir, "templates", l:template_file)
-    exe '0r ' . l:template_path
+    exe '0r ' . fnameescape(l:template_path)
     $delete _
-  else  
+  else
     let l:content = printf("package %s", l:package_name)
     call append(0, l:content)
     $delete _


### PR DESCRIPTION
Add `fnameescape()` to handle any special characters within a template path.

Example: usage of `hello_word.go` template with a space within path is broken.
![screen shot 2016-07-27 at 9 31 45 am](https://cloud.githubusercontent.com/assets/15719/17175470/18bb902c-53de-11e6-8e5f-23958e9ce4d8.png)
