### PR TITLE
Update Readme - Add vim-plug option to atomatically run GoInstallBinaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ for popular package managers:
 *  [Pathogen](https://github.com/tpope/vim-pathogen)
     * `git clone https://github.com/fatih/vim-go.git ~/.vim/bundle/vim-go`
 *  [vim-plug](https://github.com/junegunn/vim-plug)
-    * `Plug 'fatih/vim-go'`
+    * `Plug 'fatih/vim-go', { 'do': ':GoInstallBinaries' }`
 *  [Vim packages](http://vimhelp.appspot.com/repeat.txt.html#packages)
     * `git clone https://github.com/fatih/vim-go.git ~/.vim/pack/plugins/start/vim-go`
 


### PR DESCRIPTION
Hi, 

when you use Vim-Plug, you can configure it to install the go binaries after it installs or updates vim-go. This is a really handsome feature and I think, that others will appreciate this, too. 

What do you think? Are there any unintended side effects?