### PR TITLE
Use go_metalinter_command as List after split().

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -48,7 +48,7 @@ function! go#lint#Gometa(autosave, ...) abort
     let cmd += [expand('%:p:h')]
   else
     " the user wants something else, let us use it.
-    let cmd += [split(g:go_metalinter_command, " ")]
+    let cmd += split(g:go_metalinter_command, " ")
   endif
 
   if go#util#has_job() && has('lambda')


### PR DESCRIPTION
After splitting `go_metalinter_command` it is already a List. Wrapping the result inside another list causes a "using List as a String" error and linting to fail.