### PR TITLE
fix check v:version for vim 8.0

### DIFF
--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -151,7 +151,7 @@ function! go#path#CheckBinPath(binpath)
 
     " if it's in PATH just return it
     if executable(binpath)
-        if v:version == 704 && has('patch235')
+        if exists('*exepath')
             let binpath = exepath(binpath)
         endif
         let $PATH = old_path


### PR DESCRIPTION
Older checking v:version is wrong for 800.