### PR TITLE
log.Fatal(err) is useful

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -151,6 +151,14 @@ if err != nil {
 ${0}
 endsnippet
 
+# error log snippet
+snippet errl "Error with log.Fatal(err)" !b
+if err != nil {
+	log.Fatal(err)
+}
+${0}
+endsnippet
+
 # error multiple return
 snippet errn, "Error return with two return values" !b
 if err != nil {

--- a/gosnippets/snippets/go.snip
+++ b/gosnippets/snippets/go.snip
@@ -132,6 +132,13 @@ abbr if err != nil { ... }
 		t.Fatal(err)
 	}
 
+# error snippet in log.Fatal
+snippet errl
+abbr if err != nil { ... }
+	if err != nil {
+		log.Fatal(err)
+	}
+
 # error snippet with two return values
 snippet errn,
 abbr if err != nil { return [...], err }


### PR DESCRIPTION
In the most cases I write `if err != nil {}` is this.