### PR TITLE
def: fix passing build tags to guru

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -46,8 +46,8 @@ function! go#def#Jump(mode) abort
       call add(cmd, "-modified")
     endif
 
-    if exists('g:go_guru_tags')
-      let tags = get(g:, 'go_guru_tags')
+    if exists('g:go_build_tags')
+      let tags = get(g:, 'go_build_tags')
       call extend(cmd, ["-tags", tags])
     endif
 


### PR DESCRIPTION
It was using a deprecated flag.

Fixes #1312