### PR TITLE
Update license to credit Renee French for Gopher

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -56,3 +56,5 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The Go gopher was designed by Renee French. http://reneefrench.blogspot.com/ The design is licensed under the Creative Commons 3.0 Attributions license. Read this article for more details: https://blog.golang.org/gopher


### PR DESCRIPTION
Update license to credit Renee French for original Go Gopher design, since the awesome new Vim-Gopher image has recently been added to the repo.

I placed in the license file since other prominent Go sites, even golang.org don't directly credit Renee on the main page.