### PR TITLE
Allow specifying which filestypes to list for :GoFiles

### DIFF
--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -1,11 +1,42 @@
-function! go#tool#Files() abort
-  if go#util#IsWin()
-    let format = '{{range $f := .GoFiles}}{{$.Dir}}\{{$f}}{{printf \"\n\"}}{{end}}{{range $f := .CgoFiles}}{{$.Dir}}\{{$f}}{{printf \"\n\"}}{{end}}'
-  else
-    let format = "{{range $f := .GoFiles}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}{{range $f := .CgoFiles}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}"
+" From "go list -h".
+function! go#tool#ValidFiles(...)
+  let l:list = ["GoFiles", "CgoFiles", "IgnoredGoFiles", "CFiles", "CXXFiles",
+    \ "MFiles", "HFiles", "FFiles", "SFiles", "SwigFiles", "SwigCXXFiles",
+    \ "SysoFiles", "TestGoFiles", "XTestGoFiles"]
+
+  " Used as completion
+  if len(a:000) > 0
+    let l:list = filter(l:list, 'strpart(v:val, 0, len(a:1)) == a:1')
   endif
-  let command = 'go list -f '.shellescape(format)
-  let out = go#tool#ExecuteInDir(command)
+
+  return l:list
+endfunction
+
+function! go#tool#Files(...) abort
+  if len(a:000) > 0
+    let source_files = a:000
+  else
+    let source_files = ['GoFiles']
+  endif
+
+  let combined = ''
+  for sf in source_files
+    " Strip dot in case people used ":GoFiles .GoFiles".
+    let sf = substitute(sf, '^\.', '', '')
+
+    " Make sure the passed options are valid.
+    if index(go#tool#ValidFiles(), sf) == -1
+      echoerr "unknown source file variable: " . sf
+    endif
+
+    if go#util#IsWin()
+      let combined .= '{{range $f := .' . sf . '}}{{$.Dir}}\{{$f}}{{printf \"\n\"}}{{end}}{{range $f := .CgoFiles}}{{$.Dir}}\{{$f}}{{printf \"\n\"}}{{end}}'
+    else
+      let combined .= "{{range $f := ." . sf . "}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}{{range $f := .CgoFiles}}{{$.Dir}}/{{$f}}{{printf \"\\n\"}}{{end}}"
+    endif
+  endfor
+
+  let out = go#tool#ExecuteInDir('go list -f ' . shellescape(combined))
   return split(out, '\n')
 endfunction
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -436,18 +436,22 @@ CTRL-t
     Check for unchecked errors in you current package. Errors are populated in
     the quickfix window.
 
-    You may optionally pass any valid errcheck flags/options. For a full list
-    please see `errcheck -h`.
+    You may optionally pass any valid errcheck flags/options. See
+    `errcheck -h` for a full list.
 
                                                                     *:GoFiles*
-:GoFiles
+:GoFiles [source_files]
 
-    Show source files that depends for the current package
+    Show source files for the current package. The [source_files] specifies
+    which file types to list. See the "// Source files" section of
+    `go list -h` for possible values; multiple values are accepted.
+    Command-line completion also works for this command.
+    The default is to use `GoFiles` if no arguments are given.
 
                                                                      *:GoDeps*
 :GoDeps
 
-    Show dependencies for the current package
+    Show dependencies for the current package.
 
                                                           *:GoInstallBinaries*
 :GoInstallBinaries

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -23,7 +23,7 @@ command! -nargs=* -range GoAddTags call go#tags#Add(<line1>, <line2>, <count>, <
 command! -nargs=* -range GoRemoveTags call go#tags#Remove(<line1>, <line2>, <count>, <f-args>)
 
 " -- tool
-command! -nargs=0 GoFiles echo go#tool#Files()
+command! -nargs=* -complete=customlist,go#tool#ValidFiles GoFiles echo go#tool#Files(<f-args>)
 command! -nargs=0 GoDeps echo go#tool#Deps()
 command! -nargs=* GoInfo call go#tool#Info(0)
 command! -nargs=0 GoAutoTypeInfoToggle call go#complete#ToggleAutoTypeInfo()


### PR DESCRIPTION
Instead of always using `GoFiles`, you can now use `:GoFiles TestGoFiles` to
list all test files. Or `:GoFiles GoFiles TestGoFiles` to list both all regular
Go files and test files.

Fixes #1346