### PR TITLE
clear buffer-local BufWinEnter properly

### DIFF
--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -542,7 +542,7 @@ function! go#guru#ClearSameIds() abort
   endfor
 
   " remove the autocmds we defined
-  if exists("#BufWinEnter<buffer>")
+  if exists("#BufWinEnter#<buffer>")
     autocmd! BufWinEnter <buffer>
   endif
 endfunction


### PR DESCRIPTION
Fix the check for a buffer-local BufWinEnter autocmd in
go#guru#ClearSameIds() so that multiple BufWinEnter autocmds are not
registered to rehighlight the sameids when re-entering the local buffer.