### PR TITLE
Specifies the type of list to use in GoMetaLinter, by go_list_type

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -251,12 +251,17 @@ function s:lint_job(args)
   function! s:callback(chan, msg) closure
     let old_errorformat = &errorformat
     let &errorformat = l:errformat
-    caddexpr a:msg
+    if l:listtype == "locationlist"
+      lad a:msg
+    elseif l:listtype == "quickfix"
+      caddexpr a:msg
+    endif
     let &errorformat = old_errorformat
 
     " TODO(arslan): cursor still jumps to first error even If I don't want
     " it. Seems like there is a regression somewhere, but not sure where.
-    copen
+    let errors = go#list#Get(l:listtype)
+    call go#list#Window(l:listtype, len(errors))
   endfunction
 
   function! s:exit_cb(job, exitval) closure


### PR DESCRIPTION
For async mode, GoMetaLinter will use quickfix as default type of list and it can't be configured.