### PR TITLE
Fixes from wladh

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -143,6 +143,8 @@ endfunction
 " is given(which are passed directly to 'go install') it tries to install those
 " packages. Errors are populated in the location window.
 function! go#cmd#Install(bang, ...)
+  let old_gopath = $GOPATH
+  let $GOPATH = go#path#Detect()
   let default_makeprg = &makeprg
 
   " :make expands '%' and '#' wildcards, so they must also be escaped
@@ -179,6 +181,7 @@ function! go#cmd#Install(bang, ...)
     redraws! | echon "vim-go: " | echohl Function | echon "installed to ". $GOPATH | echohl None
   endif
 
+  let $GOPATH = old_gopath
   let &makeprg = default_makeprg
 endfunction
 

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -371,8 +371,8 @@ hi def goSameId term=bold cterm=bold ctermbg=white ctermfg=black
 
 " :GoCoverage commands
 hi def link goCoverageNormalText Comment
-hi def      goCoverageCovered    ctermfg=green 
-hi def      goCoverageUncover    ctermfg=red 
+hi def      goCoverageCovered    ctermfg=green guifg=#A6E22E
+hi def      goCoverageUncover    ctermfg=red guifg=#F92672
 
 " Search backwards for a global declaration to start processing the syntax.
 "syn sync match goSync grouphere NONE /^\(const\|var\|type\|func\)\>/


### PR DESCRIPTION
Contains from #976 `1` and `2`:

```
1) Added back guifg attributes for GoCoverage highlighting (this broke on colours for gvim and truecolors neovim)
2) Made GoInstall obey alternative $GOPATH, so the binaries get built correctly when godeps is used.
```

cc @wladh 