### PR TITLE
Fold import, var, and const blocks

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1606,6 +1606,10 @@ Enable folding of only imports:
 >
   let g:go_fold_enable = ['import']
 <
+Disable everything (same as not setting 'foldmethod' to `syntax`):
+>
+  let g:go_fold_enable = []
+<
 
 ==============================================================================
 DEVELOPMENT                                               *go-development*

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -690,8 +690,8 @@ CTRL-t
       :GoAddTags xml db
 <
     If [option] is passed it'll either add a new tag with an option or will
-    modify existing tags. An example of adding `omitempty` to all `json` fields
-    would be:
+    modify existing tags. An example of adding `omitempty` to all `json`
+    fields would be:
 >
       :GoAddTags json,omitempty
 <
@@ -1565,7 +1565,6 @@ default it's 60 seconds. Must be in milliseconds.
 >
       let g:go_statusline_duration = 60000
 <
-
                                                    *'g:go_addtags_transform'*
 
 Sets the `transform` option for `gomodifytags` when using |:GoAddTags| or if
@@ -1588,6 +1587,23 @@ By default "snakecase" is used. Current values are: ["snakecase",
 "camelcase"].
 >
       let g:go_addtags_transform = 'snakecase'
+<
+                                                        *'g:go_fold_enable'*
+
+Control syntax-based folding. If it's 1 all syntax-based folds are enabled.
+You can enable specific fold regions by setting an array. Possible values are:
+
+- "block"       `{` .. `}` blocks.
+- "import"      `import` block.
+- "varconst"    `var` and `const` blocks.
+
+By default it's 1.
+>
+  let g:go_fold = 1
+<
+Enable folding of only imports:
+>
+  let g:go_fold = ['import']
 <
 
 ==============================================================================

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1590,20 +1590,21 @@ By default "snakecase" is used. Current values are: ["snakecase",
 <
                                                         *'g:go_fold_enable'*
 
-Control syntax-based folding. If it's 1 all syntax-based folds are enabled.
+Control syntax-based folding which takes effect when 'foldmethod' is set to
+`syntax`.
 You can enable specific fold regions by setting an array. Possible values are:
 
 - "block"       `{` .. `}` blocks.
 - "import"      `import` block.
 - "varconst"    `var` and `const` blocks.
 
-By default it's 1.
+By default they're all enabled:
 >
-  let g:go_fold = 1
+  let g:go_fold_enable = ['block', 'import', 'varconst']
 <
 Enable folding of only imports:
 >
-  let g:go_fold = ['import']
+  let g:go_fold_enable = ['import']
 <
 
 ==============================================================================

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -92,7 +92,7 @@ endif
 let s:fold_block = 1
 let s:fold_import = 1
 let s:fold_varconst = 1
-if exists("g:go_fold_enable") && type(g:go_fold_enable) == type([])
+if exists("g:go_fold_enable")
   if index(g:go_fold_enable, 'block') == -1
     let s:fold_block = 0
   endif
@@ -108,11 +108,13 @@ syn case match
 
 syn keyword     goPackage           package
 syn keyword     goImport            import    contained
-syn keyword     goVarConst          var const contained
+syn keyword     goVar               var       contained
+syn keyword     goConst             const     contained
 
 hi def link     goPackage           Statement
 hi def link     goImport            Statement
-hi def link     goVarConst          Keyword
+hi def link     goVar               Keyword
+hi def link     goConst             Keyword
 hi def link     goDeclaration       Keyword
 
 " Keywords within functions
@@ -223,15 +225,15 @@ endif
 
 " var, const
 if s:fold_varconst
-  syn region    goVarConst          start='\(var\|const\) (' end=')' transparent fold contains=ALLBUT,goParen,goBlock
+  syn region    goVar               start='var (' end=')' transparent fold contains=ALLBUT,goParen,goBlock
+  syn region    goConst             start='const (' end=')' transparent fold contains=ALLBUT,goParen,goBlock
 else
-  syn region    goVarConst          start='\(var\|const\) (' end=')' transparent contains=ALLBUT,goParen,goBlock
+  syn region    goVar               start='var (' end=')' transparent contains=ALLBUT,goParen,goBlock
+  syn region    goConst             start='const (' end=')' transparent contains=ALLBUT,goParen,goBlock
 endif
 
 " Single-line var, const, and import.
-syn match       goSingleImport      /\(import\|var\|const\) [^(]\@=/ contains=goImport,goVarConst
-
-"syn region goImport start='var ' end=''contains=goVarConst
+syn match       goSingleDecl        /\(import\|var\|const\) [^(]\@=/ contains=goImport,goVar,goConst
 
 " Integers
 syn match       goDecimalInt        "\<-\=\d\+\%([Ee][-+]\=\d\+\)\=\>"

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -89,12 +89,30 @@ if !exists("g:go_highlight_generate_tags")
   let g:go_highlight_generate_tags = 0
 endif
 
+let s:fold_block = 1
+let s:fold_import = 1
+let s:fold_varconst = 1
+if exists("g:go_fold_enable") && type(g:go_fold_enable) == type([])
+  if index(g:go_fold_enable, 'block') == -1
+    let s:fold_block = 0
+  endif
+  if index(g:go_fold_enable, 'import') == -1
+    let s:fold_import = 0
+  endif
+  if index(g:go_fold_enable, 'varconst') == -1
+    let s:fold_varconst = 0
+  endif
+endif
+
 syn case match
 
-syn keyword     goDirective         package import
-syn keyword     goDeclaration       var const
+syn keyword     goPackage           package
+syn keyword     goImport            import    contained
+syn keyword     goVarConst          var const contained
 
-hi def link     goDirective         Statement
+hi def link     goPackage           Statement
+hi def link     goImport            Statement
+hi def link     goVarConst          Keyword
 hi def link     goDeclaration       Keyword
 
 " Keywords within functions
@@ -189,8 +207,31 @@ syn region      goCharacter         start=+'+ skip=+\\\\\|\\'+ end=+'+ contains=
 hi def link     goCharacter         Character
 
 " Regions
-syn region      goBlock             start="{" end="}" transparent fold
 syn region      goParen             start='(' end=')' transparent
+if s:fold_block
+  syn region    goBlock             start="{" end="}" transparent fold
+else
+  syn region    goBlock             start="{" end="}" transparent
+endif
+
+" import
+if s:fold_import
+  syn region    goImport            start='import (' end=')' transparent fold contains=goImport,goString
+else
+  syn region    goImport            start='import (' end=')' transparent contains=goImport,goString
+endif
+
+" var, const
+if s:fold_varconst
+  syn region    goVarConst          start='\(var\|const\) (' end=')' transparent fold contains=ALLBUT,goParen,goBlock
+else
+  syn region    goVarConst          start='\(var\|const\) (' end=')' transparent contains=ALLBUT,goParen,goBlock
+endif
+
+" Single-line var, const, and import.
+syn match       goSingleImport      /\(import\|var\|const\) [^(]\@=/ contains=goImport,goVarConst
+
+"syn region goImport start='var ' end=''contains=goVarConst
 
 " Integers
 syn match       goDecimalInt        "\<-\=\d\+\%([Ee][-+]\=\d\+\)\=\>"


### PR DESCRIPTION
This adds `foldmethod=syntax` folding for `import`, `var`, and `const` blocks.

I added a new `g:go_fold_enable` setting to selectively enable which regions get
folded. I find this useful personally as I only want to fold `import` blocks.

Future extension to this might be:

- `struct` and `interface`, to selectively fold `type foo struct { .. }` and
  `type foo interface { .. }` definitions;

- `package`, to fold the package-level comment.

But that's another PR for another day ;-)


Fixes: #963
