### PR TITLE
use funcref() instead of function() for closures used as callbacks

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -419,7 +419,7 @@ function s:cmd_job(args) abort
     call go#statusline#Update(status_dir, status)
   endfunction
 
-  let a:args.error_info_cb = function('s:error_info_cb')
+  let a:args.error_info_cb = funcref('s:error_info_cb')
   let callbacks = go#job#Spawn(a:args)
 
   let start_options = {

--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -283,7 +283,7 @@ function s:coverage_job(args)
     call go#statusline#Update(status_dir, status)
   endfunction
 
-  let a:args.error_info_cb = function('s:error_info_cb')
+  let a:args.error_info_cb = funcref('s:error_info_cb')
   let callbacks = go#job#Spawn(a:args)
 
   let start_options = {

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -299,7 +299,7 @@ function s:def_job(args) abort
     " do not print anything during async definition search&jump
   endfunction
 
-  let a:args.error_info_cb = function('s:error_info_cb')
+  let a:args.error_info_cb = funcref('s:error_info_cb')
   let callbacks = go#job#Spawn(a:args)
 
   let start_options = {

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -34,7 +34,6 @@ function! s:guru_cmd(args) range abort
   let cmd = [bin_path]
 
   let filename = fnamemodify(expand("%"), ':p:gs?\\?/?')
-  let stdin_content = ""
   if &modified
     let sep = go#util#LineEnding()
     let content  = join(getline(1, '$'), sep )
@@ -127,7 +126,7 @@ function! s:sync_guru(args) abort
 
   " run, forrest run!!!
   let command = join(result.cmd, " ")
-  if &modified
+  if has_key(result, 'stdin_content')
     let out = go#util#System(command, result.stdin_content)
   else
     let out = go#util#System(command)
@@ -198,10 +197,10 @@ function! s:async_guru(args) abort
   endfunction
 
   let start_options = {
-        \ 'close_cb': function("s:close_cb"),
+        \ 'close_cb': funcref("s:close_cb"),
         \ }
 
-  if &modified
+  if has_key(result, 'stdin_content')
     let l:tmpname = tempname()
     call writefile(split(result.stdin_content, "\n"), l:tmpname, "b")
     let l:start_options.in_io = "file"

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -283,8 +283,8 @@ function s:lint_job(args)
   endfunction
 
   let start_options = {
-        \ 'callback': function("s:callback"),
-        \ 'close_cb': function("s:close_cb"),
+        \ 'callback': funcref("s:callback"),
+        \ 'close_cb': funcref("s:close_cb"),
         \ }
 
   call job_start(a:args.cmd, start_options)

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -85,8 +85,8 @@ function s:rename_job(args)
   endfunction
 
   let start_options = {
-        \ 'callback': function("s:callback"),
-        \ 'close_cb': function("s:close_cb"),
+        \ 'callback': funcref("s:callback"),
+        \ 'close_cb': funcref("s:close_cb"),
         \ }
 
   " modify GOPATH if needed


### PR DESCRIPTION
Use funcref() instead of function() to get a Funcref that will retrieve
the function by reference instead of by name. function() returns a
Funcref that resolves the function by name, which caused multiple
concurrent jobs of the same type to both execute the callback that
closed over the arguments of the last job to be started. funcref()
returns a Funcref that returns the function by reference (not by name),
so each job is assured that its callbacks execute the function that
closed over the arguments of that job.

Also refactored a couple of the guru functions to check the result of
guru_cmd for stdin_content explicitly instead of assuming that
guru_cmd's result has a stdin_content key when the buffer is modified.

The easiest way to see the problems that this PR addresses is to set `g:go_auto_sameids=1`, and then run `GoReferrers` on some reference. One would expect the location list to be opened, but it never did.