### PR TITLE
add an option to show type info when completion is done

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1441,6 +1441,13 @@ the `hello_world.go` file is used.
 
       let g:go_decls_includes = 'func,type'
 <
+                                                       *'g:go_echo_go_info'*
+
+Use this option to show the identifier information when completion is done. By
+default it's enabled >
+
+      let g:go_echo_go_info = 1
+<
 ==============================================================================
 TROUBLESHOOTING                                         *go-troubleshooting*
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -126,6 +126,10 @@ endfunction
 " ============================================================================
 "
 function! s:echo_go_info()
+  if !get(g:, "go_echo_go_info", 1)
+    return
+  endif
+
   if !exists('v:completed_item') || empty(v:completed_item)
     return
   endif


### PR DESCRIPTION
Echoing `v:completion.info` after completion is done is annoying if users uses completion other than vim-go omni completion.

When I run completion with completefunc and this completion-item contains multi-line info, vim-go automatically echo this info and it messes up the window.
So, I added this option.
