### PR TITLE
Fixed indent for 'ife' snippet

### DIFF
--- a/gosnippets/snippets/go.snip
+++ b/gosnippets/snippets/go.snip
@@ -121,10 +121,10 @@ snippet else
 
 # if inline error
 snippet ife
-abbr if err := ...; err != nil { ... } 
-if err := ${1:condition}; err != nil {
-	${0}
-}
+abbr if err := ...; err != nil { ... }
+	if err := ${1:condition}; err != nil {
+		${0}
+	}
 
 # error snippet
 snippet errn


### PR DESCRIPTION
Fixed neosnippet errors when loading a go file due to missing indentation.