### PR TITLE
Add go_imports_options resolve #1212

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -21,6 +21,10 @@ if !exists('g:go_fmt_options')
   let g:go_fmt_options = ''
 endif
 
+if !exists('g:go_imports_options')
+  let g:go_imports_options = ''
+endif
+
 if !exists("g:go_fmt_experimental")
   let g:go_fmt_experimental = 0
 endif
@@ -168,9 +172,11 @@ function! s:fmt_cmd(bin_name, source, target)
   " start constructing the command
   let cmd = [bin_path]
   call add(cmd, "-w")
-  call extend(cmd, split(g:go_fmt_options, " "))
 
-  if a:bin_name == "goimports"
+  if a:bin_name != "goimports"
+    call extend(cmd, split(g:go_fmt_options, " "))
+  else
+    call extend(cmd, split(g:go_imports_options, " "))
     " lazy check if goimports support `-srcdir`. We should eventually remove
     " this in the future
     if !exists('b:goimports_vendor_compatible')

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1092,6 +1092,13 @@ is empty. >
 
   let g:go_fmt_options = ''
 <
+                                                          *'g:go_imports_options'*
+
+Use this option to add additional options to the |'g:go_goimports_bin'|. Default
+is empty. >
+
+  let g:go_imports_options = ''
+<
                                                     *'g:go_fmt_fail_silently'*
 
 Use this option to disable showing a location list when |'g:go_fmt_command'|


### PR DESCRIPTION
Add `go_imports_options` for `goimports`.

Witch do you like `go_imports_options` or `go_goimports_options` ?