### PR TITLE
fix bug in guru vim script

### DIFF
--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -51,7 +51,7 @@ function! s:guru_cmd(args) range abort
   if exists('g:go_guru_tags')
     let tags = get(g:, 'go_guru_tags')
     call extend(cmd, ["-tags", tags])
-    call result.tags = tags
+    let result.tags = tags
   endif
 
   " some modes require scope to be defined (such as callers). For these we


### PR DESCRIPTION
`:GoDescribe` and other `guru` functions failed with 

```
Error detected while processing function go#guru#Freevars..<SNR>33_run_guru..<SNR>33_sync_guru..<SNR>33_guru_cmd:
line   42:
E107: Missing parentheses: result.tags = tags
```

This change fixed this for me and now `:GoDescribe` works.
