### PR TITLE
test.vim: refactor to use its own parse function

### DIFF
--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -68,7 +68,7 @@ function! go#list#PopulateWin(winnr, items) abort
   call setloclist(a:winnr, a:items, 'r')
 endfunction
 
-" Parse parses the given items based on the specified errorformat nad
+" Parse parses the given items based on the specified errorformat and
 " populates the location list.
 function! go#list#ParseFormat(listtype, errformat, items, title) abort
   let l:listtype = go#list#Type(a:listtype)

--- a/autoload/go/statusline.vim
+++ b/autoload/go/statusline.vim
@@ -53,9 +53,9 @@ function! go#statusline#Show() abort
 
   " only update highlight if status has changed.
   if status_text != s:last_status
-    if status.state =~ "success" || status.state =~ "finished"
+    if status.state =~ "success" || status.state =~ "finished" || status.state =~ "pass"
       hi goStatusLineColor cterm=bold ctermbg=76 ctermfg=22
-    elseif status.state =~ "started" || status.state =~ "analysing"
+    elseif status.state =~ "started" || status.state =~ "analysing" || status.state =~ "compiling"
       hi goStatusLineColor cterm=bold ctermbg=208 ctermfg=88
     elseif status.state =~ "failed"
       hi goStatusLineColor cterm=bold ctermbg=196 ctermfg=52


### PR DESCRIPTION
This is an improvement to alter the parse function of go test specific commands. Currently the regex is still the same, but it enables us to replace it without affecting any other command.