### PR TITLE
syntax/go.vim: link goVarArgs to Type

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -315,6 +315,7 @@ if g:go_highlight_fields != 0
   syn match goVarArgs               /\.\.\.\w\+\>/
   syn match goField                 /\.\a\+\([\ \n\r\:\)\[]\)\@=/hs=s+1
 endif
+hi def link    goVarArgs            Type
 hi def link    goField              Identifier
 
 " Structs & Interfaces;


### PR DESCRIPTION
Fixes #977