### PR TITLE
allow popping from jump list when buffer is modified

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -272,7 +272,13 @@ function! go#def#Stack(...) abort
     let target = s:go_stack[s:go_stack_level]
 
     " jump
-    exec 'edit' target["file"]
+    if expand('%:p') != target["file"]
+      if &modified
+        exec 'hide edit' target["file"]
+      else
+        exec 'edit' target["file"]
+      endif
+    endif
     call cursor(target["line"], target["col"])
     normal! zz
   else


### PR DESCRIPTION
Properly pop to the requested location in the jump list, even when the
current buffer is modified. When current buffer is the target, don't try
to load the target file using edit or hide edit; just set the cursor
position. When the current buffer is modified and is not the target, use
hide edit to hide the current buffer.