### PR TITLE
Add vimhelplint to Travis tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ doc/tags
 # Test specific files
 FAILED
 test.log
+scripts/vim-vimhelplint

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -690,8 +690,8 @@ CTRL-t
       :GoAddTags xml db
 <
     If [option] is passed it'll either add a new tag with an option or will
-    modify existing tags. An example of adding `omitempty` to all `json` fields
-    would be:
+    modify existing tags. An example of adding `omitempty` to all `json`
+    fields would be:
 >
       :GoAddTags json,omitempty
 <

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -32,3 +32,14 @@ if [ -f "FAILED" ]; then
   exit 1
 fi
 echo 2>&1 "PASS"
+
+# Run vimhelplint
+[ -d vim-vimhelplint ] || git clone https://github.com/machakann/vim-vimhelplint
+echo "Running vimhelplint"
+lint=$(vim -esN --cmd 'set rtp+=./vim-vimhelplint' -c 'filetype plugin on' \
+        -c 'e ../doc/vim-go.txt' -c 'verb VimhelpLintEcho' -c q 2>&1)
+if [ -n "$lint" ]; then 
+       exit 1
+else
+       exit 0
+fi


### PR DESCRIPTION
There have been a few instances where this helped me catch some errors, for
example in #987 and #1335 where there were a few wrong tag names (e.g.
`|g:go_foo|` instead of `|'g:go_foo'|`).