### PR TITLE
Added ability to keep the quickfix/location list window open

### DIFF
--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -3,8 +3,10 @@ if !exists("g:go_list_type")
 endif
 
 " Window opens the list with the given height up to 10 lines maximum.
-" Otherwise g:go_loclist_height is used. If no or zero height is given it
-" closes the window
+" Otherwise g:go_loclist_height is used. 
+"
+" If no or zero height is given it closes the window by default.  
+" To prevent this, set g:go_list_autoclose = 0
 function! go#list#Window(listtype, ...) abort
   let l:listtype = go#list#Type(a:listtype)
   " we don't use lwindow to close the location list as we need also the
@@ -13,10 +15,13 @@ function! go#list#Window(listtype, ...) abort
   " location list increases/decreases, cwindow will not resize when a new
   " updated height is passed. lopen in the other hand resizes the screen.
   if !a:0 || a:1 == 0
-    if l:listtype == "locationlist"
-      lclose
-    else
-      cclose
+    let autoclose_window = get(g:, 'go_list_autoclose', 1)
+    if autoclose_window
+      if l:listtype == "locationlist"
+        lclose
+      else
+        cclose
+      endif
     endif
     return
   endif

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1419,6 +1419,16 @@ Supported values are "", "quickfix", and "locationlist". >
 
   let g:go_list_type = ""
 <
+
+                                                       *'g:go_list_autoclose'*
+
+Specifies whether the quickfix/location list should be closed automatically
+in the absence of errors.  The default value is 1.
+If you prefer to keep a long running error window open, you can disable 
+this by setting the value to 0.
+>
+  let g:go_list_autoclose = 1
+<
                                                       *'g:go_asmfmt_autosave'*
 
 Use this option to auto |:AsmFmt| on save. By default it's disabled. >


### PR DESCRIPTION
I have a workflow where I prefer to keep the quickfix/location window open during development.  vim-go likes to automatically close this window on successful operations (i.e., GoFmt, GoBuild, etc...).

This change adds a configuration property to prevent this from happening.  By default, the window automatically closes (current behaviour).  Users can specify 0 to allow the window to remain open.  Tested with a few of the basic operations, but let me know if you suspect any issues might arise.