### PR TITLE
Doc cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ command.
   * `NeoBundle 'fatih/vim-go'`
 *  [Vundle](https://github.com/gmarik/vundle)
   * `Plugin 'fatih/vim-go'`
+*  [Vim packages](http://vimhelp.appspot.com/repeat.txt.html#packages) (since Vim 7.4.1528)
+  * `git clone https://github.com/fatih/vim-go.git ~/.vim/pack/plugins/start/vim-go`
 
 Please be sure all necessary binaries are installed (such as `gocode`, `godef`,
 `goimports`, etc.). You can easily install them with the included

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -83,21 +83,21 @@ add the appropriate lines and execute the plugin's install command.
 
     git clone https://github.com/fatih/vim-go.git ~/.vim/bundle/vim-go
 <
-
 *  https://github.com/junegunn/vim-plug >
 
     Plug 'fatih/vim-go'
 
-<
 *  https://github.com/Shougo/neobundle.vim >
 
     NeoBundle 'fatih/vim-go'
 <
-
 *  https://github.com/gmarik/vundle >
 
     Plugin 'fatih/vim-go'
 
+*  Vim |packages| (since Vim 7.4.1528)
+>
+    git clone https://github.com/fatih/vim-go.git ~/.vim/pack/plugins/start/vim-go
 <
 *  Manual >
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1,18 +1,18 @@
 *vim-go.txt* Go development plugin
 *vim-go*
 
-===============================================================================
-#                                                                             #
-#             ##     ## #### ##     ##          ######    #######             #
-#             ##     ##  ##  ###   ###         ##    ##  ##     ##            #
-#             ##     ##  ##  #### ####         ##        ##     ##            #
-#             ##     ##  ##  ## ### ## ####### ##   #### ##     ##            #
-#              ##   ##   ##  ##     ##         ##    ##  ##     ##            #
-#               ## ##    ##  ##     ##         ##    ##  ##     ##            #
-#                ###    #### ##     ##          ######    #######             #
-#                                                                             #
-===============================================================================
-CONTENTS                                                          *go-contents*
+==============================================================================
+#                                                                            #
+#             ##     ## #### ##     ##          ######    #######            #
+#             ##     ##  ##  ###   ###         ##    ##  ##     ##           #
+#             ##     ##  ##  #### ####         ##        ##     ##           #
+#             ##     ##  ##  ## ### ## ####### ##   #### ##     ##           #
+#              ##   ##   ##  ##     ##         ##    ##  ##     ##           #
+#               ## ##    ##  ##     ##         ##    ##  ##     ##           #
+#                ###    #### ##     ##          ######    #######            #
+#                                                                            #
+==============================================================================
+CONTENTS                                                         *go-contents*
 
   1. Intro........................................|go-intro|
   2. Install......................................|go-install|
@@ -24,8 +24,8 @@ CONTENTS                                                          *go-contents*
   8. Troubleshooting..............................|go-troubleshooting|
   9. Credits......................................|go-credits|
 
-===============================================================================
-INTRO                                                                *go-intro*
+==============================================================================
+INTRO                                                               *go-intro*
 
 Go (golang) support for Vim. vim-go installs automatically all necessary
 binaries for providing seamless Vim integration.  It comes with pre-defined
@@ -34,50 +34,55 @@ support, improved syntax highlighting, go toolchain commands, etc... It's
 highly customizable and each individual feature can be disabled/enabled
 easily.
 
-  * Improved Syntax highlighting with items such as Functions, Operators, Methods.
-  * Auto completion support via `gocode`
-  * Better `gofmt` on save, which keeps cursor position and doesn't break your undo
-    history
-  * Go to symbol/declaration with `:GoDef`
-  * Look up documentation with `:GoDoc` inside Vim or open it in browser
-  * Automatically import packages via `:GoImport` or plug it into autosave
-  * Compile your package with `:GoBuild`, install it with `:GoInstall` or test
-    them with `:GoTest` (also supports running single tests via `:GoTestFunc`)
-  * Quickly execute your current file/files with `:GoRun`
-  * Automatic `GOPATH` detection based on the directory structure (i.e. `gb`
-    projects, `godep` vendored projects)
-  * Change or display `GOPATH` with `:GoPath`
+  * Improved Syntax highlighting with items such as Functions, Operators,
+    Methods.
+  * Auto completion support via `gocode`.
+  * Better `gofmt` on save, which keeps cursor position and doesn't break your
+    undo history.
+  * Go to symbol/declaration with `:GoDef`.
+  * Look up documentation with `:GoDoc` inside Vim or open it in browser.
+  * Automatically import packages via `:GoImport` or plug it into autosave.
+  * Compile your package with `:GoBuild`, install them with `:GoInstall` or
+    test them with `:GoTest` (also supports running single tests with
+    `:GoTestFunc`).
+  * Quickly execute your current file/files with `:GoRun`.
+  * Automatic `GOPATH` detection based on the directory structure (e.g. `gb`
+    projects, `godep` vendored projects).
+  * Change or display `GOPATH` with `:GoPath`.
   * Create a coverage profile and display annotated source code in to see
-    which functions are covered with `:GoCoverage`
-  * Call `gometalinter` with `:GoMetaLinter`, which invokes all possible linters
-    (golint, vet, errcheck, deadcode, etc..) and shows the warnings/errors
-  * Lint your code with `:GoLint`
-  * Run your code through `:GoVet` to catch static errors
+    which functions are covered with `:GoCoverage`.
+  * Call `gometalinter` with `:GoMetaLinter`, which invokes all possible
+    linters (golint, vet, errcheck, deadcode, etc..) and shows the
+    warnings/errors.
+  * Lint your code with `:GoLint`.
+  * Run your code through `:GoVet` to catch static errors.
   * Advanced source analysis tools utilizing guru, such as `:GoImplements`,
-    `:GoCallees`, and `:GoReferrers`
-  * Precise type-safe renaming of identifiers with `:GoRename`
-  * List all source files and dependencies
-  * Unchecked error checking with `:GoErrCheck`
-  * Integrated and improved snippets, supporting `ultisnips` or `neosnippet`
-  * Share your current code to [play.golang.org](http://play.golang.org) with `:GoPlay`
+    `:GoCallees`, and `:GoReferrers`.
+  * Precise type-safe renaming of identifiers with `:GoRename`.
+  * List all source files and dependencies.
+  * Unchecked error checking with `:GoErrCheck`.
+  * Integrated and improved snippets, supporting `ultisnips` or `neosnippet`.
+  * Share your current code to [play.golang.org](http://play.golang.org) with
+    `:GoPlay`
   * On-the-fly type information about the word under the cursor. Plug it into
-    your custom vim function.
-  * Go asm formatting on save
-  * Tagbar support to show tags of the source code in a sidebar with `gotags`
-  * Custom vim text objects such as `a function` or `inner function`
+    your custom Vim function.
+  * Go asm formatting on save.
+  * Tagbar support to show tags of the source code in a sidebar with `gotags`.
+  * Custom vim text objects such as `a function` or `inner function`.
   * A async launcher for the go command is implemented for neovim, fully async
     building and testing.
   * Integrated with the neovim terminal, launch `:GoRun` and other go commands
     in their own new terminal.
-  * Alternate between implementation and test code with `:GoAlternate`
+  * Alternate between implementation and test code with `:GoAlternate`.
 
-===============================================================================
+==============================================================================
 INSTALL                                                           *go-install*
 
-Vim-go follows the standard runtime path structure, so I highly recommend to use
-a common and well known plugin manager to install vim-go. Do not use vim-go with
-other Go plugins. For Pathogen just clone the repo, for other plugin managers
-add the appropriate lines and execute the plugin's install command.
+Vim-go follows the standard runtime path structure, so I highly recommend to
+use a common and well known plugin manager to install vim-go. Do not use
+vim-go with other Go plugins. For Pathogen just clone the repo, for other
+plugin managers add the appropriate lines and execute the plugin's install
+command.
 
 *  https://github.com/tpope/vim-pathogen >
 
@@ -97,19 +102,20 @@ add the appropriate lines and execute the plugin's install command.
 
 *  Vim |packages| (since Vim 7.4.1528)
 >
-    git clone https://github.com/fatih/vim-go.git ~/.vim/pack/plugins/start/vim-go
+    git clone https://github.com/fatih/vim-go.git \
+      ~/.vim/pack/plugins/start/vim-go
 <
 *  Manual >
 
     Copy all of the files into your `~/.vim` directory
 <
 
-Please be sure all necessary binaries are installed (such as `gocode`, `godef`,
-`goimports`, etc..). You can easily install them with the included
-|GoInstallBinaries| command. If you invoke it, all necessary binaries will be
-automatically downloaded and installed to your `$GOBIN` environment (if not set
-it will use `$GOPATH/bin`).  It requires `git` for fetching the individual Go
-packages.
+Please be sure all necessary binaries are installed (such as `gocode`,
+`godef`, `goimports`, etc.). You can easily install them with the included
+|:GoInstallBinaries| command. If you invoke it, all necessary binaries will be
+automatically downloaded and installed to your `$GOBIN` environment (if not
+set it will use `$GOPATH/bin`).  It requires `git` for fetching the individual
+Go packages.
 
 * Autocompletion is enabled by default via `<C-x><C-o>`, to get real-time
 completion (completion by type) install:
@@ -121,18 +127,19 @@ https://github.com/majutsushi/tagbar.
 * For snippet feature install:
 https://github.com/Shougo/neosnippet.vim or
 https://github.com/SirVer/ultisnips.
-* For a better documentation viewer checkout: https://github.com/garyburd/go-explorer
+* For a better documentation viewer check out:
+  https://github.com/garyburd/go-explorer
 
-===============================================================================
-COMMANDS                                                          *go-commands*
+==============================================================================
+COMMANDS                                                         *go-commands*
 
                                                                      *:GoPath*
 :GoPath [path]
 
     GoPath sets and overrides GOPATH with the given {path}. If no {path} is
     given it shows the current GOPATH. If `""` is given as path, it clears
-    current `GOPATH` which was set with |GoPath| and restores `GOPATH` back to
-    the initial value which was sourced when Vim was started.
+    current `GOPATH` which was set with |:GoPath| and restores `GOPATH` back
+    to the initial value which was sourced when Vim was started.
 
                                                                    *:GoImport*
 :GoImport[!] [path]
@@ -183,7 +190,7 @@ COMMANDS                                                          *go-commands*
 
     Filter the current Go buffer through goimports (needs to be installed).
     `goimports` automatically discards/add import path based on the code. Like
-    |GoFmt|, It tries to preserve cursor position and avoids replacing the
+    |:GoFmt|, It tries to preserve cursor position and avoids replacing the
     buffer with stderr output.
 
                                                                      *:GoPlay*
@@ -199,9 +206,9 @@ COMMANDS                                                          *go-commands*
 
     Run `go vet` for the directory under your current file. Vet examines Go
     source code and reports suspicious constructs, such as Printf calls whose
-    arguments do not align with the format string. Vet uses heuristics that do not
-    guarantee all reports are genuine problems, but it can find errors not caught
-    by the compilers.
+    arguments do not align with the format string. Vet uses heuristics that do
+    not guarantee all reports are genuine problems, but it can find errors not
+    caught by the compilers.
 
     You may optionally pass any valid go tool vet flags/options. In this case,
     `go tool vet` is run in place of `go vet`. For a full list please see
@@ -217,36 +224,37 @@ CTRL-]
     Goto declaration/definition for the given [identifier]. If no argument is
     given, it will jump to the declaration under the cursor. By default the
     CTRL-] key and the mapping `gd` are enabled to invoke :GoDef for the
-    identifier under the cursor. See |g:go_def_mapping_enabled| to disable them.
+    identifier under the cursor. See |'g:go_def_mapping_enabled'| to disable
+    them.
 
-    vim-go also keeps a per-window location stack, roughly analagous to how
-    vim's internal |tags| functionality works. This is pushed to every time a
-    jump is made using the GoDef functionality. In essence, this is a LIFO list
-    of file locations you have visited with :GoDef that is retained to help you
-    navigate software. For more information on displaying the stack, see
-    |:GoDefJump|
+    vim-go also keeps a per-window location stack, roughly analogous to how
+    Vim's internal |tags| functionality works. This is pushed to every time a
+    jump is made using the GoDef functionality. In essence, this is a LIFO
+    list of file locations you have visited with :GoDef that is retained to
+    help you navigate software.
 
                                                                  *:GoDefStack*
 :GoDefStack [number]
 
-    This command Jumps to a given location in the jumpstack, retaining all other
-    entries. Jumps to non-existent entries will print an informative message,
-    but are otherwise a noop.
+    This command Jumps to a given location in the jumpstack, retaining all
+    other entries. Jumps to non-existent entries will print an informative
+    message, but are otherwise a noop.
 
-    If no argument is given, it will print out an interactive list of all items
-    in the stack. Its output looks like this:
+    If no argument is given, it will print out an interactive list of all
+    items in the stack. Its output looks like this:
 
-      1 /path/to/first/file.go|1187 col 16|AddThing func(t *Thing)
-    > 2 /path/to/thing/thing.go|624 col 19|String() string
-      3 /path/to/thing/thing.go|744 col 6|func Sprintln(a ...interface{}) string
+      1 /path/first/file.go|1187 col 16|AddThing func(t *Thing)
+    > 2 /path/thing/thing.go|624 col 19|String() string
+      3 /path/thing/thing.go|744 col 6|func Sprintln(a ...interface{}) string
 
     This list shows the identifiers that you jumped to and the file and cursor
-    position before that jump.  The older jumps are at the top, the newer at the
-    bottom.
+    position before that jump.  The older jumps are at the top, the newer at
+    the bottom.
 
-    The '>' points to the active entry.  This entry and any newer entries below
-    it will be replaced if |:GoDef| is done from this location. The CTRL-t and
-    |:GoDefPop| command will jump to the position above the active entry.
+    The '>' points to the active entry.  This entry and any newer entries
+    below it will be replaced if |:GoDef| is done from this location. The
+    CTRL-t and |:GoDefPop| command will jump to the position above the active
+    entry.
 
     Jumps to non-existent entries will print an informative message, but are
     otherwise a noop.
@@ -260,24 +268,24 @@ CTRL-]
 :GoDefPop [count]
 CTRL-t
 
-    Navigate to the [count] earlier entry in the jump stack, retaining the newer
-    entries. If no argument is given, it will jump to the next most recent entry
-    (`:GoDefPop 1`).  If [count] is greater than the number of prior entries,
-    an error will be printed and no jump will be performed.
+    Navigate to the [count] earlier entry in the jump stack, retaining the
+    newer entries. If no argument is given, it will jump to the next most
+    recent entry (`:GoDefPop 1`).  If [count] is greater than the number of
+    prior entries, an error will be printed and no jump will be performed.
 
     If you have used :GoDefPop to jump to an earlier location, and you issue
     another :GoDef command, the current entry will be replaced, and all newer
     entries will be removed, effectively resuming the stack at that location.
 
-    By default [count]CTRL-t is enabled to invoke :GoDefPop.  Similarly, hitting
-    CTRL-t without a prior count is equivalent to `:GoDefPop 1`.  See
-    |g:go_def_mapping_enabled| to disable this.
+    By default [count]CTRL-t is enabled to invoke :GoDefPop.  Similarly,
+    hitting CTRL-t without a prior count is equivalent to `:GoDefPop 1`.  See
+    |'g:go_def_mapping_enabled'| to disable this.
 
                                                                       *:GoRun*
 :GoRun[!] [expand]
 
     Build and run your current main package. By default all main files for the
-    current file is used. If an argument is passed, 'expand' is used as file
+    current file is used. If an argument is passed, [expand] is used as file
     selector. For example use `:GoRun %` to select the current file only.
 
     You may optionally pass any valid go run flags/options. For a full list
@@ -286,7 +294,7 @@ CTRL-t
     If [!] is not given the first error is jumped to.
 
     If using neovim then `:GoRun` will run in a new terminal according to
-    |g:go_term_mode|.
+    |'g:go_term_mode'|.
 
                                                                     *:GoBuild*
 :GoBuild[!] [expand]
@@ -294,10 +302,10 @@ CTRL-t
     Build your package with `go build`. Errors are populated in the quickfix
     window. It automatically builds only the files that depends on the current
     file. `:GoBuild` doesn't produce a result file.
-    Use 'make' to create a result file.
+    Use |:make| to create a result file.
 
     You may optionally pass any valid go build flags/options. For a full list
-    please see `go help build`. Options are expanded with 'expand'.
+    please see `go help build`. Options are expanded with [expand].
 
     If [!] is not given the first error is jumped to.
 
@@ -310,8 +318,8 @@ CTRL-t
     Creates or updates your auto-generated source files by running `go
     generate`.
 
-    You may optionally pass any valid go generate flags/options. For a full list
-    please see `go help generate`. Options are expanded with 'expand'.
+    You may optionally pass any valid go generate flags/options. For a full
+    list please see `go help generate`. Options are expanded with [expand].
 
     If [!] is not given the first error is jumped to.
 
@@ -327,8 +335,8 @@ CTRL-t
 
     Install your package with `go install`.
 
-    You may optionally pass any valid go install flags/options. For a full list
-    please see `go help install`.
+    You may optionally pass any valid go install flags/options. For a full
+    list please see `go help install`.
 
     If [!] is not given the first error is jumped to.
 
@@ -336,21 +344,21 @@ CTRL-t
 :GoTest[!] [expand]
 
     Run the tests on your _test.go files via in your current directory. Errors
-    are populated in the quickfix window.  If an argument is passed, 'expand'
+    are populated in the quickfix window.  If an argument is passed, [expand]
     is used as file selector (useful for cases like `:GoTest ./...`).
 
     You may optionally pass any valid go test flags/options. For a full list
     please see `go help test`.
 
     GoTest timesout automatically after 10 seconds. To customize the timeout
-    use |g:go_test_timeout|. This feature is disabled if any arguments are
+    use |'g:go_test_timeout'|. This feature is disabled if any arguments are
     passed to the `:GoTest` command.
 
     If [!] is not given the first error is jumped to.
 
     If using neovim `:GoTest` will run in a new terminal or run asynchronously
-    in the background according to |g:go_term_enabled|. You can set the mode of
-    the new terminal with |g:go_term_mode|.
+    in the background according to |'g:go_term_enabled'|. You can set the mode
+    of the new terminal with |'g:go_term_mode'|.
 
                                                                  *:GoTestFunc*
 :GoTestFunc[!] [expand]
@@ -364,15 +372,15 @@ CTRL-t
 
     If [!] is not given the first error is jumped to.
 
-    If using neovim `:GoTestFunc` will run in a new terminal or run asynchronously
-    in the background according to |g:go_term_enabled|. You can set the mode of
-    the new terminal with |g:go_term_mode|.
+    If using neovim `:GoTestFunc` will run in a new terminal or run
+    asynchronously in the background according to |'g:go_term_enabled'|. You
+    can set the mode of the new terminal with |'g:go_term_mode'|.
 
                                                               *:GoTestCompile*
 :GoTestCompile[!] [expand]
 
     Compile your _test.go files via in your current directory. Errors are
-    populated in the quickfix window.  If an argument is passed, 'expand' is
+    populated in the quickfix window.  If an argument is passed, [expand] is
     used as file selector (useful for cases like `:GoTest ./...`). Useful to
     not run the tests and capture/fix errors before running the tests or to
     create test binary.
@@ -380,8 +388,8 @@ CTRL-t
     If [!] is not given the first error is jumped to.
 
     If using neovim `:GoTestCompile` will run in a new terminal or run
-    asynchronously in the background according to |g:go_term_enabled|. You can
-    set the mode of the new terminal with |g:go_term_mode|.
+    asynchronously in the background according to |'g:go_term_enabled'|. You
+    can set the mode of the new terminal with |'g:go_term_mode'|.
 
                                                                  *:GoCoverage*
 :GoCoverage[!] [options]
@@ -439,8 +447,8 @@ CTRL-t
 :GoInstallBinaries
 
     Download and Install all necessary Go tool binaries such as `godef`,
-    `goimports`, `gocode`, etc.. under `g:go_bin_path`. Set |g:go_get_update|
-    to disable updating dependencies.
+    `goimports`, `gocode`, etc. under `g:go_bin_path`. Set
+    |'g:go_get_update'| to disable updating dependencies.
 
                                                            *:GoUpdateBinaries*
 :GoUpdateBinaries
@@ -452,7 +460,7 @@ CTRL-t
                                                                *:GoImplements*
 :GoImplements
 
-    Show 'implements' relation for a selected package. A list of interfaces
+    Show "implements" relation for a selected package. A list of interfaces
     for the type that implements an interface under the cursor (or selected
     package) is shown in a location list.
                                                                    *:GoRename*
@@ -467,7 +475,7 @@ CTRL-t
                                                                 *:GoGuruScope*
 :GoGuruScope [pattern] [pattern2] ... [patternN]
 
-    Changes the custom |g:go_guru_scope| setting and overrides it with the
+    Changes the custom |'g:go_guru_scope'| setting and overrides it with the
     given package patterns. The custom scope is cleared (unset) if `""` is
     given as the only path. If no arguments is given it prints the current
     custom scope. Example patterns are:
@@ -491,14 +499,14 @@ CTRL-t
                                                                   *:GoCallees*
 :GoCallees
 
-    Show 'callees' relation for a selected package. A list of possible call
+    Show "callees" relation for a selected package. A list of possible call
     targets for the type under the cursor (or selected package) is shown in a
     location list.
 
                                                                   *:GoCallers*
 :GoCallers
 
-    Show 'callers' relation for a selected function. A list of possible
+    Show "callers" relation for a selected function. A list of possible
     callers for the selected function under the cursor is shown in a location
     list.
 
@@ -514,7 +522,7 @@ CTRL-t
                                                                 *:GoCallstack*
 :GoCallstack
 
-    Shows 'callstack' relation for the selected function. An arbitrary path
+    Shows "callstack" relation for the selected function. An arbitrary path
     from the root of the callgraph to the selected function is shown in a
     location list. This may be useful to understand how the function is
     reached in a given program.
@@ -536,13 +544,13 @@ CTRL-t
 :GoChannelPeers
 
     Shows the set of possible sends/receives on the channel operand of the
-    selected send or receive operation; the selection must be a <- token.
+    selected send or receive operation; the selection must be a `<-` token.
 
     For example, visually select a channel operand in the form of:
-
-      "done <- true"
-
-    and call |GoChannelPeers| on it. It will show where it was allocated, and
+>
+      done <- true
+<
+    And call |:GoChannelPeers| on it. It will show where it was allocated, and
     the sending and receiving endings.
 
                                                                 *:GoReferrers*
@@ -552,27 +560,28 @@ CTRL-t
     object as does the selected identifier, within any package in the analysis
     scope.
 
-                                                                 *:GoSameIds*
+                                                                  *:GoSameIds*
 :GoSameIds
 
     Highlights all identifiers that are equivalent to the identifier under the
     cursor.
 
-                                                          *:GoSameIdsClear*
+                                                             *:GoSameIdsClear*
 :GoSameIdsClear
 
     Clears all SameIds highlights from a |:GoSameIds| call.
 
-                                                          *:GoSameIdsToggle*
+                                                            *:GoSameIdsToggle*
 :GoSameIdsToggle
 
     Toggle between |:GoSameIds| and |:GoSameIdsClear|. 
 
-                                                          *:GoSameIdsAutoToggle*
+                                                        *:GoSameIdsAutoToggle*
 :GoSameIdsAutoToggle
 
     Enables or disables automatic highlighting of |:GoSameIds| while moving
-    the cursor. This basically toggles the option |g:go_auto_sameids| on/off.
+    the cursor. This basically toggles the option |'g:go_auto_sameids'|
+    on/off.
     If enabled it starts highlighting whenever your cursor is. If disabled it
     clears and stops automatic highlighting.
 
@@ -580,48 +589,50 @@ CTRL-t
 :GoMetaLinter [path]
 
     Calls the underlying `gometalinter` tool and displays all warnings and
-    errors in the quickfix window. By default the following linters are
-    enabled: "'vet', 'golint', 'errcheck'". This can be changed with the
-    |g:go_metalinter_enabled| variable. To override the command completely use
-    the variable |g:go_metalinter_command|. To override the maximum linters
-    execution time use |g:go_metalinter_deadline| variable.
+    errors in the |quickfix| window. By default the following linters are
+    enabled: `vet`, `golint`, and `errcheck`. This can be changed with the
+    |'g:go_metalinter_enabled'| variable. To override the command completely
+    use the variable |'g:go_metalinter_command'|. To override the maximum
+    linters execution time use |'g:go_metalinter_deadline'| variable.
 
                                                                  *:GoGuruTags*
 :GoGuruTags [tags]
 
-    Changes the custom |g:go_guru_tags| setting and overrides it with the
+    Changes the custom |'g:go_guru_tags'| setting and overrides it with the
     given build tags. This command cooperate with GoReferrers command when
-    there exist mulitiple build tags in your project, then you can set one
-    of the build tags for GoReferrers to find more accurate.
+    there exist mulitiple build tags in your project, then you can set one of
+    the build tags for GoReferrers to find more accurate.
     The custom build tags is cleared (unset) if `""` is given. If no arguments
     is given it prints the current custom build tags.
 
                                                                      *:AsmFmt*
 :AsmFmt
 
-    Filter the current Go asm buffer through asmfmt. It tries to preserve cursor
-    position and avoids replacing the buffer with stderr output.
+    Filter the current Go asm buffer through asmfmt. It tries to preserve
+    cursor position and avoids replacing the buffer with stderr output.
 
                                                                 *:GoAlternate*
 :GoAlternate[!]
 
-    Alternates between the implementation and test code. For example if in main.go,
-    switch to main_test.go. Uses the |g:go_alternate_mode| setting as the command
-    to open the file.
+    Alternates between the implementation and test code. For example if in
+    main.go, switch to main_test.go. Uses the |'g:go_alternate_mode'| setting
+    as the command to open the file.
 
-    If [!] is given then it switches to the new file even if it does not exist.
+    If [!] is given then it switches to the new file even if it does not
+    exist.
 
-    If you would like to override the traditional commands for alternating, add
-    the following to your .vimrc:
+    If you would like to override the traditional commands for alternating,
+    add the following to your .vimrc:
 >
     augroup go
       autocmd!
-      autocmd Filetype go command! -bang A call go#alternate#Switch(<bang>0, 'edit')
-      autocmd Filetype go command! -bang AV call go#alternate#Switch(<bang>0, 'vsplit')
-      autocmd Filetype go command! -bang AS call go#alternate#Switch(<bang>0, 'split')
+      autocmd Filetype go
+        \  command! -bang A call go#alternate#Switch(<bang>0, 'edit')
+        \| command! -bang AV call go#alternate#Switch(<bang>0, 'vsplit')
+        \| command! -bang AS call go#alternate#Switch(<bang>0, 'split')
     augroup END
 <
-                                                              *:GoWhicherrs*
+                                                                *:GoWhicherrs*
 :GoWhicherrs
 
     Show the list of possible constants, global variables, and concrete types
@@ -633,10 +644,8 @@ CTRL-t
     Only enabled if `ctrlp.vim` is installed. If run shows all function and
     type declarations for the current file. If [file] is non empty it parses
     the given file.
-    By default `type` and `func` declarations are being showed. This can be
-    changed via |g:go_decls_includes|, which accepts a comma delimited list of
-    definitions. By default set to: `"func,type"`. Possible options are:
-    `{func,type}`
+    By default `type` and `func` declarations are shown. This can be changed
+    via |'g:go_decls_includes'|.
 
                                                                  *:GoDeclsDir*
 :GoDeclsDir [dir]
@@ -644,10 +653,6 @@ CTRL-t
     Only enabled if `ctrlp.vim` is installed. If run shows all function and
     type declarations for the current directory. If [dir] is given it parses
     the given directory.
-    By default `type` and `func` declarations are being showed. This can be
-    changed via |g:go_decls_includes|, which accepts a comma delimited list of
-    definitions. By default set to: `"func,type"`. Possible options are:
-    `{func,type}`
 
                                                                      *:GoImpl*
 :GoImpl [receiver] [interface]
@@ -660,7 +665,7 @@ CTRL-t
       :GoImpl f *Foo io.Writer
       :GoImpl T io.ReadWriteCloser
 <
-                                                              *:GoAddTags*
+                                                                  *:GoAddTags*
 :[range]GoAddTags [key] [key1] ...
 
     Adds field tags for the fields of a struct. If called inside a struct it
@@ -675,33 +680,33 @@ CTRL-t
 >
       :GoAddTags xml db
 <
-                                                              *:GoAutoTypeInfoToggle*
+                                                       *:GoAutoTypeInfoToggle*
 :GoAutoTypeInfoToggle
 
-    Toggles |g:go_auto_type_info|.
+    Toggles |'g:go_auto_type_info'|.
 
-                                                              *:GoFmtAutoSaveToggle*
+                                                        *:GoFmtAutoSaveToggle*
 :GoFmtAutoSaveToggle
 
-    Toggles |g:go_fmt_autosave|.
+    Toggles |'g:go_fmt_autosave'|.
 
-                                                              *:GoAsmFmtAutoSaveToggle*
+                                                     *:GoAsmFmtAutoSaveToggle*
 :GoAsmFmtAutoSaveToggle
 
-    Toggles |g:go_asmfmt_autosave|.
+    Toggles |'g:go_asmfmt_autosave'|.
 
-                                                              *:GoMetalinterAutoSaveToggle*
+                                                 *:GoMetalinterAutoSaveToggle*
 :GoMetalinterAutoSaveToggle
 
-    Toggles |g:go_metalinter_autosave|.
+    Toggles |'g:go_metalinter_autosave'|.
 
-                                                              *:GoTemplateAutoCreateToggle*
+                                                 *:GoTemplateAutoCreateToggle*
 :GoTemplateAutoCreateToggle
 
-    Toggles |g:go_template_autocreate|.
+    Toggles |'g:go_template_autocreate'|.
 
 
-===============================================================================
+==============================================================================
 MAPPINGS                                                        *go-mappings*
 
 vim-go has several <Plug> keys which can be used to create custom mappings
@@ -825,17 +830,17 @@ Goto declaration/definition. Results are shown in the current buffer.
                                                               *(go-def-split)*
 
 Goto declaration/definition. Results are shown in a split window.
-Jumps to an existing buffer if |g:go_def_reuse_buffer| is enabled.
+Jumps to an existing buffer if |'g:go_def_reuse_buffer'| is enabled.
 
                                                            *(go-def-vertical)*
 
 Goto declaration/definition. Results are shown in a vertical split window.
-Jumps to an existing buffer if |g:go_def_reuse_buffer| is enabled.
+Jumps to an existing buffer if |'g:go_def_reuse_buffer'| is enabled.
 
                                                                 *(go-def-tab)*
 
 Goto declaration/definition. Results are shown in a tab window.
-Jumps to an existing buffer if |g:go_def_reuse_buffer| is enabled.
+Jumps to an existing buffer if |'g:go_def_reuse_buffer'| is enabled.
 
                                                               *(go-def-stack)*
 
@@ -906,7 +911,7 @@ Alternates between the implementation and test code in a new vertical split
 Calls `:GoImport` for the current package
 
 
-===============================================================================
+==============================================================================
 TEXT OBJECTS                                                 *go-text-objects*
 
 vim-go comes with several custom |text-objects| that can be used to operate
@@ -914,7 +919,7 @@ upon regions of text. vim-go currently defines the following text objects:
 
                                                *go-v_af* *go-af*
 af            "a function", select contents from a function definition to the
-               closing bracket. If |g:go_textobj_include_function_doc| is
+               closing bracket. If |'g:go_textobj_include_function_doc'| is
                enabled it also includes the comment doc for a function
                declaration. This text-object also supports literal functions.
 
@@ -928,7 +933,7 @@ vim-go also defines the following text motion objects:
 
                                                *go-v_]]* *go-]]*
 ]]            [count] forward to next function declaration. If
