### PR TITLE
Include keyify support

### DIFF
--- a/autoload/go/keyify.vim
+++ b/autoload/go/keyify.vim
@@ -16,7 +16,7 @@ function! go#keyify#Keyify()
 
   " We want to output the error message in case the result isn't a JSON
   if type(result) != type({})
-    echoerr s:chomp(output)
+    call go#util#EchoError(s:chomp(output))
     let $GOPATH = old_gopath
     return
   endif

--- a/autoload/go/keyify.vim
+++ b/autoload/go/keyify.vim
@@ -34,7 +34,16 @@ function! go#keyify#Keyify()
   " Replace contents between start and end with `replacement`
   call setpos("'<", start)
   call setpos("'>", end)
-  silent! execute "normal! gv\"=result.replacement\<cr>p"
+
+  let select = 'gv'
+
+  " Make sure the visual mode is 'v', to avoid some bugs
+  normal! gv
+  if mode() !=# 'v'
+    let select .= 'v'
+  endif
+
+  silent! execute "normal!" select."\"=result.replacement\<cr>p"
 
   " Replacement text isn't aligned, so it needs fix
   normal! '<v'>=

--- a/autoload/go/keyify.vim
+++ b/autoload/go/keyify.vim
@@ -14,8 +14,9 @@ function! go#keyify#Keyify()
   let output = go#util#System(command)
   silent! let result = json_decode(output)
 
-  " We don't want to do anything if output of the command was an error
+  " We want to output the error message in case the result isn't a JSON
   if type(result) != type({})
+    echoerr s:chomp(output)
     let $GOPATH = old_gopath
     return
   endif
@@ -41,4 +42,8 @@ function! go#keyify#Keyify()
   call setpos("'<", vis_start)
   call setpos("'>", vis_end)
   let $GOPATH = old_gopath
+endfunction
+
+function! s:chomp(string)
+    return substitute(a:string, '\n\+$', '', '')
 endfunction

--- a/autoload/go/keyify.vim
+++ b/autoload/go/keyify.vim
@@ -1,0 +1,44 @@
+function! go#keyify#Keyify()
+  let old_gopath = $GOPATH
+  let $GOPATH = go#path#Detect()
+  let bin_path = go#path#CheckBinPath("keyify")
+  let fname = fnamemodify(expand("%"), ':p:gs?\\?/?')
+
+  if empty(bin_path) || !exists('*json_decode')
+    let $GOPATH = old_gopath
+    return
+  endif
+
+  " Get result of command as json, that contains `start`, `end` and `replacement`
+  let command = printf("%s -json %s:#%s", bin_path, fname, go#util#OffsetCursor())
+  let output = go#util#System(command)
+  silent! let result = json_decode(output)
+
+  " We don't want to do anything if output of the command was an error
+  if type(result) != type({})
+    let $GOPATH = old_gopath
+    return
+  endif
+
+  " Because keyify returns the byte before the region we want, we goto the
+  " byte after that
+  execute "goto" result.start + 1
+  let start = getpos('.')
+  execute "goto" result.end
+  let end = getpos('.')
+
+  let vis_start = getpos("'<")
+  let vis_end = getpos("'>")
+
+  " Replace contents between start and end with `replacement`
+  call setpos("'<", start)
+  call setpos("'>", end)
+  silent! execute "normal! gv\"=result.replacement\<cr>p"
+
+  " Replacement text isn't aligned, so it needs fix
+  normal! '<v'>=
+
+  call setpos("'<", vis_start)
+  call setpos("'>", vis_end)
+  let $GOPATH = old_gopath
+endfunction

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -742,7 +742,22 @@ CTRL-t
 
     Toggles |'g:go_template_autocreate'|.
 
+                                                               *:GoKeyify*
+:GoKeyify
 
+    Uses `keyify` to turn unkeyed struct literals into keyed ones.
+
+    For example:
+>
+      Person{"John", "Smith"}
+<
+    Becomes:
+>
+      Person{
+        Name: "John",
+        Surname: "Smith",
+      }
+<
 ==============================================================================
 MAPPINGS                                                        *go-mappings*
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -92,4 +92,7 @@ command! -nargs=* -buffer -complete=customlist,go#impl#Complete GoImpl call go#i
 " -- template
 command! -nargs=0 GoTemplateAutoCreateToggle call go#template#ToggleAutoCreate()
 
+" -- keyify
+command! -nargs=0 GoKeyify call go#keyify#Keyify()
+
 " vim: sw=2 ts=2 et

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -21,6 +21,7 @@ let s:packages = [
       \ "github.com/fatih/gomodifytags",
       \ "github.com/zmb3/gogetdoc",
       \ "github.com/josharian/impl",
+      \ "github.com/dominikh/go-tools/tree/master/cmd/keyify",
       \ ]
 
 " These commands are available on any filetypes

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -21,7 +21,7 @@ let s:packages = [
       \ "github.com/fatih/gomodifytags",
       \ "github.com/zmb3/gogetdoc",
       \ "github.com/josharian/impl",
-      \ "github.com/dominikh/go-tools/tree/master/cmd/keyify",
+      \ "github.com/dominikh/go-tools/cmd/keyify",
       \ ]
 
 " These commands are available on any filetypes


### PR DESCRIPTION
Includes support for https://github.com/dominikh/go-tools/tree/master/cmd/keyify
through the `GoKeyify` command.

It turns unkeyed struct literals into keyed struct literals.