### PR TITLE
Fix :GoSameIds for light background, GUI, and after changing colour schemes

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -366,13 +366,27 @@ if g:go_highlight_build_constraints != 0
   hi def link goPackageComment    Comment
 endif
 
-" :GoSameIds
-hi def goSameId term=bold cterm=bold ctermbg=white ctermfg=black
-
 " :GoCoverage commands
 hi def link goCoverageNormalText Comment
-hi def      goCoverageCovered    ctermfg=green guifg=#A6E22E
-hi def      goCoverageUncover    ctermfg=red guifg=#F92672
+
+function! s:hi()
+  " :GoSameIds
+  if &background == 'dark'
+    hi def goSameId term=bold cterm=bold ctermbg=white ctermfg=black
+  else
+    hi def goSameId term=bold cterm=bold ctermbg=lightgreen ctermfg=black
+  endif
+
+  " :GoCoverage commands
+  hi def      goCoverageCovered    ctermfg=green guifg=#A6E22E
+  hi def      goCoverageUncover    ctermfg=red guifg=#F92672
+endfunction
+
+augroup vim-go-hi
+  autocmd!
+  autocmd ColorScheme * call s:hi()
+augroup end
+call s:hi()
 
 " Search backwards for a global declaration to start processing the syntax.
 "syn sync match goSync grouphere NONE /^\(const\|var\|type\|func\)\>/

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -372,9 +372,9 @@ hi def link goCoverageNormalText Comment
 function! s:hi()
   " :GoSameIds
   if &background == 'dark'
-    hi def goSameId term=bold cterm=bold ctermbg=white ctermfg=black
+    hi def goSameId term=bold cterm=bold ctermbg=white ctermfg=black guibg=white guifg=black
   else
-    hi def goSameId term=bold cterm=bold ctermbg=lightgreen ctermfg=black
+    hi def goSameId term=bold cterm=bold ctermbg=14 guibg=Cyan
   endif
 
   " :GoCoverage commands


### PR DESCRIPTION
This does three things:

- For light backgrounds the "highlighted" text is typically the same colour as
  the normal text:  ![2016-08-01-060201_1920x1080_scrot](https://cloud.githubusercontent.com/assets/1032692/17283412/4ad4170c-57b0-11e6-9afb-d1f518175926.png)
  So use the `background` setting to set a more appropriate colour.
  I know I can set my own colour, but it would IMHO be better if it just
  works by default.

- The second issue is that most (if not all) colour schemes do this at the
  start:

		" Remove all existing highlighting and set the defaults.
		hi clear

  Which resets all custom highlight groups (except for `:hi link`). So just
  using a "bare" `:hi ctermfg=...` won't work after changing colour schemes:

		:hi goSameId
		goSameId       xxx term=bold cterm=bold ctermfg=0 ctermbg=121

		:colorscheme default

		:hi goSameId
		goSameId       xxx cleared

  The solution is to hook into the `ColorScheme` autocommand.

- And it sets the `guifg`/`guibg` parameters, otherwise nothing gets highlighted when using Gvim...