### PR TITLE
Use a different template for test files

### DIFF
--- a/autoload/go/template.vim
+++ b/autoload/go/template.vim
@@ -14,21 +14,24 @@ function! go#template#create() abort
   " files) from the directory create the template or use the cwd
   " as the name
   if l:package_name == -1 && l:go_template_use_pkg != 1
-    let l:template_file = get(g:, 'go_template_file', "hello_world.go")
+    let l:filename = fnamemodify(expand("%"), ':t')
+    if l:filename =~ "_test.go$"
+      let l:template_file = get(g:, 'go_template_test_file', "hello_world_test.go")
+    else
+      let l:template_file = get(g:, 'go_template_file', "hello_world.go")
+    endif
     let l:template_path = go#util#Join(l:root_dir, "templates", l:template_file)
     exe '0r ' . fnameescape(l:template_path)
-    $delete _
   elseif l:package_name == -1 && l:go_template_use_pkg == 1
     " cwd is now the dir of the package
     let l:path = fnamemodify(getcwd(), ':t')
     let l:content = printf("package %s", l:path)
     call append(0, l:content)
-    $delete _
   else
     let l:content = printf("package %s", l:package_name)
     call append(0, l:content)
-    $delete _
   endif
+  $delete _
 
   " Remove the '... [New File]' message line from the command line
   echon

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1485,9 +1485,9 @@ Specifies whether `gocode` should use a different socket type. By default
                                                   *'g:go_template_autocreate'*
 
 When a new Go file is created, vim-go automatically fills the buffer content
-with a Go code template. By default the template under
-`templates/hello_world.go` is used. This can be changed with the
-|'g:go_template_file'| setting.
+with a Go code template. By default, the templates under the `templates`
+folder are used.  This can be changed with the |'g:go_template_file'| and
+|'g:go_template_test_file'| settings.
 
 If the new file is created in an already prepopulated package (with other Go
 files), in this case a Go code template with only the Go package declaration
@@ -1507,6 +1507,14 @@ is created. Checkout |'g:go_template_autocreate'| for more info. By default
 the `hello_world.go` file is used.
 >
   let g:go_template_file = "hello_world.go"
+<
+                                                        *'g:go_template_test_file'*
+
+Specifies the file under the `templates` folder that is used if a new Go test
+file is created. Checkout |'g:go_template_autocreate'| for more info. By
+default the `hello_world_test.go` file is used.
+>
+  let g:go_template_test_file = "hello_world_test.go"
 <
                                                      *'g:go_template_use_pkg'*
 

--- a/templates/hello_world_test.go
+++ b/templates/hello_world_test.go
@@ -1,0 +1,7 @@
+package main
+
+import "testing"
+
+func TestHelloWorld(t *testing.T) {
+	// t.Fatal("not implemented")
+}


### PR DESCRIPTION
Use a template more appropriate for test files than templates/hello_world.go
when creating a test file in a directory with no Go files present. A new
option, g:go_template_test_file, allows users to specify their own template to
use.

Fixes #1216 