### PR TITLE
Correctly report the value of the 'g:go_guru_tags' variable

### DIFF
--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -634,7 +634,7 @@ function! go#guru#Tags(...) abort
   if !exists('g:go_guru_tags')
     call go#util#EchoSuccess("guru tags is not set")
   else
-    call go#util#EchoSuccess("current guru tags: ". a:1)
+    call go#util#EchoSuccess("current guru tags: ". g:go_guru_tags)
   endif
 endfunction
 


### PR DESCRIPTION
When reporting the value of the Guru tags, the `a:1` variable is used. The `g:go_guru_tags` variable should be used instead.