### PR TITLE
Load buffers with :GoDef relative to cwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ IMPROVEMENTS:
 * Add package-level comment folding [gh-1377]
 * Allow using :GoImpl on the type and struct parts too. Makes it a wee bit
   easier to use [gh-1386]
+* `:GoDef` sets the path of new buffers as relative to the current directory
+  when appropriate, instead of always using the full path [gh-1277].
 
 BUG FIXES:
 

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -168,7 +168,7 @@ function! go#def#jump_to_declaration(out, mode, bin_name) abort
       endif
 
       " open the file and jump to line and column
-      exec cmd fnameescape(filename)
+      exec cmd fnameescape(fnamemodify(filename, ':.'))
     endif
   endif
   call cursor(line, col)


### PR DESCRIPTION
If I use `gd` on an identifier the filename for the new buffer is set to:

    ~/work/src/github.com/teamwork/desk/server/server.go

Instead of:

    server/server.go

This makes it open the relative directory, making it behave as `:e
server/server.go`.

I *think* this change should be safe and will work for everyone? I'm not 100% of
that, though. Perhaps we should add a setting?