### PR TITLE
Add support for FZF for :GoDecls

### DIFF
--- a/autoload/fzf/decls.vim
+++ b/autoload/fzf/decls.vim
@@ -1,0 +1,154 @@
+function! s:code(group, attr)
+  let code = synIDattr(synIDtrans(hlID(a:group)), a:attr, "cterm")
+  if code =~ '^[0-9]\+$'
+    return code
+  endif
+endfunction
+
+function! s:color(str, group)
+  let fg = s:code(a:group, "fg")
+  let bg = s:code(a:group, "bg")
+  let bold = s:code(a:group, "bold")
+  let italic = s:code(a:group, "italic")
+  let reverse = s:code(a:group, "reverse")
+  let underline = s:code(a:group, "underline")
+  let color = (empty(fg) ? "" : ("38;5;".fg)) .
+            \ (empty(bg) ? "" : (";48;5;".bg)) .
+            \ (empty(bold) ? "" : ";1") .
+            \ (empty(italic) ? "" : ";3") .
+            \ (empty(reverse) ? "" : ";7") .
+            \ (empty(underline) ? "" : ";4")
+  return printf("\x1b[%sm%s\x1b[m", color, a:str)
+endfunction
+
+function! s:sink(str)
+  if len(a:str) < 2
+    return
+  endif
+  let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
+  let dir = getcwd()
+  try
+    " we jump to the file directory so we can get the fullpath via fnamemodify
+    " below
+    execute cd . s:current_dir
+
+    let vals = matchlist(a:str[1], '|\(.\{-}\):\(\d\+\):\(\d\+\)\s*\(.*\)|')
+
+    " i.e: main.go
+    let filename =  vals[1]
+    let line =  vals[2]
+    let col =  vals[3]
+
+    " i.e: /Users/fatih/vim-go/main.go
+    let filepath =  fnamemodify(filename, ":p")
+
+    let cmd = get({'ctrl-x': 'split',
+          \ 'ctrl-v': 'vertical split',
+          \ 'ctrl-t': 'tabe'}, a:str[0], 'e')
+    execute cmd filepath
+    call cursor(line, col)
+    silent! norm! zvzz
+  finally
+    "jump back to old dir
+    execute cd . fnameescape(dir)
+  endtry
+endfunction
+
+function! s:source(mode,...)
+  let s:current_dir = fnameescape(expand('%:p:h'))
+  let ret_decls = []
+
+  let bin_path = go#path#CheckBinPath('motion')
+  if empty(bin_path)
+    return
+  endif
+  let command = printf("%s -format vim -mode decls", bin_path)
+  let command .= " -include ".  get(g:, "go_decls_includes", "func,type")
+
+  call go#cmd#autowrite()
+
+  if a:mode == 0
+    " current file mode
+    let fname = expand("%:p")
+    if a:0 && !empty(a:1)
+      let fname = a:1
+    endif
+
+    let command .= printf(" -file %s", fname)
+  else
+    " all functions mode
+    if a:0 && !empty(a:1)
+      let s:current_dir = a:1
+    endif
+
+    let command .= printf(" -dir %s", s:current_dir)
+  endif
+
+  let out = go#util#System(command)
+  if go#util#ShellError() != 0
+    call go#util#EchoError(out)
+    return
+  endif
+
+  if exists("l:tmpname")
+    call delete(l:tmpname)
+  endif
+
+  let result = eval(out)
+  if type(result) != 4 || !has_key(result, 'decls')
+    return
+  endif
+
+  let decls = result.decls
+
+  " find the maximum function name
+  let max_len = 0
+  for decl in decls
+    if len(decl.ident)> max_len
+      let max_len = len(decl.ident)
+    endif
+  endfor
+
+  for decl in decls
+    " paddings
+    let space = " "
+    for i in range(max_len - len(decl.ident))
+      let space .= " "
+    endfor
+
+    let pos = printf("|%s:%s:%s|",
+          \ fnamemodify(decl.filename, ":t"),
+          \ decl.line,
+          \ decl.col
+          \)
+    call add(ret_decls, printf("%s\t%s %s\t%s",
+          \ s:color(decl.ident . space, "Function"),
+          \ s:color(decl.keyword, "Keyword"),
+          \ s:color(pos, "SpecialComment"),
+          \ s:color(decl.full, "Comment"),
+          \))
+  endfor
+
+  return ret_decls
+endfunc
+
+function! fzf#decls#cmd(...)
+  let normal_fg = s:code("Normal", "fg")
+  let normal_bg = s:code("Normal", "bg")
+  let cursor_fg = s:code("CursorLine", "fg")
+  let cursor_bg = s:code("CursorLine", "bg")
+  let colors = printf(" --color %s%s%s%s%s",
+        \ &background,
+        \ empty(normal_fg) ? "" : (",fg:".normal_fg),
+        \ empty(normal_bg) ? "" : (",bg:".normal_bg),
+        \ empty(cursor_fg) ? "" : (",fg+:".cursor_fg),
+        \ empty(cursor_bg) ? "" : (",bg+:".cursor_bg),
+        \)
+  call fzf#run(fzf#wrap('GoDecls', {
+        \ 'source': call('<sid>source', a:000),
+        \ 'options': '-n 1 --ansi --prompt "GoDecls> " --expect=ctrl-t,ctrl-v,ctrl-x'.colors,
+        \ 'sink*': function('s:sink')
+        \ }))
+endfunction
+
+" vim: sw=2 ts=2 et

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -641,8 +641,8 @@ CTRL-t
                                                                     *:GoDecls*
 :GoDecls [file]
 
-    Only enabled if `ctrlp.vim` is installed. If run shows all function and
-    type declarations for the current file. If [file] is non empty it parses
+    Only enabled if `ctrlp.vim` or 'fzf' is installed. If run shows all function
+    and type declarations for the current file. If [file] is non empty it parses
     the given file.
     By default `type` and `func` declarations are shown. This can be changed
     via |'g:go_decls_includes'|.
@@ -650,8 +650,8 @@ CTRL-t
                                                                  *:GoDeclsDir*
 :GoDeclsDir [dir]
 
-    Only enabled if `ctrlp.vim` is installed. If run shows all function and
-    type declarations for the current directory. If [dir] is given it parses
+    Only enabled if `ctrlp.vim` or 'fzf' is installed. If run shows all function
+    and type declarations for the current directory. If [dir] is given it parses
     the given directory.
 
                                                                      *:GoImpl*

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -85,6 +85,12 @@ if globpath(&rtp, 'plugin/ctrlp.vim') != ""
   command! -nargs=? -complete=dir GoDeclsDir call ctrlp#init(ctrlp#decls#cmd(1, <q-args>))
 endif
 
+" -- fzf
+if globpath(&rtp, 'plugin/fzf.vim') != ""
+  command! -nargs=? -complete=file GoDecls call fzf#decls#cmd(0, <q-args>)
+  command! -nargs=? -complete=dir GoDeclsDir call fzf#decls#cmd(1, <q-args>)
+endif
+
 " -- impl
 command! -nargs=* -buffer -complete=customlist,go#impl#Complete GoImpl call go#impl#Impl(<f-args>)
 


### PR DESCRIPTION
This pull request includes 2 fixes and one enhancement:
1) Added back guifg attributes for GoCoverage highlighting (this broke on colours for gvim and truecolors neovim)
2) Made GoInstall obey alternative $GOPATH, so the binaries get built correctly when godeps is used.
3) Added support for FZF in GoDecls and GoDeclsDir (FZF is an alternative to CtrlP).
