### PR TITLE
Clear most recent goSameId highlights groups

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -200,6 +200,10 @@ augroup vim-go
   autocmd BufWritePre *.s call s:asmfmt_autosave()
   autocmd BufWritePost *.go call s:metalinter_autosave()
   autocmd BufNewFile *.go call s:template_autocreate()
+  " clear SameIds when the buffer is unloaded so that loading another buffer
+  " in the same window doesn't highlight the most recently matched
+  " identifier's positions.
+  autocmd BufWinEnter *.go call go#guru#ClearSameIds()
 augroup END
 
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
Clear the most recent goSameId highlight groups on BufWinEnter so that
the highlight groups do not persist when a different buffer is loaded
into a window.

Fixes #1041