### PR TITLE
Don't add offset to goTypeConstructor.

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -321,7 +321,7 @@ hi def link    goField              Identifier
 
 " Structs & Interfaces;
 if g:go_highlight_types != 0
-  syn match goTypeConstructor      /\<\w\+{\@=/he=e-1 
+  syn match goTypeConstructor      /\<\w\+{\@=/
   syn match goTypeDecl             /\<type\>/ nextgroup=goTypeName skipwhite skipnl
   syn match goTypeName             /\w\+/ contained nextgroup=goDeclType skipwhite skipnl
   syn match goDeclType             /\<\(interface\|struct\)\>/ skipwhite skipnl


### PR DESCRIPTION
This is a regression from cfa9713. Previously the offset was needed since the
`{` was matched as well. Now we don't match the `{` the offset means the last
character of the type won't be matched.

Fixes #1357