### PR TITLE
Add support for quicktemplate syntax to gohtmltmpl filetype

### DIFF
--- a/ftdetect/gofiletype.vim
+++ b/ftdetect/gofiletype.vim
@@ -27,5 +27,6 @@ au BufRead *.s call s:gofiletype_pre("asm")
 au BufReadPost *.s call s:gofiletype_post()
 
 au BufRead,BufNewFile *.tmpl set filetype=gohtmltmpl
+au BufRead,BufNewFile *.qtpl set filetype=gohtmltmpl
 
 " vim: sw=2 ts=2 et

--- a/syntax/gotexttmpl.vim
+++ b/syntax/gotexttmpl.vim
@@ -63,7 +63,7 @@ hi def link     goImaginary  Number
 
 " Token groups
 syn cluster     gotplLiteral     contains=goString,goRawString,goCharacter,@goInt,goFloat,goImaginary
-syn keyword     gotplControl     contained   if else end range with template
+syn keyword     gotplControl     contained   if else end range with template code space elseif endif endfor endfunc comment endcomment plain endplain stripspace endstripspace collapsespace endcollapsespace endswitch import func type struct return
 syn keyword     gotplFunctions   contained   and html index js len not or print printf println urlquery eq ne lt le gt ge
 syn match       gotplVariable    contained   /\$[a-zA-Z0-9_]*\>/
 syn match       goTplIdentifier  contained   /\.[^\s}]+\>/
@@ -73,8 +73,10 @@ hi def link     gotplFunctions      Function
 hi def link     goTplVariable       Special
 
 syn region gotplAction start="{{" end="}}" contains=@gotplLiteral,gotplControl,gotplFunctions,gotplVariable,goTplIdentifier display
+syn region gotplAction start="{%" end="%}" contains=@gotplLiteral,gotplControl,gotplFunctions,gotplVariable,goTplIdentifier display
 syn region gotplAction start="\[\[" end="\]\]" contains=@gotplLiteral,gotplControl,gotplFunctions,gotplVariable display
 syn region goTplComment start="{{/\*" end="\*/}}" display
+syn region goTplComment start="{%/\*" end="\*/%}" display
 syn region goTplComment start="\[\[/\*" end="\*/\]\]" display
 
 hi def link gotplAction PreProc


### PR DESCRIPTION
This is a fairly popular template package. It would be great to
support this. This causes no conflicts that I can see and is a very
simple addition. For more details see: [quicktemplate](https://github.com/valyala/quicktemplate)