### PR TITLE
vim: require at least 8.0.0087 for +job features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,8 @@ FEATURES:
 * Vim 8.0 support! This is the initial version to add Vim 8.0 based support to
   all basic commands (check out below for more information). With time we'll
   going to extend it to other commands. All the features are only enabled if
-  you have at least Vim 8.0 (at least version `8.0.0093` recommended due the
-  recent fixes). Backwards compatible with Vim 7.4.xx. If you see any
-  problems, please open an issue.
+  you have at least Vim 8.0.0087. Backwards compatible with Vim 7.4.x.
+  If you see any problems, please open an issue.
 
 * We have now a [logo for vim-go](https://github.com/fatih/vim-go/blob/master/assets/vim-go.png)! Thanks to @egonelbre for his work on this. 
 

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -21,7 +21,7 @@ function! go#cmd#Build(bang, ...) abort
   " placeholder with the current folder (indicated with '.')
   let args = ["build"]  + goargs + [".", "errors"]
 
-  if has('job')
+  if go#util#has_job()
     if get(g:, 'go_echo_command_info', 1)
       call go#util#EchoProgress("building dispatched ...")
     endif
@@ -93,7 +93,7 @@ function! go#cmd#Run(bang, ...) abort
     return
   endif
 
-  if has('job')
+  if go#util#has_job()
     " NOTE(arslan): 'term': 'open' case is not implement for +jobs. This means
     " executions waiting for stdin will not work. That's why we don't do
     " anything. Once this is implemented we're going to make :GoRun async
@@ -148,7 +148,7 @@ endfunction
 " those packages. Errors are populated in the location window.
 function! go#cmd#Install(bang, ...) abort
   " use vim's job functionality to call it asynchronously
-  if has('job')
+  if go#util#has_job()
     " expand all wildcards(i.e: '%' to the current file name)
     let goargs = map(copy(a:000), "expand(v:val)")
 
@@ -237,7 +237,7 @@ function! go#cmd#Test(bang, compile, ...) abort
     endif
   endif
 
-  if has('job')
+  if go#util#has_job()
     " use vim's job functionality to call it asynchronously
     let job_args = {
           \ 'cmd': ['go'] + args,

--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -44,7 +44,7 @@ function! go#coverage#Buffer(bang, ...) abort
   let s:toggle = 1
   let l:tmpname = tempname()
 
-  if has('job')
+  if go#util#has_job()
     call s:coverage_job({
           \ 'cmd': ['go', 'test', '-coverprofile', l:tmpname],
           \ 'custom_cb': function('s:coverage_callback', [l:tmpname]),
@@ -104,7 +104,7 @@ endfunction
 " a new HTML coverage page from that profile in a new browser
 function! go#coverage#Browser(bang, ...) abort
   let l:tmpname = tempname()
-  if has('job')
+  if go#util#has_job()
     call s:coverage_job({
           \ 'cmd': ['go', 'test', '-coverprofile', l:tmpname],
           \ 'custom_cb': function('s:coverage_browser_callback', [l:tmpname]),

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -55,7 +55,7 @@ function! go#def#Jump(mode) abort
     let fname = fname.':#'.go#util#OffsetCursor()
     call extend(cmd, ["definition", fname])
 
-    if has('job')
+    if go#util#has_job()
       let l:spawn_args = {
             \ 'cmd': cmd,
             \ 'custom_cb': function('s:jump_to_declaration_cb', [a:mode, bin_name]),

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -82,7 +82,7 @@ function! s:guru_cmd(args) range abort
     let scopes = go#util#StripTrailingSlash(scopes)
 
     " create shell-safe entries of the list
-    if !has('job') | let scopes = go#util#Shelllist(scopes) | endif
+    if !go#util#has_job() | let scopes = go#util#Shelllist(scopes) | endif
 
     " guru expect a comma-separated list of patterns, construct it
     let l:scope = join(scopes, ",")
@@ -219,10 +219,7 @@ endfunc
 
 " run_guru runs the given guru argument
 function! s:run_guru(args) abort
-  " NOTE(arslan): Having just 'job' is not sufficient as there are still many
-  " fixes after vim8 was released. Therefor we also need at minimum the patch
-  " 15 which has some core fixes we need (8.0.0015). 
-  if has('job') && has("patch15")
+  if go#util#has_job()
     return s:async_guru(a:args)
   endif
 

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -51,7 +51,7 @@ function! go#lint#Gometa(autosave, ...) abort
     let cmd += [split(g:go_metalinter_command, " ")]
   endif
 
-  if has('job') && has('lambda')
+  if go#util#has_job() && has('lambda')
     call go#util#EchoProgress("linting started ...")
     call s:lint_job({'cmd': cmd})
     return

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -35,13 +35,13 @@ function! go#rename#Rename(bang, ...) abort
   let offset = printf('%s:#%d', fname, pos)
 
   " no need to escape for job call
-  let bin_path = has('job') ? bin_path : shellescape(bin_path)
-  let offset = has('job') ? offset : shellescape(offset)
-  let to_identifier = has('job') ? to_identifier : shellescape(to_identifier)
+  let bin_path = go#util#has_job() ? bin_path : shellescape(bin_path)
+  let offset = go#util#has_job() ? offset : shellescape(offset)
+  let to_identifier = go#util#has_job() ? to_identifier : shellescape(to_identifier)
 
   let cmd = [bin_path, "-offset", offset, "-to", to_identifier]
 
-  if has('job')
+  if go#util#has_job()
     call go#util#EchoProgress(printf("renaming to '%s' ...", to_identifier))
     call s:rename_job({
           \ 'cmd': cmd,

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -43,6 +43,12 @@ function! go#util#IsWin() abort
   return 0
 endfunction
 
+function! go#util#has_job() abort
+  " job was introduced in 7.4.xxx however there are multiple bug fixes and one
+  " of the latest is 8.0.0087 which is required for a stable async API.
+  return has('job') && has("patch-8.0.0087")
+endfunction
+
 let s:env_cache = {}
 
 " env returns the go environment variable for the given key. Where key can be


### PR DESCRIPTION
+job was introduced in 7.4.x cycle and later at one time it was decided
to release vim with the version number of 8.0. This means that people
having a recent 7.4.x version might have the `+job` feature. But this is
problematic because the initial `+job` implementation is full of bugs.
It was fixed later by many fixes and improvements. 8.0.0087 is the
minimum for *now*, as it fixes another issue about jobs.

We introduce a new wrapper, so we can tweak the requirement ourselves
and tweak the patch level if needed.