### PR TITLE
goVarArgs highlight groups is too greedy.

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -271,6 +271,7 @@ hi def link     goSpaceError        Error
 syn keyword     goTodo              contained NOTE
 hi def link     goTodo              Todo
 
+syn match goVarArgs /\.\.\./
 
 " Operators;
 if g:go_highlight_operators != 0
@@ -285,9 +286,9 @@ if g:go_highlight_operators != 0
   " match remaining two-char operators: := && || <- ++ --
   syn match goOperator /:=\|||\|<-\|++\|--/
   " match ...
-  syn match goOperator /\.\.\./
 
   hi def link     goPointerOperator   Operator
+  hi def link     goVarArgs           Operator
 endif
 hi def link     goOperator          Operator
 
@@ -312,7 +313,6 @@ hi def link     goMethod            Type
 
 " Fields;
 if g:go_highlight_fields != 0
-  syn match goVarArgs               /\.\.\.\w\+\>/
   syn match goField                 /\.\a\+\([\ \n\r\:\)\[]\)\@=/hs=s+1
 endif
 hi def link    goField              Identifier

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -287,8 +287,8 @@ if g:go_highlight_operators != 0
   syn match goOperator /:=\|||\|<-\|++\|--/
   " match ...
 
-  hi def link     goPointerOperator   Operator
-  hi def link     goVarArgs           Operator
+  hi def link     goPointerOperator   goOperator
+  hi def link     goVarArgs           goOperator
 endif
 hi def link     goOperator          Operator
 


### PR DESCRIPTION
Also this group should be highlighed when g:go_highlight_operators is enabled.
Fixes #977