### PR TITLE
job: close quickfix window if a job has succeeded

### DIFF
--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -57,16 +57,17 @@ function go#job#Spawn(args)
       endif
     endif
 
+    let l:listtype = go#list#Type("quickfix")
     if exitval == 0
-      call go#list#Clean(0)
-      call go#list#Window(0)
+      call go#list#Clean(l:listtype)
+      call go#list#Window(l:listtype)
       return
     endif
 
-    call self.show_errors()
+    call self.show_errors(l:listtype)
   endfunction
 
-  function cbs.show_errors() dict
+  function cbs.show_errors(listtype) dict
     let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
     try
       execute cd self.jobdir
@@ -84,11 +85,10 @@ function go#job#Spawn(args)
     endif
 
     if self.winnr == winnr()
-      let l:listtype = "quickfix"
-      call go#list#Populate(l:listtype, errors)
-      call go#list#Window(l:listtype, len(errors))
+      call go#list#Populate(a:listtype, errors)
+      call go#list#Window(a:listtype, len(errors))
       if !empty(errors) && !self.bang
-        call go#list#JumpToFirst(l:listtype)
+        call go#list#JumpToFirst(a:listtype)
       endif
     endif
   endfunction

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -99,9 +99,10 @@ function! s:on_exit(job_id, exit_status) abort
 
   call s:callback_handlers_on_exit(s:jobs[a:job_id], a:exit_status, std_combined)
 
+  let l:listtype = go#list#Type("quickfix")
   if a:exit_status == 0
-    call go#list#Clean(0)
-    call go#list#Window(0)
+    call go#list#Clean(l:listtype)
+    call go#list#Window(l:listtype)
 
     let self.state = "SUCCESS"
     call go#util#EchoSuccess("SUCCESS")
@@ -126,7 +127,6 @@ function! s:on_exit(job_id, exit_status) abort
 
   " if we are still in the same windows show the list
   if self.winnr == winnr()
-    let l:listtype = "locationlist"
     call go#list#Populate(l:listtype, errors)
     call go#list#Window(l:listtype, len(errors))
     if !empty(errors) && !self.bang


### PR DESCRIPTION
Otherwise all previous build errors are shown even after successful
build.

Signed-off-by: Pavel Borzenkov <pavel.borzenkov@gmail.com>