### PR TITLE
fmt: fix blocking ui when swapfile is enabled

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -116,7 +116,7 @@ function! go#fmt#update_file(source, target)
   endif
 
   " reload buffer to reflect latest changes
-  silent! edit!
+  silent edit!
 
   let &fileformat = old_fileformat
   let &syntax = &syntax


### PR DESCRIPTION
silent! is skipping any error message when calling the command. However
if swapfile is enabled, the user is prompted to recover or edit the
file. If swapfile is enabled, the prompt is still called in background,
but the user doesn't see it. So the whole UI is blocked until you hit a
character (such as enter) which basically closes the hidden prompt.

By removing the `!` we still call the command silently, but at
least the user will see the message (such as swapfile prompts) in case
of errors.

fixes #1360