### PR TITLE
Add path conversion for MSYS2 environments

### DIFF
--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -17,7 +17,7 @@ function! go#coverage#BufferToggle(bang, ...) abort
 endfunction
 
 " Buffer creates a new cover profile with 'go test -coverprofile' and changes
-" teh current buffers highlighting to show covered and uncovered sections of
+" the current buffers highlighting to show covered and uncovered sections of
 " the code. Calling it again reruns the tests and shows the last updated
 " coverage.
 function! go#coverage#Buffer(bang, ...) abort
@@ -46,14 +46,14 @@ function! go#coverage#Buffer(bang, ...) abort
 
   if go#util#has_job()
     call s:coverage_job({
-          \ 'cmd': ['go', 'test', '-coverprofile', l:tmpname],
-          \ 'custom_cb': function('s:coverage_callback', [l:tmpname]),
+          \ 'cmd': ['go', 'test', '-coverprofile',  fnameescape(go#util#ToExternalPath(l:tmpname))],
+          \ 'custom_cb': function('s:coverage_callback', [fnameescape(go#util#ToExternalPath(l:tmpname))]),
           \ 'bang': a:bang,
           \ })
     return
   endif
 
-  let args = [a:bang, 0, "-coverprofile", l:tmpname]
+  let args = [a:bang, 0, "-coverprofile",  fnameescape(go#util#ToExternalPath(l:tmpname))]
   if a:0
     call extend(args, a:000)
   endif
@@ -136,7 +136,7 @@ function! go#coverage#parsegocoverline(line) abort
   let mx = '\([^:]\+\):\(\d\+\)\.\(\d\+\),\(\d\+\)\.\(\d\+\)\s\(\d\+\)\s\(\d\+\)'
   let tokens = matchlist(a:line, mx)
   let ret = {}
-  let ret.file = tokens[1]
+  let ret.file = go#util#ToInternalPath(fnameescape(tokens[1]))
   let ret.startline  = str2nr(tokens[2])
   let ret.startcol = str2nr(tokens[3])
   let ret.endline = str2nr(tokens[4])

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -6,6 +6,7 @@ function! go#def#Jump(mode) abort
   let $GOPATH = go#path#Detect()
 
   let fname = fnamemodify(expand("%"), ':p:gs?\\?/?')
+  let fname = fnameescape(go#util#ToExternalPath(fname))
 
   " so guru right now is slow for some people. previously we were using
   " godef which also has it's own quirks. But this issue come up so many
@@ -109,13 +110,13 @@ function! s:jump_to_declaration(out, mode, bin_name) abort
 
   " strip line ending
   let out = split(final_out, go#util#LineEnding())[0]
-  if go#util#IsWin()
+  if go#util#IsWin() || go#util#IsWinUnix()
     let parts = split(out, '\(^[a-zA-Z]\)\@<!:')
   else
     let parts = split(out, ':')
   endif
 
-  let filename = parts[0]
+  let filename = go#util#ToInternalPath(fnameescape(parts[0]))
   let line = parts[1]
   let col = parts[2]
   let ident = parts[3]

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -134,7 +134,7 @@ function! s:gogetdoc(json) abort
   let cmd =  [bin_path]
 
   let offset = go#util#OffsetCursor()
-  let fname = expand("%:p:gs!\\!/!")
+  let fname = go#util#ToExternalPath(expand("%:p:gs!\\!/!"))
   let pos = shellescape(fname.':#'.offset)
 
   let cmd += ["-pos", pos]

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -33,7 +33,7 @@ function! s:guru_cmd(args) range abort
   " start constructing the command
   let cmd = [bin_path]
 
-  let filename = fnamemodify(expand("%"), ':p:gs?\\?/?')
+  let filename = fnameescape(go#util#ToExternalPath(fnamemodify(expand("%"), ':p:gs?\\?/?')))
   let stdin_content = ""
   if &modified
     let sep = go#util#LineEnding()

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -15,7 +15,7 @@ function! go#path#GoPath(...) abort
     " initial GOPATH, which was set when Vim was started.
     if len(a:000) == 1 && a:1 == '""'
       if !empty(s:initial_go_path)
-        let $GOPATH = s:initial_go_path
+        let $GOPATH = go#util#ToExternalPath(s:initial_go_path)
         let s:initial_go_path = ""
       endif
 
@@ -24,8 +24,8 @@ function! go#path#GoPath(...) abort
     endif
 
     echon "vim-go: " | echohl Function | echon "GOPATH changed to ". a:1 | echohl None
-    let s:initial_go_path = $GOPATH
-    let $GOPATH = a:1
+    let s:initial_go_path = go#util#ToInternalPath($GOPATH)
+    let $GOPATH = go#util#ToExternalPath(a:1)
     return
   endif
 
@@ -36,7 +36,7 @@ endfunction
 " it. For multiple GOPATHS separated with a the OS specific separator, only
 " the first one is returned
 function! go#path#Default() abort
-  let go_paths = split($GOPATH, go#util#PathListSep())
+  let go_paths = split(go#util#ToInternalPath($GOPATH), go#util#PathListSep())
 
   if len(go_paths) == 1
     return $GOPATH
@@ -48,7 +48,7 @@ endfunction
 " HasPath checks whether the given path exists in GOPATH environment variable
 " or not
 function! go#path#HasPath(path) abort
-  let go_paths = split($GOPATH, go#util#PathListSep())
+  let go_paths = split(go#util#ToInternalPath($GOPATH), go#util#PathListSep())
   let last_char = strlen(a:path) - 1
 
   " check cases of '/foo/bar/' and '/foo/bar'
@@ -70,7 +70,7 @@ endfunction
 " over the current GOPATH. It also detects diretories whose are outside
 " GOPATH.
 function! go#path#Detect() abort
-  let gopath = $GOPATH
+  let gopath = go#util#ToInternalPath($GOPATH)
 
   " don't lookup for godeps if autodetect is disabled.
   if !get(g:, "go_autodetect_gopath", 1)

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -32,7 +32,7 @@ function! go#rename#Rename(bang, ...) abort
 
   let fname = expand('%:p')
   let pos = go#util#OffsetCursor()
-  let offset = printf('%s:#%d', fname, pos)
+  let offset = printf('%s:#%d', go#util#ToExternalPath(fname), pos)
 
   " no need to escape for job call
   let bin_path = go#util#has_job() ? bin_path : shellescape(bin_path)


### PR DESCRIPTION
In a MSYS2-based environment on Windows (this includes the shell
provided by Git for Windows) Vim operates as if running on a Unix
system. The external tools used by vim-go on the other hand expect path
names in Windows path notation as command line arguments. When called
from a MSYS2 environment, they were supplied with a path in Unix notation
instead (e.g. /c/gopath/src/foo.go). To resolve this discrepancy, all
command line arguments passed to external tools must be translated into
Windows path notation in such an environment. Similarly, output created
by external tools must be converted back to Unix notation when it
contains path names.

This commit introduces functions for translating paths between internal
and external (native to the tool) notation. Path translation is
performed with the help of the cygpath utility provided by the Cygwin
environment on which MSYS2 is based. As Windows path names contain
backslashes, further escaping is often required when using the
conversion functions introduced here.

The path conversion functions are then used in the vim-go commands where
command line arguments for external tools are constructed or tool output
and environment variables are parsed. The translation is a no-op on
other platforms and when using a native Vim build on Windows.

Thanks to @fawick for testing and rebasing to the Vim 8.0 changes!