### PR TITLE
Add table-driven tests and subtests snippets

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -2,6 +2,40 @@
 
 priority -10
 
+snippet tt "table-driven tests"
+func Test${1:Func}(t *testing.T) {
+	testCases := []struct {
+		${2:input} ${3:Type}
+		want ${4:Type} 
+	}{
+		{$2: ${5:""}, want: ${6:""}},${0: // comment}
+	}
+	for _, tc := range testCases {
+		if got := $1(tc.$2); got != tc.want {
+			t.Errorf("$1(%s) = %s; want %s", tc.$2, got, tc.want)
+		}
+	}
+}
+endsnippet
+
+snippet tts "table-drive tests using subtests"
+func Test${1:Func}(t *testing.T) {
+	testCases := []struct {
+		${2:input} ${3:Type}
+		want ${4:Type} 
+	}{
+		{$2: ${5:""}, want: ${6:""}},${0: // comment}
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%q", tc.$2), func(t *testing.T) {
+			if got := $1(tc.$2); got != tc.want {
+				t.Errorf("got %s; want %s", got, tc.want)
+			}
+		})
+	}
+}
+endsnippet
+
 # shorthand variable declaration
 snippet : "v := value"
 ${1} := ${0}


### PR DESCRIPTION
These table-driven tests snippets where created from the examples in the "Using Subtests and Sub-benchmarks" post on [blog.golang.org](https://blog.golang.org/subtests)
