### PR TITLE
skip go#util#Shelllist if nvim is being used

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -19,7 +19,7 @@ function! go#cmd#Build(bang, ...)
 
   " escape all shell arguments before we pass it to make
   if !has('nvim')
-  let goargs = go#util#Shelllist(goargs, 1)
+    let goargs = go#util#Shelllist(goargs, 1)
   endif
   " create our command arguments. go build discards any results when it
   " compiles multiple packages. So we pass the `errors` package just as an

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -18,8 +18,9 @@ function! go#cmd#Build(bang, ...)
   let goargs = map(copy(a:000), "expand(v:val)")
 
   " escape all shell arguments before we pass it to make
+  if !has('nvim')
   let goargs = go#util#Shelllist(goargs, 1)
-
+  endif
   " create our command arguments. go build discards any results when it
   " compiles multiple packages. So we pass the `errors` package just as an
   " placeholder with the current folder (indicated with '.')


### PR DESCRIPTION
see original issue #1042 (:GoBuild -tags 'debug' causes issue in neovim)