### PR TITLE
Add option to use cwd as package name instead of template

### DIFF
--- a/autoload/go/template.vim
+++ b/autoload/go/template.vim
@@ -1,7 +1,7 @@
 let s:current_file = expand("<sfile>")
 
 function! go#template#create() abort
-  let l:go_template_no_file = get(g:, 'go_template_no_file', 0)
+  let l:go_template_use_pkg = get(g:, 'go_template_use_pkg', 0)
   let l:root_dir = fnamemodify(s:current_file, ':h:h:h')
 
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
@@ -13,12 +13,12 @@ function! go#template#create() abort
   " if we can't figure out any package name(no Go files or non Go package
   " files) from the directory create the template or use the cwd
   " as the name
-  if l:package_name == -1 && l:go_template_no_file != 1
+  if l:package_name == -1 && l:go_template_use_pkg != 1
     let l:template_file = get(g:, 'go_template_file', "hello_world.go")
     let l:template_path = go#util#Join(l:root_dir, "templates", l:template_file)
     exe '0r ' . fnameescape(l:template_path)
     $delete _
-  elseif l:package_name == -1 && l:go_template_no_file == 1
+  elseif l:package_name == -1 && l:go_template_use_pkg == 1
     " cwd is now the dir of the package
     let l:path = fnamemodify(getcwd(), ':t')
     let l:content = printf("package %s", l:path)

--- a/autoload/go/template.vim
+++ b/autoload/go/template.vim
@@ -1,6 +1,7 @@
 let s:current_file = expand("<sfile>")
 
 function! go#template#create() abort
+  let l:go_template_no_file = get(g:, 'go_template_no_file', 0)
   let l:root_dir = fnamemodify(s:current_file, ':h:h:h')
 
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
@@ -10,11 +11,18 @@ function! go#template#create() abort
   let l:package_name = go#tool#PackageName()
 
   " if we can't figure out any package name(no Go files or non Go package
-  " files) from the directory create the template
-  if l:package_name == -1
+  " files) from the directory create the template or use the cwd
+  " as the name
+  if l:package_name == -1 && l:go_template_no_file != 1
     let l:template_file = get(g:, 'go_template_file', "hello_world.go")
     let l:template_path = go#util#Join(l:root_dir, "templates", l:template_file)
     exe '0r ' . fnameescape(l:template_path)
+    $delete _
+  elseif l:package_name == -1 && l:go_template_no_file == 1
+    " cwd is now the dir of the package
+    let l:path = fnamemodify(getcwd(), ':t')
+    let l:content = printf("package %s", l:path)
+    call append(0, l:content)
     $delete _
   else
     let l:content = printf("package %s", l:package_name)

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1438,13 +1438,12 @@ with a Go code template. By default the template under
 `templates/hello_world.go` is used. This can be changed with the
 |'g:go_template_file'| setting.
 
-To use the package's directory as the name of the package instead of a template
-when new Go file is created in a directory with no Go files, enable the
-|'g:go_template_no_file'| setting.
-
 If the new file is created in an already prepopulated package (with other Go
 files), in this case a Go code template with only the Go package declaration
 (which is automatically determined according to the current package) is added.
+
+To always use the package name instead of the template, enable the
+|`g:go_template_use_pkg`| setting.
 
 By default it is enabled.
 >
@@ -1458,12 +1457,14 @@ the `hello_world.go` file is used.
 >
   let g:go_template_file = "hello_world.go"
 <
-                                                     *'g:go_template_no_file'*
+                                                     *'g:go_template_use_pkg'*
 
-Specifies that, rather than using a template, the directory name is used as the
-package name if a new Go file is created. Checkout |'g:go_template_autocreate'| for more info. By default it is disabled.
+Specifies that, rather than using a template, the package name is used if a new
+Go file is created. Checkout |'g:go_template_autocreate'| for more info. By
+default the template file specified by |'g:go_template_file'| is used.
+
 >
-  let g:go_template_no_file = 0
+  let g:go_template_use_pkg = 0
 <
                                                        *'g:go_decls_includes'*
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1438,6 +1438,10 @@ with a Go code template. By default the template under
 `templates/hello_world.go` is used. This can be changed with the
 |'g:go_template_file'| setting.
 
+To use the package's directory as the name of the package instead of a template
+when new Go file is created in a directory with no Go files, enable the
+|'g:go_template_no_file'| setting.
+
 If the new file is created in an already prepopulated package (with other Go
 files), in this case a Go code template with only the Go package declaration
 (which is automatically determined according to the current package) is added.
@@ -1453,6 +1457,13 @@ is created. Checkout |'g:go_template_autocreate'| for more info. By default
 the `hello_world.go` file is used.
 >
   let g:go_template_file = "hello_world.go"
+<
+                                                     *'g:go_template_no_file'*
+
+Specifies that, rather than using a template, the directory name is used as the
+package name if a new Go file is created. Checkout |'g:go_template_autocreate'| for more info. By default it is disabled.
+>
+  let g:go_template_no_file = 0
 <
                                                        *'g:go_decls_includes'*
 


### PR DESCRIPTION
This adds an option to use the directory name that contains a package as the name of the package instead of using a template, as requested in issue #1053 