### PR TITLE
Show correct message when editing a new file

### DIFF
--- a/autoload/go/template.vim
+++ b/autoload/go/template.vim
@@ -21,7 +21,7 @@ function! go#template#create() abort
       let l:template_file = get(g:, 'go_template_file', "hello_world.go")
     endif
     let l:template_path = go#util#Join(l:root_dir, "templates", l:template_file)
-    exe '0r ' . fnameescape(l:template_path)
+    silent exe '0r ' . fnameescape(l:template_path)
   elseif l:package_name == -1 && l:go_template_use_pkg == 1
     " cwd is now the dir of the package
     let l:path = fnamemodify(getcwd(), ':t')
@@ -32,9 +32,6 @@ function! go#template#create() abort
     call append(0, l:content)
   endif
   $delete _
-
-  " Remove the '... [New File]' message line from the command line
-  echon
 
   execute cd . fnameescape(dir)
 endfunction


### PR DESCRIPTION
When editing a new file:

	vim newfile.go

Vim would show the results of the `:0r` command on startup:

	"~/.vim/pack/plugins/start/vim-go/templates/hello_world.go" 7L, 67C

Instead of the default:

	"newfile2.go" [New File]

This corrects that by adding running the `:0r` command with `silent`.

This would only occur if `go#tool#PackageName()` returns `-1`; the correct
message was already shown when a package is found.

There was an `echon` with a comment about removing the `[New File]` message, but
this seems like the wrong behaviour to me. Either way, it didn't work; maybe the
behaviour of `echon` subtly changed?

Fixes #1347