### PR TITLE
Add compatibility for GoAddTags and google/jsonapi

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -276,6 +276,13 @@ function! go#util#AddTags(line1, line2, ...)
     endif
 
     let word = go#util#snippetcase(l:matched)
+    if l:keys == ["jsonapi"]
+      let prefix = "attr"
+      if word == "id"
+        let prefix = "primary"
+      endif
+      let word = printf('%s,%s', prefix, word)
+    endif
     let tags = map(copy(l:keys), 'printf("%s:%s", v:val,"\"'. word .'\"")')
     let updated_line = printf("%s `%s`", getline(line), join(tags, " "))
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -680,6 +680,8 @@ CTRL-t
 >
       :GoAddTags xml db
 <
+    If the key `jsonapi` is used, the values generated will be compatible with
+    the  https://godoc.org/github.com/google/jsonapi tags.                                              
                                                        *:GoAutoTypeInfoToggle*
 :GoAutoTypeInfoToggle
 


### PR DESCRIPTION
Not sure if it would be desirable to have library specific features like this?

This is the result when using `jsonapi` with the `:GoAddTags` command:
```
type User struct {
	ID  int  `jsonapi:"primary,id"`
	Name  string  `jsonapi:"attr,name"`
}
```

One caveat: the user will still need to manually change `id` to the name of the resource, in this case, like so:

```
	ID  int  `jsonapi:"primary,users"`
```

But it's still a lot of savings on typing if using this library.