### PR TITLE
Fix Issue #1283 Resolve highlighting error by surrounding expression in \(\)

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -324,7 +324,7 @@ if g:go_highlight_types != 0
   syn match goTypeConstructor      /\<\w\+{/he=e-1
   syn match goTypeDecl             /\<type\>/ nextgroup=goTypeName skipwhite skipnl
   syn match goTypeName             /\w\+/ contained nextgroup=goDeclType skipwhite skipnl
-  syn match goDeclType             /\<interface\|struct\>/ skipwhite skipnl
+  syn match goDeclType             /\<\(interface\|struct\)\>/ skipwhite skipnl
   hi def link     goReceiverType      Type
 else
   syn keyword goDeclType           struct interface


### PR DESCRIPTION
/\<interface\|struct\>/  would highlight **interface** or **struct** when **interface** was at the beginning of the word or **struct** at the end. By putting this in parenthesis, the word boundary checks correctly. 