### PR TITLE
handle :GoDef from modified buffer

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -146,19 +146,27 @@ function! s:jump_to_declaration(out, mode, bin_name) abort
     if get(g:, 'go_def_reuse_buffer', 0) && bufloaded(filename) != 0 && bufwinnr(filename) != -1
       " jumpt to existing buffer if it exists
       execute bufwinnr(filename) . 'wincmd w'
-    elseif a:mode == "tab"
-      let &switchbuf = "usetab"
-      if bufloaded(filename) == 0
-        tab split
+    else
+      if &modified
+        let cmd = 'hide edit'
+      else
+         let cmd = 'edit'
       endif
-    elseif a:mode == "split"
-      split
-    elseif a:mode == "vsplit"
-      vsplit
-    endif
 
-    " open the file and jump to line and column
-    exec 'edit' filename
+      if a:mode == "tab"
+        let &switchbuf = "usetab"
+        if bufloaded(filename) == 0
+          tab split
+        endif
+      elseif a:mode == "split"
+        split
+      elseif a:mode == "vsplit"
+        vsplit
+      endif
+
+      " open the file and jump to line and column
+      exec cmd filename
+    endif
   endif
   call cursor(line, col)
 


### PR DESCRIPTION
Handle jumping to type definitions from a modified buffer. When the
definition is in the same file, skip trying to open the file that
contains the definition - just set the cursor position. When the
definition is in a different file and the current buffer has unsaved
modifications, use :hide edit instead of :edit.

Fixes #1125