### PR TITLE
Include if with inline error handling

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -143,6 +143,13 @@ else {
 }
 endsnippet
 
+# if inline error
+snippet ife "If with inline erro"
+if err := ${1:condition}; err != nil {
+	${0:${VISUAL}}
+}
+endsnippet
+
 # error snippet
 snippet errn "Error return " !b
 if err != nil {

--- a/gosnippets/snippets/go.snip
+++ b/gosnippets/snippets/go.snip
@@ -118,6 +118,14 @@ snippet else
 	else {
 		${0}
 	}
+
+# if inline error
+snippet ife
+abbr if err := ...; err != nil { ... } 
+if err := ${1:condition}; err != nil {
+	${0}
+}
+
 # error snippet
 snippet errn
 abbr if err != nil { ... }


### PR DESCRIPTION
This pattern is widely enough used to be a snippet i believe.
Examples from one golang.org example.
 ```
// ...
	if err := cmd.Start(); err != nil {
		log.Fatal(err)
	}
// ...
	if err := json.NewDecoder(stdout).Decode(&person); err != nil {
		log.Fatal(err)
	}
	if err := cmd.Wait(); err != nil {
		log.Fatal(err)
	}
 ```