### PR TITLE
Exclude iota and nil from goBoolean

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -125,14 +125,14 @@ hi def link     goComplexes         Type
 
 
 " Predefined functions and values
-syn match       goBuiltins          /\<\v(append|cap|close|complex|copy|delete|imag|len)\ze\(/
-syn match       goBuiltins          /\<\v(make|new|panic|print|println|real|recover)\ze\(/
-syn keyword     goPredefinedVars    nil, iota
-syn keyword     goBoolean           true false
+syn match       goBuiltins                 /\<\v(append|cap|close|complex|copy|delete|imag|len)\ze\(/
+syn match       goBuiltins                 /\<\v(make|new|panic|print|println|real|recover)\ze\(/
+syn keyword     goPredefinedIdentifiers    nil, iota
+syn keyword     goBoolean                  true false
 
-hi def link     goBuiltins          Keyword
-hi def link     goPredefinedVars    Keyword
-hi def link     goBoolean           Boolean
+hi def link     goBuiltins                 Keyword
+hi def link     goPredefinedIdentifiers    Identifier
+hi def link     goBoolean                  Boolean
 
 " Comments; their contents
 syn keyword     goTodo              contained TODO FIXME XXX BUG

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -127,9 +127,11 @@ hi def link     goComplexes         Type
 " Predefined functions and values
 syn match       goBuiltins          /\<\v(append|cap|close|complex|copy|delete|imag|len)\ze\(/
 syn match       goBuiltins          /\<\v(make|new|panic|print|println|real|recover)\ze\(/
-syn keyword     goBoolean           iota true false nil
+syn keyword     goPredefinedVars    nil, iota
+syn keyword     goBoolean           true false
 
 hi def link     goBuiltins          Keyword
+hi def link     goPredefinedVars    Keyword
 hi def link     goBoolean           Boolean
 
 " Comments; their contents


### PR DESCRIPTION
exclude iota and nil from `goBoolean`
It would be better to treat them separately.

## Before
![before](https://cloud.githubusercontent.com/assets/4014912/18027647/6d513874-6ca4-11e6-9f58-22153730e731.png)

## After
![after](https://cloud.githubusercontent.com/assets/4014912/18027649/71f1fb5c-6ca4-11e6-98b9-0c7594f9b39b.png)

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fatih/vim-go/1030)
<!-- Reviewable:end -->
