### PR TITLE
Match zero-width in goTypeConstructor

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -321,7 +321,7 @@ hi def link    goField              Identifier
 
 " Structs & Interfaces;
 if g:go_highlight_types != 0
-  syn match goTypeConstructor      /\<\w\+{/he=e-1
+  syn match goTypeConstructor      /\<\w\+{\@=/he=e-1 
   syn match goTypeDecl             /\<type\>/ nextgroup=goTypeName skipwhite skipnl
   syn match goTypeName             /\w\+/ contained nextgroup=goDeclType skipwhite skipnl
   syn match goDeclType             /\<\(interface\|struct\)\>/ skipwhite skipnl


### PR DESCRIPTION
The `{` here interferes with the folding in:

	syn region      goBlock             start="{" end="}" transparent fold

I'm not sure if this is the best way to fix it; but it seems to work well as far
as I can see. I also tried mucking about with `contained` and such, but wasn't
able to get that to work.

Fixes #1282