### PR TITLE
Provide a descriptive quickfix/location list title.

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -133,7 +133,7 @@ function! go#cmd#Run(bang, ...) abort
   let items = go#list#Get(l:listtype)
   let errors = go#tool#FilterValids(items)
 
-  call go#list#Populate(l:listtype, errors)
+  call go#list#Populate(l:listtype, errors, &makeprg)
   call go#list#Window(l:listtype, len(errors))
   if !empty(errors) && !a:bang
     call go#list#JumpToFirst(l:listtype)
@@ -285,7 +285,7 @@ function! go#cmd#Test(bang, compile, ...) abort
     let errors = go#tool#ParseErrors(split(out, '\n'))
     let errors = go#tool#FilterValids(errors)
 
-    call go#list#Populate(l:listtype, errors)
+    call go#list#Populate(l:listtype, errors, command)
     call go#list#Window(l:listtype, len(errors))
     if !empty(errors) && !a:bang
       call go#list#JumpToFirst(l:listtype)

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -185,7 +185,7 @@ function! go#fmt#Format(withGoimport) abort
       % | " Couldn't detect gofmt error format, output errors
     endif
     if !empty(errors)
-      call go#list#Populate(l:listtype, errors)
+      call go#list#Populate(l:listtype, errors, 'Format')
       echohl Error | echomsg "Gofmt returned error" | echohl None
     endif
 

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -235,7 +235,7 @@ function! go#guru#Implements(selected) abort
         \ 'needs_scope': 1,
         \ }
 
-  call s:run_guru(args, 'Implements')
+  call s:run_guru(args)
 endfunction
 
 " Report the possible constants, global variables, and concrete types that may
@@ -254,7 +254,7 @@ function! go#guru#Whicherrs(selected) abort
   "   call go#util#EchoSuccess("no error variables found. Try to change the scope with :GoGuruScope")
   "   return
   " endif
-  call s:run_guru(args, 'Whicherrs')
+  call s:run_guru(args)
 endfunction
 
 " Describe selected syntax: definition, methods, etc
@@ -266,7 +266,7 @@ function! go#guru#Describe(selected) abort
         \ 'needs_scope': 1,
         \ }
 
-  call s:run_guru(args, 'Describe')
+  call s:run_guru(args)
 endfunction
 
 function! go#guru#DescribeInfo() abort
@@ -372,7 +372,7 @@ function! go#guru#DescribeInfo() abort
         \ 'disable_progress': 1,
         \ }
 
-  call s:run_guru(args, 'DescribeInfo')
+  call s:run_guru(args)
 endfunction
 
 " Show possible targets of selected function call
@@ -384,7 +384,7 @@ function! go#guru#Callees(selected) abort
         \ 'needs_scope': 1,
         \ }
 
-  call s:run_guru(args, 'Callees')
+  call s:run_guru(args)
 endfunction
 
 " Show possible callers of selected function
@@ -396,7 +396,7 @@ function! go#guru#Callers(selected) abort
         \ 'needs_scope': 1,
         \ }
 
-  call s:run_guru(args, 'Callers')
+  call s:run_guru(args)
 endfunction
 
 " Show path from callgraph root to selected function
@@ -408,7 +408,7 @@ function! go#guru#Callstack(selected) abort
         \ 'needs_scope': 1,
         \ }
 
-  call s:run_guru(args, 'Callstack')
+  call s:run_guru(args)
 endfunction
 
 " Show free variables of selection
@@ -426,7 +426,7 @@ function! go#guru#Freevars(selected) abort
         \ 'needs_scope': 0,
         \ }
 
-  call s:run_guru(args, 'Freevars')
+  call s:run_guru(args)
 endfunction
 
 " Show send/receive corresponding to selected channel op
@@ -438,7 +438,7 @@ function! go#guru#ChannelPeers(selected) abort
         \ 'needs_scope': 1,
         \ }
 
-  call s:run_guru(args, 'ChannelPeers')
+  call s:run_guru(args)
 endfunction
 
 " Show all refs to entity denoted by selected identifier
@@ -450,7 +450,7 @@ function! go#guru#Referrers(selected) abort
         \ 'needs_scope': 0,
         \ }
 
-  call s:run_guru(args, 'Referrers')
+  call s:run_guru(args)
 endfunction
 
 function! go#guru#SameIdsTimer() abort
@@ -481,7 +481,7 @@ function! go#guru#SameIds() abort
         \ 'custom_parse': function('s:same_ids_highlight'),
         \ }
 