-              |g:go_textobj_include_function_doc| is enabled and if your
+              |'g:go_textobj_include_function_doc'| is enabled and if your
               on a comment, it skips the function which the comment
               belongs and forwards to the next function declaration.
 
@@ -937,23 +942,23 @@ vim-go also defines the following text motion objects:
 
 
 
-===============================================================================
+==============================================================================
 FUNCTIONS                                                       *go-functions*
 
                                                   *go#jobcontrol#Statusline()*
 
 Shows the status of a job running asynchronously. Can be used to plug into the
 statusline. It works to show the status per package instead of per
-file. Assume you have three files open, all belonging to the same package,
-if the package build (`:GoBuild`) is successful, all statusline's will be empty
+file. Assume you have three files open, all belonging to the same package, if
+the package build (`:GoBuild`) is successful, all statusline's will be empty
 (means SUCCESS), if you it fails all file's statusline will show FAILED.
 
                                                        *go#complete#GetInfo()*
 
 Returns the description of the identifer under the cursor. Can be used to plug
-into the statusline. This function is also used for |g:go_auto_type_info|.
+into the statusline. This function is also used for |'g:go_auto_type_info'|.
 
-===============================================================================
+==============================================================================
 SETTINGS                                                        *go-settings*
 
                                                          *'g:go_test_timeout'*
