### PR TITLE
Introduce GoDebug

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -385,6 +385,61 @@ function! go#cmd#Generate(bang, ...) abort
   let $GOPATH = old_gopath
 endfunction
 
+function! go#cmd#ToggleBreakpoint(file, line, ...) abort
+  " Compose the breakpoint for delve:
+  " Example: break /home/user/path/to/go/file.go:23
+  let breakpoint = "break " . a:file. ':' . a:line
+
+  " Define the sign for the gutter
+  exe "sign define gobreakpoint text=◉ texthl=Search"
+
+  " If the line isn't already in the list, add it.
+  " Otherwise remove it from the list.
+  let i = index(g:go_breakpoints, breakpoint)
+  if i == -1
+    call add(g:go_breakpoints, breakpoint)
+    exe "sign place ". a:line ." line=" . a:line . " name=gobreakpoint file=" . a:file
+  else
+    call remove(g:go_breakpoints, i)
+    exe "sign unplace ". a:line ." file=" . a:file
+  endif
+endfunction
+
+function! go#cmd#writeBreakpointsFile(...) abort
+  call writefile(g:go_breakpoints + ["continue"], g:go_breakpoints_file)
+endfunction
+
+function! go#cmd#deleteBreakpointsFile(...) abort
+  if filereadable(g:go_breakpoints_file)
+    call delete(g:go_breakpoints_file)
+  endif
+endfunction
+
+function! go#cmd#Debug(bang, ...) abort
+  call go#cmd#writeBreakpointsFile()
+  let args = ["debug", "--init=" . g:go_breakpoints_file]
+
+  " FIXME: this doesn't works for Vim 8
+  if go#util#has_job()
+    " use vim's job functionality to call it asynchronously
+    let job_args = {
+          \ 'cmd': ['dlv'] + args,
+          \ 'bang': a:bang,
+          \ }
+
+    call s:cmd_job(job_args)
+    return
+  elseif has('nvim')
+    " use nvims's job functionality
+    if get(g:, 'go_term_enabled', 0)
+      let id = go#term#new(a:bang, ["dlv"] + args)
+    else
+      let id = go#jobcontrol#Spawn(a:bang, "dlv", args)
+    endif
+
+    return id
+  endif
+endfunction
 
 " ---------------------
 " | Vim job callbacks |

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -60,6 +60,17 @@ if get(g:, "go_auto_type_info", 0) || get(g:, "go_auto_sameids", 0)
   let &l:updatetime= get(g:, "go_updatetime", 800)
 endif
 
+" Set a global list of breakpoints, if not already exist
+if !exists("g:go_breakpoints")
+  let g:go_breakpoints = []
+endif
+
+if !exists("g:go_breakpoints_file")
+  let g:go_breakpoints_file = '.gobreakpoints'
+endif
+
+autocmd VimLeave * call go#cmd#deleteBreakpointsFile()<cr>
+
 " NOTE(arslan): experimental, disabled by default, doesn't work well. No
 " documentation as well. If anyone feels adventerous, enable the following and
 " try to search for Go identifiers ;)

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -36,6 +36,8 @@ command! -nargs=* -bang GoInstall call go#cmd#Install(<bang>0, <f-args>)
 command! -nargs=* -bang GoTest call go#cmd#Test(<bang>0, 0, <f-args>)
 command! -nargs=* -bang GoTestFunc call go#cmd#TestFunc(<bang>0, <f-args>)
 command! -nargs=* -bang GoTestCompile call go#cmd#Test(<bang>0, 1, <f-args>)
+command! -nargs=* -bang GoToggleBreakpoint call go#cmd#ToggleBreakpoint(expand('%:p'), line('.'), <f-args>)
+command! -nargs=* -bang GoDebug call go#cmd#Debug(<bang>0, 0, <f-args>)
 
 " -- cover
 command! -nargs=* -bang GoCoverage call go#coverage#Buffer(<bang>0, <f-args>)


### PR DESCRIPTION
Hi, `vim-go` it's an essential plugin for me, thank you!

---

This is a proposal to introduce `GoDebug` command. It runs a debugging session in (Neo)Vim.
The debugger engine is [delve](https://github.com/derekparker/delve), which needs to be installed on the developer's machine.

I haven't added it to the list of the `GoInstallBinaries` because on OSX requires Homebrew for automatic installation. In case of manual installation things get more [complicated](https://github.com/derekparker/delve/blob/master/Documentation/installation/osx/install.md#manual-install).

---

Another addition of this PR is the `GoToggleBreakpoint` command, to toggle a breakpoint from a buffer. It adds a visual sign in the gutter column.

---

**Please note that this PR works only for NeoVim**. I didn't manage to get it to work for Vim too. Please advise. 😄 

I'm not sure if you want to add this debugging feature. If so, let me know, so I can fix the missing parts.

---

See it in action:

![vim-go-debug](https://cloud.githubusercontent.com/assets/5089/22627232/28d7b872-ebbf-11e6-93dc-fafc21cc31d2.gif)