-  call s:run_guru(args, 'SameIds')
+  call s:run_guru(args)
 endfunction
 
 function! s:same_ids_highlight(exit_val, output) abort

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -106,7 +106,7 @@ function! s:guru_cmd(args) range abort
 endfunction
 
 " sync_guru runs guru in sync mode with the given arguments
-function! s:sync_guru(args, title) abort
+function! s:sync_guru(args) abort
   let result = s:guru_cmd(a:args)
   if has_key(result, 'err')
     call go#util#EchoError(result.err)
@@ -136,16 +136,16 @@ function! s:sync_guru(args, title) abort
   let $GOPATH = old_gopath
 
   if has_key(a:args, 'custom_parse')
-    call a:args.custom_parse(go#util#ShellError(), out, a:title)
+    call a:args.custom_parse(go#util#ShellError(), out)
   else
-    call s:parse_guru_output(go#util#ShellError(), out, a:title)
+    call s:parse_guru_output(go#util#ShellError(), out, a:args.mode)
   endif
 
   return out
 endfunc
 
 " async_guru runs guru in async mode with the given arguments
-function! s:async_guru(args, title) abort
+function! s:async_guru(args) abort
   let result = s:guru_cmd(a:args)
   if has_key(result, 'err')
     call go#util#EchoError(result.err)
@@ -154,7 +154,6 @@ function! s:async_guru(args, title) abort
 
   let status_dir =  expand('%:p:h')
   let statusline_type = printf("%s", a:args.mode)
-  let title = a:title
 
   if !has_key(a:args, 'disable_progress')
     if a:args.needs_scope
@@ -192,9 +191,9 @@ function! s:async_guru(args, title) abort
     call go#statusline#Update(status_dir, status)
 
     if has_key(a:args, 'custom_parse')
-      call a:args.custom_parse(l:info.exitval, out, title)
+      call a:args.custom_parse(l:info.exitval, out)
     else
-      call s:parse_guru_output(l:info.exitval, out, title)
+      call s:parse_guru_output(l:info.exitval, out, a:args.mode)
     endif
   endfunction
 
@@ -219,12 +218,12 @@ function! s:async_guru(args, title) abort
 endfunc
 
 " run_guru runs the given guru argument
-function! s:run_guru(args, title) abort
+function! s:run_guru(args) abort
   if go#util#has_job()
-    return s:async_guru(a:args, a:title)
+    return s:async_guru(a:args)
   endif
 
-  return s:sync_guru(a:args, a:title)
+  return s:sync_guru(a:args)
 endfunction
 
 " Show 'implements' relation for selected package
@@ -279,7 +278,7 @@ function! go#guru#DescribeInfo() abort
     return
   endif
 
-  function! s:info(exit_val, output, title)
+  function! s:info(exit_val, output)
     if a:exit_val != 0
       return
     endif
@@ -485,7 +484,7 @@ function! go#guru#SameIds() abort
   call s:run_guru(args, 'SameIds')
 endfunction
 
-function! s:same_ids_highlight(exit_val, output, title) abort
+function! s:same_ids_highlight(exit_val, output) abort
   call go#guru#ClearSameIds() " run after calling guru to reduce flicker.
 
   if a:output[0] !=# '{'

--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -85,7 +85,7 @@ function go#job#Spawn(args)
     endif
 
     if self.winnr == winnr()
-      call go#list#Populate(a:listtype, errors)
+      call go#list#Populate(a:listtype, errors, join(self.args))
       call go#list#Window(a:listtype, len(errors))
       if !empty(errors) && !self.bang
         call go#list#JumpToFirst(a:listtype)

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -127,7 +127,7 @@ function! s:on_exit(job_id, exit_status) abort
 
   " if we are still in the same windows show the list
   if self.winnr == winnr()
-    call go#list#Populate(l:listtype, errors)
+    call go#list#Populate(l:listtype, errors, self.desc)
     call go#list#Window(l:listtype, len(errors))
     if !empty(errors) && !self.bang
       call go#list#JumpToFirst(l:listtype)

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -269,6 +269,12 @@ function s:lint_job(args)
     let errors = go#list#Get(l:listtype)
     if empty(errors) 
       call go#list#Window(l:listtype, len(errors))
+    else
+      if l:listtype == 'quickfix'
+        call setqflist([], 'a', {'title': 'Lint'})
+      else
+        call setloclist(0, [], 'a', {'title': 'Lint'})
+      endif
     endif
 
     if get(g:, 'go_echo_command_info', 1)

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -82,7 +82,7 @@ function! go#lint#Gometa(autosave, ...) abort
     let errformat = "%f:%l:%c:%t%*[^:]:\ %m,%f:%l::%t%*[^:]:\ %m"
 
     " Parse and populate our location list
-    call go#list#ParseFormat(l:listtype, errformat, split(out, "\n"))
+    call go#list#ParseFormat(l:listtype, errformat, split(out, "\n"), 'GoMetaLinter')
 
     let errors = go#list#Get(l:listtype)
     call go#list#Window(l:listtype, len(errors))
@@ -134,7 +134,7 @@ function! go#lint#Vet(bang, ...) abort
   let l:listtype = "quickfix"
   if go#util#ShellError() != 0
     let errors = go#tool#ParseErrors(split(out, '\n'))
-    call go#list#Populate(l:listtype, errors)
+    call go#list#Populate(l:listtype, errors, 'Vet')
     call go#list#Window(l:listtype, len(errors))
     if !empty(errors) && !a:bang
       call go#list#JumpToFirst(l:listtype)
@@ -176,7 +176,7 @@ function! go#lint#Errcheck(...) abort
     let errformat = "%f:%l:%c:\ %m, %f:%l:%c\ %#%m"
 
     " Parse and populate our location list
-    call go#list#ParseFormat(l:listtype, errformat, split(out, "\n"))
+    call go#list#ParseFormat(l:listtype, errformat, split(out, "\n"), 'Errcheck')
 
     let errors = go#list#Get(l:listtype)
 
@@ -187,7 +187,7 @@ function! go#lint#Errcheck(...) abort
     endif
 
     if !empty(errors)
-      call go#list#Populate(l:listtype, errors)
+      call go#list#Populate(l:listtype, errors, 'Errcheck')
       call go#list#Window(l:listtype, len(errors))
       if !empty(errors)
         call go#list#JumpToFirst(l:listtype)

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -50,12 +50,14 @@ function! go#list#Get(listtype) abort
 endfunction
 
 " Populate populate the location list with the given items
-function! go#list#Populate(listtype, items) abort
+function! go#list#Populate(listtype, items, title) abort
   let l:listtype = go#list#Type(a:listtype)
   if l:listtype == "locationlist"
     call setloclist(0, a:items, 'r')
+    call setloclist(0, [], 'a', {'title': a:title})
   else
     call setqflist(a:items, 'r')
+    call setqflist([], 'a', {'title': a:title})
   endif
 endfunction
 
@@ -65,7 +67,7 @@ endfunction
 
 " Parse parses the given items based on the specified errorformat nad
 " populates the location list.
-function! go#list#ParseFormat(listtype, errformat, items) abort
+function! go#list#ParseFormat(listtype, errformat, items, title) abort
   let l:listtype = go#list#Type(a:listtype)
   " backup users errorformat, will be restored once we are finished
   let old_errorformat = &errorformat
@@ -74,8 +76,10 @@ function! go#list#ParseFormat(listtype, errformat, items) abort
   let &errorformat = a:errformat
   if l:listtype == "locationlist"
     lgetexpr a:items
+    call setloclist(0, [], 'a', {'title': a:title})
   else
     cgetexpr a:items
+    call setqflist([], 'a', {'title': a:title})
   endif
 
   "restore back

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -118,7 +118,7 @@ function s:parse_errors(exit_val, bang, out)
   if a:exit_val != 0
     call go#util#EchoError("FAILED")
     let errors = go#tool#ParseErrors(a:out)
-    call go#list#Populate(l:listtype, errors)
+    call go#list#Populate(l:listtype, errors, 'Rename')
     call go#list#Window(l:listtype, len(errors))
     if !empty(errors) && !a:bang
       call go#list#JumpToFirst(l:listtype)

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -53,6 +53,7 @@ function! go#term#newmode(bang, cmd, mode) abort
   let $GOPATH = old_gopath
 
   let job.id = id
+  let job.cmd = a:cmd
   startinsert
 
   " resize new term if needed.
@@ -115,7 +116,7 @@ function! s:on_exit(job_id, exit_status) abort
     " close terminal we don't need it anymore
     close 
 
-    call go#list#Populate(l:listtype, errors)
+    call go#list#Populate(l:listtype, errors, job.cmd)
     call go#list#Window(l:listtype, len(errors))
     if !self.bang
       call go#list#JumpToFirst(l:listtype)


### PR DESCRIPTION
Currently, the `w:quickfix_title` is being automatically set to the actual
Vim command that populates quickfix/location list. For example, running
any Guru command it will be displayed as `:    lgetexpr a:items` which
is not really informative.