@@ -981,13 +986,13 @@ with |:GoPlay|. By default it's enabled. >
 <
                                                        *'g:go_auto_type_info'*
 
-Use this option to show the type info (|:GoInfo|) for the word under the cursor
-automatically. Whenever the cursor changes the type info will be updated.
-By default it's disabled.
+Use this option to show the type info (|:GoInfo|) for the word under the
+cursor automatically. Whenever the cursor changes the type info will be
+updated. By default it's disabled.
 >
   let g:go_auto_type_info = 0
 <
-                                                      *'g:go_auto_sameids'*
+                                                         *'g:go_auto_sameids'*
 
 Use this option to highlight all uses of the identifier under the cursor
 (:GoSameIds) automatically. By default it's disabled.
@@ -1020,14 +1025,14 @@ used >
 <
                                                           *'g:go_fmt_options'*
 
-Use this option to add additional options to the |g:go_fmt_command|. Default
+Use this option to add additional options to the |'g:go_fmt_command'|. Default
 is empty. >
 
   let g:go_fmt_options = ''
 <
                                                     *'g:go_fmt_fail_silently'*
 
-Use this option to disable showing a location list when |g:go_fmt_command|
+Use this option to disable showing a location list when |'g:go_fmt_command'|
 fails. By default the location list is shown. >
 
   let g:go_fmt_fail_silently = 0
