### PR TITLE
Fix syntastic help

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1657,7 +1657,8 @@ How do I use vim-go with syntastic?~
 Sometimes when using both `vim-go` and `syntastic` Vim will start lagging
 while saving and opening files. The following fixes this:
 >
- let g:syntastic_go_checkers = ['golint', 'govet', 'errcheck']
+ let g:syntastic_go_checkers = ['golint', 'govet', 'gometalinter']
+ let g:syntastic_go_gometalinter_args = ['--disable-all', '--enable=errcheck']
  let g:syntastic_mode_map = { 'mode': 'active', 'passive_filetypes': ['go'] }
 <
 Another issue with `vim-go` and `syntastic` is that the location list window

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1657,6 +1657,11 @@ How do I use vim-go with syntastic?~
 Sometimes when using both `vim-go` and `syntastic` Vim will start lagging
 while saving and opening files. The following fixes this:
 >
+ let g:syntastic_go_checkers = ['golint', 'govet']
+ let g:syntastic_mode_map = { 'mode': 'active', 'passive_filetypes': ['go'] }
+<
+If you want to add errcheck you can use gometalinter as a wrapper
+>
  let g:syntastic_go_checkers = ['golint', 'govet', 'gometalinter']
  let g:syntastic_go_gometalinter_args = ['--disable-all', '--enable=errcheck']
  let g:syntastic_mode_map = { 'mode': 'active', 'passive_filetypes': ['go'] }


### PR DESCRIPTION
`syntastic` can not use `errcheck` as a checker.

Sample vimrc:

```vim
let g:syntastic_go_checkers = ['golint', 'govet', 'errcheck']
```

Run `:SyntasticInfo`

```
Syntastic version: 3.8.0-56 (Vim 800, Darwin)
Info for filetype: go
...
Available checkers: go gofmt golint gometalinter govet
Currently enabled checkers: golint govet
```

When using `errcheck` with `syntastic`, you need to use `gometalinter` and specify `errcheck` as an option.