### PR TITLE
coverage.vim: pass along arguments to coverage_job

### DIFF
--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -46,7 +46,7 @@ function! go#coverage#Buffer(bang, ...) abort
 
   if go#util#has_job()
     call s:coverage_job({
-          \ 'cmd': ['go', 'test', '-coverprofile', l:tmpname],
+          \ 'cmd': ['go', 'test', '-coverprofile', l:tmpname] + a:000,
           \ 'custom_cb': function('s:coverage_callback', [l:tmpname]),
           \ 'bang': a:bang,
           \ })


### PR DESCRIPTION
This allows things like ```:GoCoverage -run TestSpecific``` which allows you to see the exact coverage for a test/subtest.

It looks like this was the intent but may have been missed in https://github.com/fatih/vim-go/commit/dc8073386754bf5ca09a8dbe2bd9cc8886c61446