### PR TITLE
Add support for highlighting function calls

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -302,10 +302,12 @@ if g:go_highlight_functions != 0
   syn match goPointerOperator   /\*/ nextgroup=goReceiverType contained skipwhite skipnl
   syn match goReceiverType      /\w\+/ contained
   syn match goFunction          /\w\+/ contained
+  syn match goFunctionCall      /\w\+\ze(/
 else
   syn keyword goDeclaration func
 endif
 hi def link     goFunction          Function
+hi def link     goFunctionCall      Type
 
 " Methods;
 if g:go_highlight_methods != 0


### PR DESCRIPTION
`g:go_highlight_methods` highlights method calls, but `g:go_highlight_functions` does not highlight function calls.

So this PR adds the same highlighting for function calls as well. See the examples below where the call to `demoFunc()` is not highlighted initially where the call to `demoMethod()` is.

Before:
![image](https://cloud.githubusercontent.com/assets/4171547/18504896/daf91338-7a64-11e6-9264-b774ca01e96f.png)

After:
![image](https://cloud.githubusercontent.com/assets/4171547/18504832/9d4e6484-7a64-11e6-817c-3941ddd064bc.png)
