### PR TITLE
fixes #1144: "E118: Too many arguments for function: <SNR>173_on_exit"

### DIFF
--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -38,9 +38,9 @@ endfunction
 " GOPATH when g:go_autodetect_gopath is enabled. The job is started inside the
 " current files folder.
 function! s:spawn(bang, desc, args) abort
-  let job = { 
-        \ 'desc': a:desc, 
-        \ 'bang': a:bang, 
+  let job = {
+        \ 'desc': a:desc,
+        \ 'bang': a:bang,
         \ 'winnr': winnr(),
         \ 'importpath': go#package#ImportPath(expand('%:p:h')),
         \ 'state': "RUNNING",
@@ -90,7 +90,7 @@ endfunction
 " references and also displaying errors in the quickfix window collected by
 " on_stderr handler. If there are no errors and a quickfix window is open,
 " it'll be closed.
-function! s:on_exit(job_id, exit_status) abort
+function! s:on_exit(job_id, exit_status, event) dict abort
   let std_combined = self.stderr + self.stdout
 
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
@@ -147,14 +147,14 @@ function! s:callback_handlers_on_exit(job, exit_status, data) abort
 endfunction
 
 " on_stdout is the stdout handler for jobstart(). It collects the output of
-" stderr and stores them to the jobs internal stdout list. 
-function! s:on_stdout(job_id, data) abort
+" stderr and stores them to the jobs internal stdout list.
+function! s:on_stdout(job_id, data) dict abort
   call extend(self.stdout, a:data)
 endfunction
 
 " on_stderr is the stderr handler for jobstart(). It collects the output of
 " stderr and stores them to the jobs internal stderr list.
-function! s:on_stderr(job_id, data) abort
+function! s:on_stderr(job_id, data) dict abort
   call extend(self.stderr, a:data)
 endfunction
 

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -36,7 +36,7 @@ function! go#term#newmode(bang, cmd, mode) abort
   setlocal noswapfile
   setlocal nobuflisted
 
-  let job = { 
+  let job = {
         \ 'stderr' : [],
         \ 'stdout' : [],
         \ 'bang' : a:bang,
@@ -75,7 +75,7 @@ function! go#term#newmode(bang, cmd, mode) abort
   return id
 endfunction
 
-function! s:on_stdout(job_id, data) abort
+function! s:on_stdout(job_id, data, event) dict abort
   if !has_key(s:jobs, a:job_id)
     return
   endif
@@ -84,7 +84,7 @@ function! s:on_stdout(job_id, data) abort
   call extend(job.stdout, a:data)
 endfunction
 
-function! s:on_stderr(job_id, data) abort
+function! s:on_stderr(job_id, data, event) dict abort
   if !has_key(s:jobs, a:job_id)
     return
   endif
@@ -93,7 +93,7 @@ function! s:on_stderr(job_id, data) abort
   call extend(job.stderr, a:data)
 endfunction
 
-function! s:on_exit(job_id, exit_status) abort
+function! s:on_exit(job_id, exit_status, event) dict abort
   if !has_key(s:jobs, a:job_id)
     return
   endif
@@ -114,7 +114,7 @@ function! s:on_exit(job_id, exit_status) abort
 
   if !empty(errors)
     " close terminal we don't need it anymore
-    close 
+    close
 
     call go#list#Populate(l:listtype, errors, job.cmd)
     call go#list#Window(l:listtype, len(errors))


### PR DESCRIPTION
Changes in neovim job control API broke vim-go integration. This commit
updates alters the integration to follow recommended practices from the
neovim wiki: https://github.com/neovim/neovim/wiki/Following-HEAD#20161212