### PR TITLE
Add go_highlight_generate_tags in docs

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1231,6 +1231,12 @@ Highlights build constraints. By default it's disabled. >
 
   let g:go_highlight_build_constraints = 0
 <
+                                          *'g:go_highlight_generate_tags'*
+
+Highlights go:generate directives. By default it's disabled. >
+
+  let g:go_highlight_generate_tags = 0
+<
                                           *'g:go_highlight_string_spellcheck'*
 
 Use this option to highlight spelling errors in strings when |spell| is


### PR DESCRIPTION
Add `go_highlight_generate_tags` in `doc/vim-go.txt`
(Related PR is https://github.com/fatih/vim-go/pull/757.)

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fatih/vim-go/1023)
<!-- Reviewable:end -->
