### PR TITLE
Add :GoAddTags transform

### DIFF
--- a/autoload/go/tags.vim
+++ b/autoload/go/tags.vim
@@ -122,11 +122,13 @@ func s:create_cmd(args) abort
   let l:offset = a:args.offset
   let l:mode = a:args.mode
   let l:cmd_args = a:args.cmd_args
+  let l:modifytags_transform = get(g:, 'go_modifytags_transform', "snakecase")
 
   " start constructing the command
   let cmd = [bin_path]
   call extend(cmd, ["-format", "json"])
   call extend(cmd, ["-file", a:args.fname])
+  call extend(cmd, ["-transform", l:modifytags_transform])
 
   if l:offset != 0
     call extend(cmd, ["-offset", l:offset])

--- a/autoload/go/tags.vim
+++ b/autoload/go/tags.vim
@@ -122,7 +122,7 @@ func s:create_cmd(args) abort
   let l:offset = a:args.offset
   let l:mode = a:args.mode
   let l:cmd_args = a:args.cmd_args
-  let l:modifytags_transform = get(g:, 'go_modifytags_transform', "snakecase")
+  let l:modifytags_transform = get(g:, 'go_addtags_transform', "snakecase")
 
   " start constructing the command
   let cmd = [bin_path]

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -102,7 +102,7 @@ command.
 
     Plugin 'fatih/vim-go'
 
-*  Vim |packages| 
+*  Vim |packages|
 >
     git clone https://github.com/fatih/vim-go.git \
       ~/.vim/pack/plugins/start/vim-go
@@ -219,7 +219,7 @@ COMMANDS                                                         *go-commands*
     If [!] is not given the first error is jumped to.
 
                                                                       *:GoDef*
-:GoDef 
+:GoDef
 gd
 CTRL-]
 
@@ -605,7 +605,7 @@ CTRL-t
     Changes the build tags for various commands. If you have any file that
     uses a custom build tag, such as `//+build integration` , this command can
     be used to pass it to all tools that accepts tags, such as guru, gorenate,
-    etc.. 
+    etc..
 
     The build tags is cleared (unset) if `""` is given. If no arguments is
     given it prints the current custom build tags.
@@ -1538,6 +1538,16 @@ default it's 60 seconds. Must be in milliseconds.
 >
       let g:go_statusline_duration = 60000
 <
+
+                                                   *'g:go_modifytags_transform'*
+
+Sets the `transform` option for `gomodifytags` when using |:GoAddTags|.
+Possible options are: `snakecase`, `camelcase`. By default it is set to
+`snakecase`.
+>
+      let g:go_modifytags_transform = 'snakecase'
+<
+
 ==============================================================================
 DEVELOPMENT                                               *go-development*
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1539,13 +1539,13 @@ default it's 60 seconds. Must be in milliseconds.
       let g:go_statusline_duration = 60000
 <
 
-                                                   *'g:go_modifytags_transform'*
+                                                   *'g:go_addtags_transform'*
 
 Sets the `transform` option for `gomodifytags` when using |:GoAddTags|.
 Possible options are: `snakecase`, `camelcase`. By default it is set to
 `snakecase`.
 >
-      let g:go_modifytags_transform = 'snakecase'
+      let g:go_addtags_transform = 'snakecase'
 <
 
 ==============================================================================


### PR DESCRIPTION
Hey guys, I added a global option to set `gomodifytags`' transform (I like `camelCase` over `snake_case`).

The variable name is `g:go_modifytags_transform` (defaults to `snakecase`, possible values are `camelcase` and `snakecase`)

This is my first time doing Vim script, so if I did something really wrong, please correct me 😄 (Well... It's two lines so what could be wrong)