### PR TITLE
Preserve cursor column through formatting

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -69,6 +69,7 @@ function! go#fmt#Format(withGoimport) abort
     let bin_name = "goimports"
   endif
 
+  let cursor_pos = getpos(".")
   let out = go#fmt#run(bin_name, l:tmpname, expand('%'))
   let diff_offset = len(readfile(l:tmpname)) - line('$') 
 
@@ -99,7 +100,7 @@ function! go#fmt#Format(withGoimport) abort
   endif
 
   " be smart and jump to the line the new statement was added/removed
-  call cursor(line('.') + diff_offset, 0)
+  call cursor(line('.') + diff_offset, cursor_pos[2])
 endfunction
 
 " update_file updates the target file with the given formatted source

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -69,7 +69,7 @@ function! go#fmt#Format(withGoimport) abort
     let bin_name = "goimports"
   endif
 
-  let cursor_pos = getpos(".")
+  let current_col = col('.')
   let out = go#fmt#run(bin_name, l:tmpname, expand('%'))
   let diff_offset = len(readfile(l:tmpname)) - line('$') 
 
@@ -100,7 +100,7 @@ function! go#fmt#Format(withGoimport) abort
   endif
 
   " be smart and jump to the line the new statement was added/removed
-  call cursor(line('.') + diff_offset, cursor_pos[2])
+  call cursor(line('.') + diff_offset, current_col)
 endfunction
 
 " update_file updates the target file with the given formatted source


### PR DESCRIPTION
Save it before calling the formatter, and use the column argument
when setting the position after.