### PR TITLE
Fix syntax goFormatSpecifier: check '%%'

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -175,7 +175,7 @@ else
 endif
 
 if g:go_highlight_format_strings != 0
-  syn match       goFormatSpecifier   /%[-#0 +]*\%(\*\|\d\+\)\=\%(\.\%(\*\|\d\+\)\)*[vTtbcdoqxXUeEfgGsp]/ contained containedin=goString
+  syn match       goFormatSpecifier   /\([^%]\(%%\)*\)\@<=%[-#0 +]*\%(\*\|\d\+\)\=\%(\.\%(\*\|\d\+\)\)*[vTtbcdoqxXUeEfgGsp]/ contained containedin=goString
   hi def link     goFormatSpecifier   goSpecialString
 endif
 


### PR DESCRIPTION
It should not highlight format specifiers in strings like "something %%c".