### PR TITLE
Add :GoBuildTags to set build tags

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -76,6 +76,28 @@ function! go#cmd#Build(bang, ...) abort
 endfunction
 
 
+" BuildTags sets or shows the current build tags used for tools
+function! go#cmd#BuildTags(bang, ...) abort
+  if a:0
+    if a:0 == 1 && a:1 == '""'
+      unlet g:go_build_tags
+      call go#util#EchoSuccess("build tags are cleared")
+    else
+      let g:go_build_tags = a:1
+      call go#util#EchoSuccess("build tags are changed to: ". a:1)
+    endif
+
+    return
+  endif
+
+  if !exists('g:go_build_tags')
+    call go#util#EchoSuccess("build tags are not set")
+  else
+    call go#util#EchoSuccess("current build tags: ". g:go_build_tags)
+  endif
+endfunction
+
+
 " Run runs the current file (and their dependencies if any) in a new terminal.
 function! go#cmd#RunTerm(bang, mode, files) abort
   if empty(a:files)

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -46,8 +46,8 @@ function! s:guru_cmd(args) range abort
   endif
 
   " check for any tags
-  if exists('g:go_guru_tags')
-    let tags = get(g:, 'go_guru_tags')
+  if exists('g:go_build_tags')
+    let tags = get(g:, 'go_build_tags')
     call extend(cmd, ["-tags", tags])
     let result.tags = tags
   endif
@@ -616,26 +616,6 @@ function! go#guru#Scope(...) abort
     call go#util#EchoError("guru scope is not set")
   else
     call go#util#EchoSuccess("current guru scope: ". join(g:go_guru_scope, ","))
-  endif
-endfunction
-
-function! go#guru#Tags(...) abort
-  if a:0
-    if a:0 == 1 && a:1 == '""'
-      unlet g:go_guru_tags
-      call go#util#EchoSuccess("guru tags is cleared")
-    else
-      let g:go_guru_tags = a:1
-      call go#util#EchoSuccess("guru tags changed to: ". a:1)
-    endif
-
-    return
-  endif
-
-  if !exists('g:go_guru_tags')
-    call go#util#EchoSuccess("guru tags is not set")
-  else
-    call go#util#EchoSuccess("current guru tags: ". g:go_guru_tags)
   endif
 endfunction
 

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -41,8 +41,9 @@ function! go#rename#Rename(bang, ...) abort
 
   let cmd = [bin_path, "-offset", offset, "-to", to_identifier]
 
-  if exists('g:go_rename_tags')
-    let tags = get(g:, 'go_rename_tags')
+  " check for any tags
+  if exists('g:go_build_tags')
+    let tags = get(g:, 'go_build_tags')
     call extend(cmd, ["-tags", tags])
   endif
 
@@ -146,26 +147,6 @@ function s:parse_errors(exit_val, bang, out)
   " we need a way to get the list of changes from gorename upon an success
   " change.
   silent execute ":e"
-endfunction
-
-function! go#rename#Tags(...) abort
-  if a:0
-    if a:0 == 1 && a:1 == '""'
-      unlet g:go_rename_tags
-      call go#util#EchoSuccess("rename tags is cleared")
-    else
-      let g:go_rename_tags = a:1
-      call go#util#EchoSuccess("rename tags changed to ". a:1)
-    endif
-
-    return
-  endif
-
-  if !exists('g:go_rename_tags')
-    call go#util#EchoSuccess("rename tags is not set")
-  else
-    call go#util#EchoSuccess("current rename tags: ". g:go_rename_tags)
-  endif
 endfunction
 
 " vim: sw=2 ts=2 et

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -598,25 +598,16 @@ CTRL-t
     use the variable |'g:go_metalinter_command'|. To override the maximum
     linters execution time use |'g:go_metalinter_deadline'| variable.
 
-                                                                 *:GoGuruTags*
-:GoGuruTags [tags]
+                                                                 *:GoBuildTags*
+:GoBuildTags [tags]
 
-    Changes the custom |'g:go_guru_tags'| setting and overrides it with the
-    given build tags. This command cooperate with GoReferrers command when
-    there exist mulitiple build tags in your project, then you can set one of
-    the build tags for GoReferrers to find more accurate.
-    The custom build tags is cleared (unset) if `""` is given. If no arguments
-    is given it prints the current custom build tags.
+    Changes the build tags for various commands. If you have any file that
+    uses a custom build tag, such as `//+build integration` , this command can
+    be used to pass it to all tools that accepts tags, such as guru, gorenate,
+    etc.. 
 
-                                                                 *:GoRenameTags*
-:GoRenameTags [tags]
-
-    Changes the custom |'g:go_rename_tags'| setting and overrides it with the
-    given build tags. This command cooperate with GoRename command when
-    there exist mulitiple build tags in your project, then you can set one of
-    the build tags for GoRename to find more accurate.
-    The custom build tags is cleared (unset) if `""` is given. If no arguments
-    is given it prints the current custom build tags.
+    The build tags is cleared (unset) if `""` is given. If no arguments is
+    given it prints the current custom build tags.
 
                                                                      *:AsmFmt*
 :AsmFmt
@@ -1218,22 +1209,15 @@ set, so the relevant commands defaults are being used.
 >
   let g:go_guru_scope = []
 <
-                                                        *'g:go_guru_tags'*
+                                                           *'g:go_build_tags'*
 
 These options that will be automatically passed to the `-tags` option of
-`go guru` when it's invoked with |:GoDef|. You can use |:GoGuruTags| to set
-this. By default it's not set.
+various tools, such as `guru`, `gorename`, etc... This is a permanatent
+setting. A more useful way is to use |:GoBuildTags| to dynamically change or
+remove build tags. By default it's not set.
 >
-  let g:go_guru_tags = ''
+  let g:go_build_tags = ''
 <
-                                                        *'g:go_rename_tags'*
-
-These options that will be automatically passed to the `-tags` option of
-`gorename` when it's invoked with |:GoRename|. By default it's not set.
->
-  let g:go_rename_tags = ''
-<
-
                                      *'g:go_highlight_array_whitespace_error'*
 
 Highlights white space after "[]". >

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -12,8 +12,6 @@ command! -range=% GoCallstack call go#guru#Callstack(<count>)
 command! -range=% GoFreevars call go#guru#Freevars(<count>)
 command! -range=% GoChannelPeers call go#guru#ChannelPeers(<count>)
 command! -range=% GoReferrers call go#guru#Referrers(<count>)
-command! -nargs=? GoGuruTags call go#guru#Tags(<f-args>)
-command! -nargs=? GoRenameTags call go#rename#Tags(<f-args>)
 
 command! -range=0 GoSameIds call go#guru#SameIds()
 command! -range=0 GoSameIdsClear call go#guru#ClearSameIds()
@@ -32,6 +30,7 @@ command! -nargs=0 GoAutoTypeInfoToggle call go#complete#ToggleAutoTypeInfo()
 
 " -- cmd
 command! -nargs=* -bang GoBuild call go#cmd#Build(<bang>0,<f-args>)
+command! -nargs=? -bang GoBuildTags call go#cmd#BuildTags(<bang>0, <f-args>)
 command! -nargs=* -bang GoGenerate call go#cmd#Generate(<bang>0,<f-args>)
 command! -nargs=* -bang -complete=file GoRun call go#cmd#Run(<bang>0,<f-args>)
 command! -nargs=* -bang GoInstall call go#cmd#Install(<bang>0, <f-args>)


### PR DESCRIPTION
Remove also :GoRenameTags and :GoGuruTags as this is a fundamental
feature. No need to duplicate it for each independent tool.