### PR TITLE
SameIds: Fix Sentence, add hint to 'updatetime'

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -582,8 +582,9 @@ CTRL-t
     Enables or disables automatic highlighting of |:GoSameIds| while moving
     the cursor. This basically toggles the option |'g:go_auto_sameids'|
     on/off.
-    If enabled it starts highlighting whenever your cursor is. If disabled it
-    clears and stops automatic highlighting.
+    If enabled it starts highlighting whenever your cursor is staying at the
+    same position for a configurable period of time (see 'updatetime'). If
+    disabled it clears and stops automatic highlighting.
 
                                                                *:GoMetaLinter*
 :GoMetaLinter [path]
@@ -995,7 +996,8 @@ updated. By default it's disabled.
                                                          *'g:go_auto_sameids'*
 
 Use this option to highlight all uses of the identifier under the cursor
-(:GoSameIds) automatically. By default it's disabled.
+(:GoSameIds) automatically. By default it's disabled. The delay can be
+configured with the 'updatetime' setting.
 >
   let g:go_auto_sameids = 0
 <


### PR DESCRIPTION
I turned on `g:go_auto_sameids` and nothing happened, in contrast to your tutorial. Then I investigated and found out that the cursor needs to rest at the same position at least for `updatetime` ms, which means 4s by default. That's way too long for me.

I've added a hint for `updatetime` in the manual, and thereby fixed a sentence that was incomplete.