### PR TITLE
Support 'encoding != utf-8'

### DIFF
--- a/autoload/go/asmfmt.vim
+++ b/autoload/go/asmfmt.vim
@@ -25,7 +25,7 @@ function! go#asmfmt#Format() abort
 
   " Write the current buffer to a tempfile.
   let l:tmpname = tempname()
-  call writefile(getline(1, '$'), l:tmpname)
+  call writefile(go#util#GetLines(), l:tmpname)
 
   " Run asmfmt.
   let path = go#path#CheckBinPath("asmfmt")

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -1,18 +1,8 @@
 let s:sock_type = (has('win32') || has('win64')) ? 'tcp' : 'unix'
 
 function! s:gocodeCurrentBuffer() abort
-  let buf = getline(1, '$')
-  if &encoding != 'utf-8'
-    let buf = map(buf, 'iconv(v:val, &encoding, "utf-8")')
-  endif
-  if &l:fileformat == 'dos'
-    " XXX: line2byte() depend on 'fileformat' option.
-    " so if fileformat is 'dos', 'buf' must include '\r'.
-    let buf = map(buf, 'v:val."\r"')
-  endif
   let file = tempname()
-  call writefile(buf, file)
-
+  call writefile(go#util#GetLines(), file)
   return file
 endfunction
 

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -16,7 +16,7 @@ function! go#def#Jump(mode) abort
     if &modified
       " Write current unsaved buffer to a temp file and use the modified content
       let l:tmpname = tempname()
-      call writefile(getline(1, '$'), l:tmpname)
+      call writefile(go#util#GetLines(), l:tmpname)
       let fname = l:tmpname
     endif
 
@@ -41,8 +41,7 @@ function! go#def#Jump(mode) abort
     let stdin_content = ""
 
     if &modified
-      let sep = go#util#LineEnding()
-      let content  = join(getline(1, '$'), sep)
+      let content  = join(go#util#GetLines(), "\n")
       let stdin_content = fname . "\n" . strlen(content) . "\n" . content
       call add(cmd, "-modified")
     endif

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -152,8 +152,7 @@ function! s:gogetdoc(json) abort
     "     file size followed by newline
     "     file contents
     let in = ""
-    let sep = go#util#LineEnding()
-    let content = join(getline(1, '$'), sep)
+    let content = join(go#util#GetLines(), "\n")
     let in = fname . "\n" . strlen(content) . "\n" . content
     let command .= " -modified"
     let out = go#util#System(command, in)

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -63,7 +63,7 @@ function! go#fmt#Format(withGoimport) abort
 
   " Write current unsaved buffer to a temp file
   let l:tmpname = tempname()
-  call writefile(getline(1, '$'), l:tmpname)
+  call writefile(go#util#GetLines(), l:tmpname)
   if go#util#IsWin()
     let l:tmpname = tr(l:tmpname, '\', '/')
   endif

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -35,8 +35,7 @@ function! s:guru_cmd(args) range abort
 
   let filename = fnamemodify(expand("%"), ':p:gs?\\?/?')
   if &modified
-    let sep = go#util#LineEnding()
-    let content  = join(getline(1, '$'), sep )
+    let content  = join(go#util#GetLines(), "\n")
     let result.stdin_content = filename . "\n" . strlen(content) . "\n" . content
     call add(cmd, "-modified")
   endif

--- a/autoload/go/textobj.vim
+++ b/autoload/go/textobj.vim
@@ -20,7 +20,7 @@ function! go#textobj#Function(mode) abort
   if &modified
     " Write current unsaved buffer to a temp file and use the modified content
     let l:tmpname = tempname()
-    call writefile(getline(1, '$'), l:tmpname)
+    call writefile(go#util#GetLines(), l:tmpname)
     let fname = l:tmpname
   endif
 
@@ -107,7 +107,7 @@ function! go#textobj#FunctionJump(mode, direction) abort
   if &modified
     " Write current unsaved buffer to a temp file and use the modified content
     let l:tmpname = tempname()
-    call writefile(getline(1, '$'), l:tmpname)
+    call writefile(go#util#GetLines(), l:tmpname)
     let fname = l:tmpname
   endif
 

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -305,4 +305,17 @@ function! go#util#EchoInfo(msg)
   redraw | echohl Debug | echom "vim-go: " . a:msg | echohl None
 endfunction
 
+function! go#util#GetLines()
+  let buf = getline(1, '$')
+  if &encoding != 'utf-8'
+    let buf = map(buf, 'iconv(v:val, &encoding, "utf-8")')
+  endif
+  if &l:fileformat == 'dos'
+    " XXX: line2byte() depend on 'fileformat' option.
+    " so if fileformat is 'dos', 'buf' must include '\r'.
+    let buf = map(buf, 'v:val."\r"')
+  endif
+  return buf
+endfunction
+
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
All of files should be written in utf-8 if the file will be passed to external command.