### PR TITLE
Always use full path as statusline target directory

### DIFF
--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -275,7 +275,7 @@ function s:coverage_job(args)
   " autowrite is not enabled for jobs
   call go#cmd#autowrite()
 
-  let import_path =  go#package#ImportPath(expand('%:p:h'))
+  let status_dir =  expand('%:p:h')
   function! s:error_info_cb(job, exit_status, data) closure
     let status = {
           \ 'desc': 'last status',
@@ -287,7 +287,7 @@ function s:coverage_job(args)
       let status.state = "failed"
     endif
 
-    call go#statusline#Update(import_path, status)
+    call go#statusline#Update(status_dir, status)
   endfunction
 
   let a:args.error_info_cb = function('s:error_info_cb')
@@ -308,7 +308,7 @@ function s:coverage_job(args)
   let jobdir = fnameescape(expand("%:p:h"))
   execute cd . jobdir
 
-  call go#statusline#Update(import_path, {
+  call go#statusline#Update(status_dir, {
         \ 'desc': "current status",
         \ 'type': "coverage",
         \ 'state': "started",

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -152,7 +152,7 @@ function! s:async_guru(args) abort
     return
   endif
 
-  let import_path =  go#package#ImportPath(expand('%:p:h'))
+  let status_dir =  expand('%:p:h')
   let statusline_type = printf("%s", a:args.mode)
 
   if !has_key(a:args, 'disable_progress')
@@ -188,7 +188,7 @@ function! s:async_guru(args) abort
       let status.state = "failed"
     endif
 
-    call go#statusline#Update(import_path, status)
+    call go#statusline#Update(status_dir, status)
 
     if has_key(a:args, 'custom_parse')
       call a:args.custom_parse(l:info.exitval, out)
@@ -208,7 +208,7 @@ function! s:async_guru(args) abort
     let l:start_options.in_name = l:tmpname
   endif
 
-  call go#statusline#Update(import_path, {
+  call go#statusline#Update(status_dir, {
         \ 'desc': "current status",
         \ 'type': statusline_type,
         \ 'state': "analysing",

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -63,7 +63,7 @@ function s:rename_job(args)
     call add(messages, a:msg)
   endfunction
 
-  let import_path =  go#package#ImportPath(expand('%:p:h'))
+  let status_dir =  expand('%:p:h')
 
   function! s:close_cb(chan) closure
     let l:job = ch_getjob(a:chan)
@@ -79,7 +79,7 @@ function s:rename_job(args)
       let status.state = "failed"
     endif
 
-    call go#statusline#Update(import_path, status)
+    call go#statusline#Update(status_dir, status)
 
     call s:parse_errors(l:info.exitval, a:args.bang, messages)
   endfunction
@@ -93,7 +93,7 @@ function s:rename_job(args)
   let old_gopath = $GOPATH
   let $GOPATH = go#path#Detect()
 
-  call go#statusline#Update(import_path, {
+  call go#statusline#Update(status_dir, {
         \ 'desc': "current status",
         \ 'type': "gorename",
         \ 'state': "started",


### PR DESCRIPTION
Some parts of the code use go package dir relative to the current GOPATH
as a target for statusline update message which leads to their messages
not being displayed in the statusline (because it expects full path to
the package). Fix this by always using full package path.

Signed-off-by: Pavel Borzenkov <pavel.borzenkov@gmail.com>