### PR TITLE
GoImpl: support relative (vendor) imports

### DIFF
--- a/autoload/go/impl.vim
+++ b/autoload/go/impl.vim
@@ -40,7 +40,8 @@ function! go#impl#Impl(...) abort
   endif
 
   try
-    let result = go#util#System(join(go#util#Shelllist([binpath, recv, iface], ' ')))
+    let dirname = fnameescape(expand('%:p:h'))
+    let result = go#util#System(join(go#util#Shelllist([binpath, '-dir', dirname, recv, iface], ' ')))
     let result = substitute(result, "\n*$", "", "")
     if go#util#ShellError() != 0
       call go#util#EchoError(result)


### PR DESCRIPTION
This fixes `:GoImpl` for cases when the interface package is in `vendor` or similar.  It depends on josharian/impl#18, which adds the `-dir` argument (`-dir` defaults to `$PWD` so hopefully the fallback won't be used much).
