### PR TITLE
Reset shell before running a command in go#util#System

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -92,11 +92,11 @@ else
 endif
 
 function! go#util#System(str, ...)
-    let l:shell = &shell
-    let &shell = '/bin/sh'
-    let l:output = call(s:vim_system, [a:str] + a:000)
-    let &shell = l:shell
-    return l:output
+  let l:shell = &shell
+  let &shell = '/bin/sh'
+  let l:output = call(s:vim_system, [a:str] + a:000)
+  let &shell = l:shell
+  return l:output
 endfunction
 
 function! go#util#ShellError()

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -92,7 +92,11 @@ else
 endif
 
 function! go#util#System(str, ...)
-  return call(s:vim_system, [a:str] + a:000)
+    let l:shell = &shell
+    let &shell = '/bin/sh'
+    let l:output = call(s:vim_system, [a:str] + a:000)
+    let &shell = l:shell
+    return l:output
 endfunction
 
 function! go#util#ShellError()


### PR DESCRIPTION
This makes sure the commands still work when using a non-Bourne shell such as
fish or tcsh.

:help vim-doc recommends:

        set shell='/bin/sh'

But this is not a great solution. This will mean that `:sh` will now invoke
`/bin/sh`, instead of `tcsh` or `fish`. It also means that things such as shell
aliases for `:!` will no longer work.