### PR TITLE
Change GoLint command to lint the current directory

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -123,12 +123,11 @@ function! go#lint#Golint(...) abort
   endif
 
   if a:0 == 0
-    let goargs = shellescape(expand('%'))
+    let out = go#util#System(bin_path)
   else
-    let goargs = go#util#Shelljoin(a:000)
+    let out = go#util#System(bin_path . " " . go#util#Shelljoin(a:000))
   endif
 
-  let out = go#util#System(bin_path . " " . goargs)
   if empty(out)
     echon "vim-go: " | echohl Function | echon "[lint] PASS" | echohl None
     return

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -167,7 +167,7 @@ COMMANDS                                                         *go-commands*
                                                                      *:GoLint*
 :GoLint [packages]
 
-    Run golint for the current Go file, or for given packages.
+    Run golint for the current directory, or for given packages.
 
                                                                       *:GoDoc*
 :GoDoc [word]


### PR DESCRIPTION
With no arguments passed to GoLint, the golint command will be executed on the current directory.

#1263 