### PR TITLE
fix :GoBuild issues in neovim

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -32,8 +32,11 @@ function! go#cmd#Build(bang, ...) abort
           \})
     return
   elseif has('nvim')
+    if get(g:, 'go_echo_command_info', 1)
+      call go#util#EchoProgress("building dispatched ...")
+    endif
+
     " if we have nvim, call it asynchronously and return early ;)
-    call go#util#EchoProgress("building dispatched ...")
     call go#jobcontrol#Spawn(a:bang, "build", args)
     return
   endif


### PR DESCRIPTION
1. honor `g:go_echo_command_info` when dispatching builds in neovim
1. fix `:GoBuild` error in neovim due to invalid jobcontrol handler function signatures (`s:on_stdout`, `s:on_stderr`)
1. update statusline before and after `go#jobcontrol#Spawn` command is executed

also, as an aside, it looks like vim's job capability is utilized much more than neovim's job-control. it would be nice to abstract the differences and bring neovim up to parity again.