### PR TITLE
Rename GoMetalinterAutoSaveToggle to GoMetaLinterAutoSaveToggle

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -695,8 +695,8 @@ CTRL-t
 
     Toggles |'g:go_asmfmt_autosave'|.
 
-                                                 *:GoMetalinterAutoSaveToggle*
-:GoMetalinterAutoSaveToggle
+                                                 *:GoMetaLinterAutoSaveToggle*
+:GoMetaLinterAutoSaveToggle
 
     Toggles |'g:go_metalinter_autosave'|.
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -71,7 +71,7 @@ command! -nargs=* -bang -complete=customlist,go#package#Complete GoImportAs call
 
 " -- linters
 command! -nargs=* GoMetaLinter call go#lint#Gometa(0, <f-args>)
-command! -nargs=0 GoMetalinterAutoSaveToggle call go#lint#ToggleMetaLinterAutoSave()
+command! -nargs=0 GoMetaLinterAutoSaveToggle call go#lint#ToggleMetaLinterAutoSave()
 command! -nargs=* GoLint call go#lint#Golint(<f-args>)
 command! -nargs=* -bang GoVet call go#lint#Vet(<bang>0, <f-args>)
 command! -nargs=* -complete=customlist,go#package#Complete GoErrCheck call go#lint#Errcheck(<f-args>)


### PR DESCRIPTION
Hi!

I've changed the `:GoMetalinterAutoSaveToggle` command name to become `Linter` because the command calls `go#lint#ToggleMetaLinterAutoSave()` which has already defined `MetaLinter`.
So, I just chose "`MetaLinter`" to the command name.

Thanks!