### PR TITLE
Add build tags support for gorename

### DIFF
--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -41,6 +41,11 @@ function! go#rename#Rename(bang, ...) abort
 
   let cmd = [bin_path, "-offset", offset, "-to", to_identifier]
 
+  if exists('g:go_rename_tags')
+    let tags = get(g:, 'go_rename_tags')
+    call extend(cmd, ["-tags", tags])
+  endif
+
   if go#util#has_job()
     call go#util#EchoProgress(printf("renaming to '%s' ...", to_identifier))
     call s:rename_job({

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -148,4 +148,24 @@ function s:parse_errors(exit_val, bang, out)
   silent execute ":e"
 endfunction
 
+function! go#rename#Tags(...) abort
+  if a:0
+    if a:0 == 1 && a:1 == '""'
+      unlet g:go_rename_tags
+      call go#util#EchoSuccess("rename tags is cleared")
+    else
+      let g:go_rename_tags = a:1
+      call go#util#EchoSuccess("rename tags changed to ". a:1)
+    endif
+
+    return
+  endif
+
+  if !exists('g:go_rename_tags')
+    call go#util#EchoSuccess("rename tags is not set")
+  else
+    call go#util#EchoSuccess("current rename tags: ". g:go_rename_tags)
+  endif
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -608,6 +608,16 @@ CTRL-t
     The custom build tags is cleared (unset) if `""` is given. If no arguments
     is given it prints the current custom build tags.
 
+                                                                 *:GoRenameTags*
+:GoRenameTags [tags]
+
+    Changes the custom |'g:go_rename_tags'| setting and overrides it with the
+    given build tags. This command cooperate with GoRename command when
+    there exist mulitiple build tags in your project, then you can set one of
+    the build tags for GoRename to find more accurate.
+    The custom build tags is cleared (unset) if `""` is given. If no arguments
+    is given it prints the current custom build tags.
+
                                                                      *:AsmFmt*
 :AsmFmt
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1216,6 +1216,13 @@ this. By default it's not set.
 >
   let g:go_guru_tags = ''
 <
+                                                        *'g:go_rename_tags'*
+
+These options that will be automatically passed to the `-tags` option of
+`gorename` when it's invoked with |:GoRename|. By default it's not set.
+>
+  let g:go_rename_tags = ''
+<
 
                                      *'g:go_highlight_array_whitespace_error'*
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -13,6 +13,7 @@ command! -range=% GoFreevars call go#guru#Freevars(<count>)
 command! -range=% GoChannelPeers call go#guru#ChannelPeers(<count>)
 command! -range=% GoReferrers call go#guru#Referrers(<count>)
 command! -nargs=? GoGuruTags call go#guru#Tags(<f-args>)
+command! -nargs=? GoRenameTags call go#rename#Tags(<f-args>)
 
 command! -range=0 GoSameIds call go#guru#SameIds()
 command! -range=0 GoSameIdsClear call go#guru#ClearSameIds()


### PR DESCRIPTION
Reopening issue #389, it seems like `gorename` supports `-tags` flag for a while now, still undocumented however.

See https://github.com/golang/tools/blob/master/cmd/gorename/main.go#L29 for reference.

This patch add support for this flag. I'm sure, I'm not the only one who misses this feature badly.