### PR TITLE
Clarify :helpt prerequisite for using :help vim-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Official documentation can be found under [doc/vim-go.txt](doc/vim-go.txt). You 
 ```
 :help vim-go
 ```
+
+Depending on your installation, you may have to generate the plugin's [help
+tags](https://github.com/vim/vim/blob/v8.0.0711/runtime/doc/helphelp.txt#L206-L227)
+manually (eg. `:helptags ALL`).
+
 We also have an [official vim-go
 tutorial](https://github.com/fatih/vim-go-tutorial).
 


### PR DESCRIPTION
It took me a while to figure out the help tags had to be generated in order to use `:help vim-go`.
Making this more explicit might save some wandering souls a Google search :)

For most people `:helptags ALL` will do the right thing.