@@ -1043,9 +1048,9 @@ it's causing problems on some Vim versions. By default it's disabled. >
 <
                                                *'g:go_doc_keywordprg_enabled'*
 
-Use this option to run `godoc` on words under the cursor with the default
-K , keywordprg shortcut. Usually this shortcut is set to use the program `man`.
-In Go, using `godoc` is more idiomatic. Default is enabled. >
+Use this option to run `godoc` on words under the cursor with the default K ,
+keywordprg shortcut. Usually this shortcut is set to use the program `man`. In
+Go, using `godoc` is more idiomatic. Default is enabled. >
 
   let g:go_doc_keywordprg_enabled = 1
 <
@@ -1060,8 +1065,8 @@ Use this option to define the command to be used for |:GoDef|. By default
                                                   *'g:go_def_mapping_enabled'*
 
 Use this option to enable/disable the default mapping of CTRL-] and (`gd`) for
-GoDef and CTRL-t for :GoDefPop. Disabling it allows you to map something else to
-these keys or mappings. Default is enabled. >
+GoDef and CTRL-t for :GoDefPop. Disabling it allows you to map something else
+to these keys or mappings. Default is enabled. >
 
   let g:go_def_mapping_enabled = 1
 <
@@ -1074,9 +1079,9 @@ mappings of |:GoDef|. By default it's disabled. >
 <
                                                      *'g:go_dispatch_enabled'*
 
