### PR TITLE
list: set title only for recent Vim versions

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -269,11 +269,11 @@ function s:lint_job(args)
     let errors = go#list#Get(l:listtype)
     if empty(errors) 
       call go#list#Window(l:listtype, len(errors))
-    else
+    elseif has("patch-7.4.2200")
       if l:listtype == 'quickfix'
-        call setqflist([], 'a', {'title': 'Lint'})
+        call setqflist([], 'a', {'title': 'GoMetaLinter'})
       else
-        call setloclist(0, [], 'a', {'title': 'Lint'})
+        call setloclist(0, [], 'a', {'title': 'GoMetaLinter'})
       endif
     endif
 

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -54,10 +54,13 @@ function! go#list#Populate(listtype, items, title) abort
   let l:listtype = go#list#Type(a:listtype)
   if l:listtype == "locationlist"
     call setloclist(0, a:items, 'r')
-    call setloclist(0, [], 'a', {'title': a:title})
+
+    " The last argument ({what}) is introduced with 7.4.2200:
+    " https://github.com/vim/vim/commit/d823fa910cca43fec3c31c030ee908a14c272640
+    if has("patch-7.4.2200") | call setloclist(0, [], 'a', {'title': a:title}) | endif
   else
     call setqflist(a:items, 'r')
-    call setqflist([], 'a', {'title': a:title})
+    if has("patch-7.4.2200") | call setqflist([], 'a', {'title': a:title}) | endif
   endif
 endfunction
 
@@ -76,10 +79,10 @@ function! go#list#ParseFormat(listtype, errformat, items, title) abort
   let &errorformat = a:errformat
   if l:listtype == "locationlist"
     lgetexpr a:items
-    call setloclist(0, [], 'a', {'title': a:title})
+    if has("patch-7.4.2200") | call setloclist(0, [], 'a', {'title': a:title}) | endif
   else
     cgetexpr a:items
-    call setqflist([], 'a', {'title': a:title})
+    if has("patch-7.4.2200") | call setqflist([], 'a', {'title': a:title}) | endif
   endif
 
   "restore back


### PR DESCRIPTION
The last argument was introduced with 7.4.2200. Make sure it's only used
with that version.

https://github.com/vim/vim/commit/d823fa910cca43fec3c31c030ee908a14c272640

Fixes: #1131