### PR TITLE
fmt.vim: default to quickfix list for showing errors

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -122,7 +122,7 @@ function! go#fmt#update_file(source, target)
   let &syntax = &syntax
 
   " clean up previous location list
-  let l:listtype = "locationlist"
+  let l:listtype = go#list#Type("quickfix")
   call go#list#Clean(l:listtype)
   call go#list#Window(l:listtype)
 endfunction
@@ -228,7 +228,7 @@ endfunction
 " show_errors opens a location list and shows the given errors. If the given
 " errors is empty, it closes the the location list
 function! s:show_errors(errors) abort
-  let l:listtype = go#list#Type("locationlist")
+  let l:listtype = go#list#Type("quickfix")
   if !empty(a:errors)
     call go#list#Populate(l:listtype, a:errors, 'Format')
     echohl Error | echomsg "Gofmt returned error" | echohl None

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1129,7 +1129,7 @@ The dictionary version allows you to define options for multiple binaries:
 <
                                                     *'g:go_fmt_fail_silently'*
 
-Use this option to disable showing a location list when |'g:go_fmt_command'|
+Use this option to disable showing a quickfix list when |'g:go_fmt_command'|
 fails. By default the location list is shown. >
 
   let g:go_fmt_fail_silently = 0


### PR DESCRIPTION
Not sure why we were using location list, but I think quickfix is the
better way going forward as it's more known. The user can change the
behaviour back to locationlist if they want

    let g:go_list_type = "locationlist"

Also fix fetching the correct list type setting (we were not checking it
at all)

fixes #1359