### PR TITLE
Document 'noshowmode' requirement for echo_go_info

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1488,6 +1488,8 @@ default it's enabled >
 
       let g:go_echo_go_info = 1
 <
+Please note that 'noshowmode' must be set for this feature to work correctly.
+
                                                     *'g:go_statusline_duration'*
 
 Specifices the duration of statusline information being showed per package. By


### PR DESCRIPTION
After playing around with vim 8 and a minimal vimrc, I found that noshowmode was the only way to see post-completion usage information.