### PR TITLE
Add go_highlight_extra_vars option

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1245,6 +1245,13 @@ By default it's enabled. >
 
   let g:go_highlight_format_strings = 1
 <
+                                                *'g:go_highlight_extra_vars'*
+
+Highlights not predeclared but commonly used variables, such as ok, err.
+By default it's disabled. >
+
+  let g:go_highlight_extra_vars = 0
+<
                                                     *'g:go_autodetect_gopath'*
 
 Automatically modifies GOPATH for certain directory structures, such as for

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -91,6 +91,10 @@ if !exists("g:go_highlight_generate_tags")
   let g:go_highlight_generate_tags = 0
 endif
 
+if !exists("g:go_highlight_extra_vars")
+  let g:go_highlight_extra_vars = 0
+endif
+
 syn case match
 
 syn keyword     goDirective         package import
@@ -364,6 +368,12 @@ if g:go_highlight_build_constraints != 0
         \ end=/\v\n\s*package/he=e-7,me=e-7,re=e-7
         \ contains=@goCommentGroup,@Spell
   hi def link goPackageComment    Comment
+endif
+
+" Highlights commonly used variables name.
+if g:go_highlight_extra_vars != 0
+  syn keyword     goExtraVars         ok err
+  hi def link     goExtraVars         Identifier
 endif
 
 " :GoCoverage commands


### PR DESCRIPTION
## *Proposal*

In idiomatic Go code,
`ok` and `err` are commonly used.

So I add a highlight option for them.
(_By default it's disabled._)



## Before

![2016-08-26 1 43 41](https://cloud.githubusercontent.com/assets/4014912/17977938/9f4b6736-6b2e-11e6-9acc-59672af5c636.png)

## After

![2016-08-26 1 44 04](https://cloud.githubusercontent.com/assets/4014912/17977944/a4c34788-6b2e-11e6-954e-1a45e7231043.png)

----

If you enable this setting

```vim
let g:go_highlight_extra_vars = 1
``` 

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fatih/vim-go/1024)
<!-- Reviewable:end -->
