### PR TITLE
Updated Broken Link

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,6 +4,6 @@ Thanks for improving vim-go! Before you dive in please read the following:
    [FAQ](https://github.com/fatih/vim-go/wiki/FAQ-Troubleshooting), it might
    have answers for your problem
 2. If you add a new feature please don't forget to update the documentation:
-   [doc/vim-go.txt](doc/vim-go.txt)
+   [doc/vim-go.txt](https://github.com/fatih/vim-go/blob/master/doc/vim-go.txt)
 3. If it's a breaking change or exceed +100 lines please open an issue first
    and describe the changes you want to make.


### PR DESCRIPTION
Old link for `doc/vim-go.txt` would lead to the URL https://github.com/fatih/vim-go/blob/master/.github/doc/vim-go.txt