### PR TITLE
coverage: allow to run coverage on _test.go files in subdirs

### DIFF
--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -204,7 +204,7 @@ function! go#coverage#overlay(file)
     let cnt += 1
   endwhile
 
-  let fname = expand('%:t')
+  let fname = expand('%')
 
   " when called for a _test.go file, run the coverage for the actuall file
   " file
@@ -220,6 +220,9 @@ function! go#coverage#overlay(file)
     " open the alternate file to show the coverage
     exe ":edit ". fnamemodify(fname, ":p")
   endif
+
+  " cov.file includes only the filename itself, without full path
+  let fname = fnamemodify(fname, ":t")
 
   for line in lines[1:]
     let cov = go#coverage#parsegocoverline(line)


### PR DESCRIPTION
Due to usage of ':t' modifier to extract filename when switching from
file_test.go to file.go, the original path to file is lost and Vim can't
open it if it's stored in some subdir. It only worked by accident if the
file was located in the same directory.
