### PR TITLE
Highlight nested fields or chained fields

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -313,7 +313,7 @@ hi def link     goMethod            Type
 
 " Fields;
 if g:go_highlight_fields != 0
-  syn match goField                 /\.\w\+\([\ \n\r\:\)\[,]\)\@=/hs=s+1
+  syn match goField                 /\.\w\+\([.\ \n\r\:\)\[,]\)\@=/hs=s+1
 endif
 hi def link    goField              Identifier
 


### PR DESCRIPTION
Currently, nested or chained fields are not getting highlighted.

<img width="241" alt="screen shot 2016-08-14 at 12 53 42 pm" src="https://cloud.githubusercontent.com/assets/7953984/17650866/2c2315c4-621e-11e6-91bc-8c4b52de584a.png">

This will change that to this:

<img width="262" alt="screen shot 2016-08-14 at 12 54 21 pm" src="https://cloud.githubusercontent.com/assets/7953984/17650868/3f787308-621e-11e6-97db-eafe94909ffd.png">
