### PR TITLE
fix: restore syntax state after gofmt

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -161,6 +161,9 @@ function! go#fmt#Format(withGoimport)
     silent edit!
     let &fileformat = old_fileformat
     let &syntax = &syntax
+    if exists("g:syntax_on")
+      syntax enable
+    endif
 
     " clean up previous location list, but only if it's due to fmt
     if exists('b:got_fmt_error') && b:got_fmt_error


### PR DESCRIPTION
When running gofmt on saving file syntax highlight is turned off.
I'm not sure why it happens at first place, so maybe I'm fixing consequences instead of main reason.
I didn't bisect this, but it doesn't happens at 4f67ae2, so this bug was introduced in last months.

I'm using vim-7.4.2102.