### PR TITLE
Ensure no trailing : in gopath

### DIFF
--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -110,6 +110,9 @@ function! go#path#Detect() abort
     endif
   endif
 
+  " Fix up the case where initial $GOPATH is empty,
+  " and we end up with a trailing :
+  let gopath = substitute(gopath, ":$", "", "")
   return gopath
 endfunction
 


### PR DESCRIPTION
This can happen if, for example, you don't currently have a $GOPATH set.