### PR TITLE
Highlight nested structs

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -326,7 +326,7 @@ if g:go_highlight_types != 0
   syn match goTypeConstructor      /\<\w\+{/he=e-1
   syn match goTypeDecl             /\<type\>/ nextgroup=goTypeName skipwhite skipnl
   syn match goTypeName             /\w\+/ contained nextgroup=goDeclType skipwhite skipnl
-  syn match goDeclType             /\<interface\|struct\>/ contained skipwhite skipnl
+  syn match goDeclType             /\<interface\|struct\>/ skipwhite skipnl
   hi def link     goReceiverType      Type
 else
   syn keyword goDeclType           struct interface


### PR DESCRIPTION
This will allow nested `struct` to be highlighted.

![screen shot 2016-10-07 at 8 21 50 am](https://cloud.githubusercontent.com/assets/7953984/19191265/4e61d81e-8c67-11e6-9456-67cb3b787465.png)

![screen shot 2016-10-07 at 8 22 07 am](https://cloud.githubusercontent.com/assets/7953984/19191269/547f4b50-8c67-11e6-8cee-8154ca40bee7.png)

