### PR TITLE
Fix :GoDocBrowser for third party package doc.

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -31,12 +31,11 @@ function! go#doc#OpenBrowser(...) abort
 
     let import = out["import"]
     let name = out["name"]
-
-    " if import is empty, it means we selected a package name
-    if import ==# ""
-      let godoc_url = "https://godoc.org/" . name 
-    else
-      let godoc_url = "https://godoc.org/" . import . "#" . name
+    let decl = out["decl"]
+    
+    let godoc_url = "https://godoc.org/" . import
+    if decl !~ "^package"
+      let godoc_url .= "#" . name 
     endif
 
     echo godoc_url


### PR DESCRIPTION
gogetdoc now includes import paths for package doc too.
We now detect package doc by checking the decl field.

Fixes #1173