### PR TITLE
Improve caching for go env calls

### DIFF
--- a/autoload/go/impl.vim
+++ b/autoload/go/impl.vim
@@ -71,12 +71,12 @@ endif
 
 function! s:root_dirs() abort
   let dirs = []
-  let root = go#util#goroot()
+  let root = go#util#env("goroot")
   if root !=# '' && isdirectory(root)
     call add(dirs, root)
   endif
 
-  let paths = map(split(go#util#gopath(), go#util#PathListSep()), "substitute(v:val, '\\\\', '/', 'g')")
+  let paths = map(split(go#util#env("gopath"), go#util#PathListSep()), "substitute(v:val, '\\\\', '/', 'g')")
   if go#util#ShellError()
     return []
   endif

--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -33,7 +33,7 @@ function! go#package#Paths() abort
 
   if !exists("s:goroot")
     if executable('go')
-      let s:goroot = go#util#goroot()
+      let s:goroot = go#util#env("goroot")
       if go#util#ShellError() != 0
         echomsg '''go env GOROOT'' failed'
       endif

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -39,7 +39,7 @@ endfunction
 function! go#path#Default() abort
   if $GOPATH == ""
     " use default GOPATH via go env
-    return go#util#gopath()
+    return go#util#env("gopath")
   endif
 
   return $GOPATH

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -74,24 +74,32 @@ function! go#util#env(key) abort
   return l:var
 endfunction
 
+" goarch returns 'go env GOARCH'. This is an internal function and shouldn't
+" be used. Instead use 'go#util#env("goarch")'
 function! go#util#goarch() abort
   return substitute(go#util#System('go env GOARCH'), '\n', '', 'g')
 endfunction
 
+" goos returns 'go env GOOS'. This is an internal function and shouldn't
+" be used. Instead use 'go#util#env("goos")'
 function! go#util#goos() abort
   return substitute(go#util#System('go env GOOS'), '\n', '', 'g')
 endfunction
 
+" goroot returns 'go env GOROOT'. This is an internal function and shouldn't
+" be used. Instead use 'go#util#env("goroot")'
 function! go#util#goroot() abort
   return substitute(go#util#System('go env GOROOT'), '\n', '', 'g')
 endfunction
 
+" gopath returns 'go env GOPATH'. This is an internal function and shouldn't
+" be used. Instead use 'go#util#env("gopath")'
 function! go#util#gopath() abort
   return substitute(go#util#System('go env GOPATH'), '\n', '', 'g')
 endfunction
 
 function! go#util#osarch() abort
-  return go#util#goos() . '_' . go#util#goarch()
+  return go#util#env("goos") . '_' . go#util#env("goarch")
 endfunction
 
 " System runs a shell command. If possible, it will temporary set 


### PR DESCRIPTION
This improves vim-go by caching some of the most used commands and call paths.