### PR TITLE
Provide completions for unimported packages.

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -74,6 +74,7 @@ function! s:gocodeEnableOptions()
 
   call go#util#System(printf('%s set propose-builtins %s', go#util#Shellescape(bin_path), s:toBool(get(g:, 'go_gocode_propose_builtins', 1))))
   call go#util#System(printf('%s set autobuild %s', go#util#Shellescape(bin_path), s:toBool(get(g:, 'go_gocode_autobuild', 1))))
+  call go#util#System(printf('%s set unimported-packages %s', go#util#Shellescape(bin_path), s:toBool(get(g:, 'go_gocode_unimported_packages', 1))))
 endfunction
 
 function! s:toBool(val)

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1396,6 +1396,12 @@ to an autocompletion proposals. By default it is enabled.
 >
   let g:go_gocode_propose_builtins = 1
 <
+                                              *'g:go_gocode_unimported_packages'*
+
+Specifies whether `gocode` should include suggestions from unimported packages.
+By default it is enabled
+>
+  let g:go_gocode_unimported_packages = 1
                                                    *'g:go_gocode_socket_type'*
 
 Specifies whether `gocode` should use a different socket type. By default


### PR DESCRIPTION
gocode recently added support for unimported packages.
https://github.com/nsf/gocode/commit/57b3fab1de11102eee896051605108949fbe75da

This comes in handy for example when you know approximately what
function you're looking for but don't remember the exact
name or signature.  It's must faster to get suggestions for
packages without having to import them first.

The feature is optional and must be enabled with `gocode set unimported-packages true`.
Enable the gocode feature by default, but allow it to be configured with
g:go_gocode_unimported_packages.