### PR TITLE
tool: use double quotes in PackageName for Windows compatibility

### DIFF
--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -44,7 +44,7 @@ function! go#tool#Imports()
 endfunction
 
 function! go#tool#PackageName()
-  let command = "go list -f '{{.Name}}'"
+  let command = "go list -f \"{{.Name}}\""
   let out = go#tool#ExecuteInDir(command)
   if go#util#ShellError() != 0
       return -1


### PR DESCRIPTION
Tested on Mac OS X using bash/zsh as Vim's shell, Linux with bash/zsh as Vim's shell and on Windows 10.

Fixes #959.
