### PR TITLE
Allow trimming around comments in gotexttmpl syntax.

### DIFF
--- a/syntax/gotexttmpl.vim
+++ b/syntax/gotexttmpl.vim
@@ -74,8 +74,8 @@ hi def link     goTplVariable       Special
 
 syn region gotplAction start="{{" end="}}" contains=@gotplLiteral,gotplControl,gotplFunctions,gotplVariable,goTplIdentifier display
 syn region gotplAction start="\[\[" end="\]\]" contains=@gotplLiteral,gotplControl,gotplFunctions,gotplVariable display
-syn region goTplComment start="{{/\*" end="\*/}}" display
-syn region goTplComment start="\[\[/\*" end="\*/\]\]" display
+syn region goTplComment start="{{\(- \)\?/\*" end="\*/\( -\)\?}}" display
+syn region goTplComment start="\[\[\(- \)\?/\*" end="\*/\( -\)\?\]\]" display
 
 hi def link gotplAction PreProc
 hi def link goTplComment Comment


### PR DESCRIPTION
In `text/template` starting from Go 1.6, whitespace around actions can be trimmed with "- " and " -" to result in cleaner output (https://golang.org/pkg/text/template/#hdr-Text_and_spaces). Update `syntax/gotexttmpl.vim` to allow using this construction around comments.