### PR TITLE
Modify the resize behavior for godoc

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -92,13 +92,20 @@ function! s:GodocView(newposition, position, content) abort
     execute bufwinnr(s:buf_nr) . 'wincmd w'
   endif
 
-  " cap buffer height to 20, but resize it for smaller contents
-  let max_height = 20
-  let content_height = len(split(a:content, "\n"))
-  if content_height > max_height
-    exe 'resize ' . max_height
+  if a:position == "split"
+    " cap buffer height to 20, but resize it for smaller contents
+    let max_height = 20
+    let content_height = len(split(a:content, "\n"))
+    if content_height > max_height
+      exe 'resize ' . max_height
+    else
+      exe 'resize ' . content_height
+    endif
   else
-    exe 'resize ' . content_height
+    " set a sane maximum width for vertical splits. In this case the minimum
+    " that fits the godoc for package http without extra linebreaks and line
+    " numbers on
+    exe 'vertical resize 84'
   endif
 
   setlocal filetype=godoc


### PR DESCRIPTION
The default behavior for resizing the split when using godoc was to limit the
vertical size, even when using the vertical split. This is now constrained to
only limit vertical size for horizontal splits and vice-versa.