### PR TITLE
fmt: change go_fmt_options's type to dict

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -9,16 +9,12 @@ if !exists("g:go_fmt_command")
   let g:go_fmt_command = "gofmt"
 endif
 
-if !exists("g:go_goimports_bin")
-  let g:go_goimports_bin = "goimports"
+if !exists('g:go_fmt_options')
+  let g:go_fmt_options = ''
 endif
 
 if !exists('g:go_fmt_fail_silently')
   let g:go_fmt_fail_silently = 0
-endif
-
-if !exists('g:go_fmt_options')
-  let g:go_fmt_options = ''
 endif
 
 if !exists("g:go_fmt_experimental")
@@ -70,7 +66,7 @@ function! go#fmt#Format(withGoimport) abort
 
   let bin_name = g:go_fmt_command
   if a:withGoimport == 1
-    let bin_name = g:go_goimports_bin
+    let bin_name = "goimports"
   endif
 
   let out = go#fmt#run(bin_name, l:tmpname, expand('%'))
@@ -172,7 +168,15 @@ function! s:fmt_cmd(bin_name, source, target)
   " start constructing the command
   let cmd = [bin_path]
   call add(cmd, "-w")
-  call extend(cmd, split(g:go_fmt_options, " "))
+    
+  " add the options for binary (if any). go_fmt_options was by default of type
+  " string, however to allow customization it's now a dictionary of binary
+  " name mapping to options.
+  let opts = g:go_fmt_options
+  if type(g:go_fmt_options) == type({})
+    let opts = has_key(g:go_fmt_options, a:bin_name) ? g:go_fmt_options[a:bin_name] : ""
+  endif
+  call extend(cmd, split(opts, " "))
 
   if a:bin_name == "goimports"
     " lazy check if goimports support `-srcdir`. We should eventually remove

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1107,10 +1107,23 @@ used >
 <
                                                           *'g:go_fmt_options'*
 
-Use this option to add additional options to the |'g:go_fmt_command'|. Default
-is empty. >
-
+Use this option to add additional options to the |'g:go_fmt_command'|. It's
+value type can be either a string or a dictionary. This is due backwards
+compatibility. The string version will be removed in the future so please use
+the dictionary version. Default is empty. 
+>
   let g:go_fmt_options = ''
+
+  or 
+
+  let g:go_fmt_options = {}
+<
+The dictionary version allows you to define options for multiple binaries:
+>
+  let g:go_fmt_options = {
+    \ 'gofmt': '-s',
+    \ 'goimports': '-local mycompany.com',
+    \ }
 <
                                                     *'g:go_fmt_fail_silently'*
 


### PR DESCRIPTION
* add the ability to specificy binary specific options
* remove `go_imports_bin` settings as it's subject to confusion

Thanks to @cespare for the idea and @hori-ryota for initial code snippet

Fixes #1212