### PR TITLE
More robust resetting of the shell.

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -95,7 +95,7 @@ endif
 " systems if it is executable.
 function! go#util#System(str, ...)
   let l:shell = &shell
-  if !(has('win32') || has('win64')) && executable('/bin/sh')
+  if !go#util#IsWin() && executable('/bin/sh')
     let &shell = '/bin/sh'
   endif
 

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -91,12 +91,20 @@ else
   let s:vim_shell_error = ''
 endif
 
+" System runs a shell command. It will reset the shell to /bin/sh for Unix-like
+" systems if it is executable.
 function! go#util#System(str, ...)
   let l:shell = &shell
-  let &shell = '/bin/sh'
-  let l:output = call(s:vim_system, [a:str] + a:000)
-  let &shell = l:shell
-  return l:output
+  if !(has('win32') || has('win64')) && executable('/bin/sh')
+    let &shell = '/bin/sh'
+  endif
+
+  try
+    let l:output = call(s:vim_system, [a:str] + a:000)
+    return l:output
+  finally
+    let &shell = l:shell
+  endtry
 endfunction
 
 function! go#util#ShellError()


### PR DESCRIPTION
Don't reset it on Windows, and only reset it if `/bin/sh` is executable (which
should pretty much always be the case, but it's not in POSIX and IIRC POSIX
explicitly advises against relying on it).

This is basically the same method that vim-plug uses.

This improves #967 and should fix #986.