### PR TITLE
Fix indentation broken when using a action with a minus sign like `{{-'

### DIFF
--- a/indent/gohtmltmpl.vim
+++ b/indent/gohtmltmpl.vim
@@ -30,13 +30,13 @@ function! GetGoHTMLTmplIndent(lnum)
 
   " If need to indent based on last line
   let last_line = getline(a:lnum-1)
-  if last_line =~ '^\s*{{\s*\%(if\|else\|range\|with\|define\|block\).*}}'
+  if last_line =~ '^\s*{{-\=\s*\%(if\|else\|range\|with\|define\|block\).*}}'
     let ind += sw
   endif
 
   " End of FuncMap block
   let current_line = getline(a:lnum)
-  if current_line =~ '^\s*{{\s*\%(else\|end\).*}}'
+  if current_line =~ '^\s*{{-\=\s*\%(else\|end\).*}}'
     let ind -= sw
   endif
 


### PR DESCRIPTION
Golang's template has supported a action with a minus sign like `{{-` since go1.6.

Using this syntax breaks the indentation.