### PR TITLE
If GOPATH is empty check for the value of go env GOPATH

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -32,7 +32,7 @@ command! -nargs=? -complete=dir GoPath call go#path#GoPath(<f-args>)
 " target install directory. GoInstallBinaries doesn't install binaries if they
 " exist, to update current binaries pass 1 to the argument.
 function! s:GoInstallBinaries(updateBinaries)
-  if $GOPATH == ""
+  if $GOPATH == "" && go#util#gopath() == ""
     echohl Error
     echomsg "vim.go: $GOPATH is not set"
     echohl None


### PR DESCRIPTION
Go 1.8 has a default GOPATH (~/go) , if there is no GOPATH set we should also check for the value of go env GOPATH before bailing out.