-Use this option to enable/disable the use of Dispatch to execute the
-`:GoRun`, `:GoBuild` and `:GoGenerate` commands. More information about Dispatch
-is available at https://github.com/tpope/vim-dispatch. Default is disabled. >
+Use this option to enable/disable the use of Dispatch to execute the `:GoRun`,
+`:GoBuild` and `:GoGenerate` commands. More information about Dispatch is
+available at https://github.com/tpope/vim-dispatch. Default is disabled. >
 
   let g:go_dispatch_enabled = 0
 <
@@ -1089,7 +1094,7 @@ used >
 <
                                                           *'g:go_doc_options'*
 
-Use this option to add additional options to the |g:go_doc_command|. Default
+Use this option to add additional options to the |'g:go_doc_command'|. Default
 is empty. >
 
   let g:go_doc_options = ''
@@ -1097,7 +1102,7 @@ is empty. >
 <                                                            *'g:go_bin_path'*
 
 Use this option to change default path for vim-go tools when using
-|GoInstallBinaries| and |GoUpdateBinaries|. If not set `$GOBIN` or
+|:GoInstallBinaries| and |:GoUpdateBinaries|. If not set `$GOBIN` or
 `$GOPATH/bin` is used. >
 
   let g:go_bin_path = ""
@@ -1126,13 +1131,14 @@ If "camelcase" is used:
     FooBarQuz string `json:"fooBarQuz"
   }
 <
-By default "snakecase" is used. Current values are: ["snakecase", "camelcase"].
+By default "snakecase" is used. Current values are: ["snakecase",
+"camelcase"].
 >
   let g:go_snippet_case_type = "snakecase"
 <
                                                            *'g:go_get_update'*
 
-Use this option to disable updating dependencies with |GoInstallBinaries|. By
+Use this option to disable updating dependencies with |:GoInstallBinaries|. By
 default this is enabled.
 >
   let g:go_get_update = 1
@@ -1140,14 +1146,23 @@ default this is enabled.
                                                            *'g:go_guru_scope'*
 
 Use this option to define the scope of the analysis to be passed for guru
-related commands, such as |GoImplements|, |GoCallers|, etc.You can change it
-on-the-fly with |GoGuruScope|. The input should be a a list of package
+related commands, such as |:GoImplements|, |:GoCallers|, etc. You can change
+it on-the-fly with |:GoGuruScope|. The input should be a a list of package
 pattern. An example input might be:
-`["github.com/fatih/color","github.com/fatih/structs"]` By default it's not set,
-so the relevant commands defaults are being used.
+`["github.com/fatih/color","github.com/fatih/structs"]` By default it's not
+set, so the relevant commands defaults are being used.
 >
   let g:go_guru_scope = []
 <
+                                                        *'g:go_guru_tags'*
+
+These options that will be automatically passed to the `-tags` option of
+`go guru` when it's invoked with |:GoDef|. You can use |:GoGuruTags| to set
+this. By default it's not set.
+>
+  let g:go_guru_tags = ''
+<
+
                                      *'g:go_highlight_array_whitespace_error'*
 
 Highlights white space after "[]". >
@@ -1178,7 +1193,7 @@ Highlights instances of tabs following spaces. >
 Highlights trailing white space. >
 
   let g:go_highlight_trailing_whitespace_error = 1
-
+<
                                                   *'g:go_highlight_operators'*
 
 Highlights operators such as `:=` , `==`, `-=`, etc. By default it's
@@ -1235,7 +1250,7 @@ By default it's enabled. >
 Automatically modifies GOPATH for certain directory structures, such as for
 the tool `godep` which has his own dependencies via the `Godeps` folder. What
 this means is that all tools are now working with the newly modified GOPATH.
-So |GoDef| for example jumps to the source inside the `Godeps` (vendored)
+So |:GoDef| for example jumps to the source inside the `Godeps` (vendored)
 source. Currently `godep` and `gb` is supported, in the near future more tool
 supports will be added. By default it's enabled. >
 
@@ -1247,6 +1262,13 @@ Adds custom text objects. By default it's enabled. >
 
   let g:go_textobj_enabled = 1
 <
+                                         *'g:go_textobj_include_function_doc'*
+
+Consider the comment above a function to be part of the function when using
+the `af` text object and `[[` motion. By default it's enabled. >
+
+  let g:go_textobj_include_function_doc = 1
+<
                                                   *'g:go_metalinter_autosave'*
 
 Use this option to auto |:GoMetaLinter| on save. Only linter messages for
@@ -1256,21 +1278,21 @@ the active buffer will be shown. By default it's disabled >
 <
                                           *'g:go_metalinter_autosave_enabled'*
 
-Specifies the enabled linters for auto |GoMetaLinter| on save. By
+Specifies the enabled linters for auto |:GoMetaLinter| on save. By
 default it's using `vet` and `golint`.
 >
   let g:go_metalinter_autosave_enabled = ['vet', 'golint']
 <
                                                    *'g:go_metalinter_enabled'*
 
-Specifies the currently enabled linters for the |GoMetaLinter| command. By
+Specifies the currently enabled linters for the |:GoMetaLinter| command. By
 default it's using `vet`, `golint` and `errcheck`.
 >
   let g:go_metalinter_enabled = ['vet', 'golint', 'errcheck']
 <
                                                    *'g:go_metalinter_command'*
 
-Overrides the command to be executed when |GoMetaLinter| is called. This is
+Overrides the command to be executed when |:GoMetaLinter| is called. This is
 an advanced settings and is for users who want to have a complete control
 over how `gometalinter` should be executed. By default it's empty.
 >
@@ -1331,9 +1353,9 @@ For example here is how to set each to 30.
 
 This option is Neovim only. Use it to change the behavior of the test
 commands. If set to 1 it opens the test commands inside a new terminal
-according to |g:go_term_mode|, otherwise it will run them in the background
-just like `:GoBuild` and then display the status with |go#jobcontrol#Statusline()|.
-By default it is disabled.
+according to |'g:go_term_mode'|, otherwise it will run them in the background
+just like `:GoBuild` and then display the status with
+|go#jobcontrol#Statusline()|. By default it is disabled.
 >
   let g:go_term_enabled = 0
 <
@@ -1371,7 +1393,7 @@ to an autocompletion proposals. By default it is enabled.
 When a new Go file is created, vim-go automatically fills the buffer content
 with a Go code template. By default the template under
 `templates/hello_world.go` is used. This can be changed with the
-|g:go_template_file| setting.
+|'g:go_template_file'| setting.
 
 If the new file is created in an already prepopulated package (with other Go
 files), in this case a Go code template with only the Go package declaration
@@ -1384,12 +1406,21 @@ By default it is enabled.
                                                         *'g:go_template_file'*
 
 Specifies the file under the `templates` folder that is used if a new Go file
-is created. Checkout |g:go_template_autocreate| for more info. By default the
-`hello_world.go` file is used.
+is created. Checkout |'g:go_template_autocreate'| for more info. By default
+the `hello_world.go` file is used.
 >
   let g:go_template_file = "hello_world.go"
 <
-===============================================================================
+                                                       *'g:go_decls_includes'*
+
+    Only useful if `ctrlp.vim` is installed. This sets which declarations to
+    show for |:GoDecls|.
+    It is a Comma delimited list Possible options are: {func,type}.
+    The default is: >
+
+      let g:go_decls_includes = 'func,type'
+<
+==============================================================================
 TROUBLESHOOTING                                         *go-troubleshooting*
 
 I get "not an editor command" error when I invoke :GoXXX~
@@ -1402,8 +1433,8 @@ line into your vimrc:
 
 I get a "command not found" error when I invoke :GoXXX~
 
-If you try to call |:GoDef|, |:GoInfo| and get a command not found, check that you
-have the binaries installed by using |:GoInstallBinaries|.
+If you try to call |:GoDef|, |:GoInfo| and get a command not found, check that
+you have the binaries installed by using |:GoInstallBinaries|.
 
 Before opening vim, check your current $PATH:
 >
@@ -1423,30 +1454,30 @@ Don't enable these options:
   let g:go_highlight_operators = 0
 <
 
-I'm seeing weird errors during installation of binaries with GoInstallBinaries~
+I get errors when using GoInstallBinaries~
 
 If you see errors like this:
 >
   Error installing golang.org/x/tools/cmd/goimports
 <
 that means your local Go setup is broken or the remote website is down.  For
-example sometimes code.google.com times out. To test, just execute a simple go
-get:
+example sometimes code.google.com times out. To test, just execute a simple
+`go get`:
 
   go get golang.org/x/tools/cmd/goimports
 <
 You'll see a more detailed error. If this works, vim-go will work too.
 
 
-===============================================================================
+==============================================================================
 CREDITS                                                         *go-credits*
 
-* Go Authors for official vim plugins
+* Go Authors for official Vim plugins.
 * Gocode, Godef, Golint, Guru, Goimports, Errcheck projects and authors of
   those projects.
 * Other vim-plugins, thanks for inspiration (vim-golang, go.vim, vim-gocode,
-  vim-godef)
-* vim-go contributors: https://github.com/fatih/vim-go/graphs/contributors
+  vim-godef).
+* vim-go contributors: https://github.com/fatih/vim-go/graphs/contributors.
 
 
 vim:ft=help:et:ts=2:sw=2:sts=2:norl

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1392,43 +1392,51 @@ is created. Checkout |g:go_template_autocreate| for more info. By default the
 ===============================================================================
 TROUBLESHOOTING                                         *go-troubleshooting*
 
-I'm using Fish shell but have some problems using vim-go~
+I get "not an editor command" error when I invoke :GoXXX~
 
-First environment variables in Fish are applied differently, it should be like:
+This happens if vim-go is not installed properly. Be sure you have added this
+line into your vimrc:
 >
-  set -x GOPATH /your/own/gopath
+  filetype plugin indent on
 <
-Second, Vim needs a POSIX compatible shell (more info here:
-https://github.com/dag/vim-fish#teach-a-vim-to-fish). If you use Fish to open
-Vim, it will make certain shell based commands fail (means vim-go will fail
-too). To overcome this problem change the default shell by adding the
-following into your .vimrc (on the top of the file):
->
-  if $SHELL =~ 'fish'
-    set shell='/bin/sh'
-  endif
-<
-or
->
-  set shell='/bin/sh'
->
 
-I'm seeing weird errors during installation of binaries with
-GoInstallBinaries:
+I get a "command not found" error when I invoke :GoXXX~
+
+If you try to call |:GoDef|, |:GoInfo| and get a command not found, check that you
+have the binaries installed by using |:GoInstallBinaries|.
+
+Before opening vim, check your current $PATH:
+>
+  echo $PATH
+<
+After opening vim, run `:echo $PATH`, the output must be your current `$PATH`
+plus `$GOPATH/bin` (the location where |:GoInstallBinaries| installed the
+binaries).
+
+
+Vim becomes slow while editing Go files~
+
+Don't enable these options:
+>
+  let g:go_highlight_structs = 0
+  let g:go_highlight_interfaces = 0
+  let g:go_highlight_operators = 0
+<
+
+I'm seeing weird errors during installation of binaries with GoInstallBinaries~
 
 If you see errors like this:
 >
-  Error installing code.google.com/p/go.tools/cmd/goimports:
-  Error installing code.google.com/p/rog-go/exp/cmd/godef:
+  Error installing golang.org/x/tools/cmd/goimports
 <
 that means your local Go setup is broken or the remote website is down.  For
 example sometimes code.google.com times out. To test, just execute a simple go
 get:
 
->
-  go get code.google.com/p/go.tools/cmd/goimports
+  go get golang.org/x/tools/cmd/goimports
 <
 You'll see a more detailed error. If this works, vim-go will work too.
+
 
 ===============================================================================
 CREDITS                                                         *go-credits*


### PR DESCRIPTION
- This merges @svanburen 's PR #935 − resolving the conflicts.

- Sync "troubleshooting" section with the one on the Wiki. IMHO we're probably best off deleting the wiki page after this is merged?

- Mention Vim's packages feature for installing.

- Run [vimhelplint](https://github.com/machakann/vim-vimhelplint) and fix all the reported errors. Many are boring line width changes, but there were also quite a few "missing link" errors (e.g. `|g:go_foo|` instead of `|'g:go_foo'|` was used).

- Add a few settings that were undocumented.

- Fix a few minor typos.