### PR TITLE
Document how to use a different Go binary

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1716,16 +1716,8 @@ wrapper script; for example if you would like to run `goapp` instead of `go`:
 >
      PATH="$HOME/gobin/:$PATH" vim
 <
-   Or from within your vimrc:
->
-     augroup go_path
-       autocmd!
-       autocmd FileType go 
-         \  if stridx($PATH, expand("$HOME/gobin")) == -1
-         \|   let $PATH = expand("$HOME/gobin:$PATH")
-         \| endif
-     augroup end
-<
+   Alternatively you you could set `$PATH` in your vimrc with an |autocmd|.
+
 
 How do I use vim-go with syntastic?~
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1700,6 +1700,33 @@ example sometimes code.google.com times out. To test, just execute a simple
 You'll see a more detailed error. If this works, vim-go will work too.
 
 
+I want to use a different binary name than "go", can I do this?~
+
+There is no way to directly configure the binary name; but you can use a
+wrapper script; for example if you would like to run `goapp` instead of `go`:
+
+1. In `~/gobin/go` (remember to make it executable):
+>
+     #!/bin/sh
+     # Remove gobin from PATH and run goapp.
+     PATH=${PATH#$HOME/gobin} goapp "$@"
+<
+2. Start Vim with `~/gobin` as the first `PATH` entry so it will use the
+   wrapper script:
+>
+     PATH="$HOME/gobin/:$PATH" vim
+<
+   Or from within your vimrc:
+>
+     augroup go_path
+       autocmd!
+       autocmd FileType go 
+         \  if stridx($PATH, expand("$HOME/gobin")) == -1
+         \|   let $PATH = expand("$HOME/gobin:$PATH")
+         \| endif
+     augroup end
+<
+
 How do I use vim-go with syntastic?~
 
 Sometimes when using both `vim-go` and `syntastic` Vim will start lagging

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1716,7 +1716,7 @@ wrapper script; for example if you would like to run `goapp` instead of `go`:
 >
      PATH="$HOME/gobin/:$PATH" vim
 <
-   Alternatively you you could set `$PATH` in your vimrc with an |autocmd|.
+   Alternatively you you could set `$PATH` in your vimrc with an |:autocmd|.
 
 
 How do I use vim-go with syntastic?~


### PR DESCRIPTION
Tested my wrapper script from #1222 and confirmed this works fine.

IMHO it's not worth making an option for this, as:

- very few people need it;
- is quite a bit of effort to implement;
- will make the code less readable;
- an easy workaround exists.

Fixes #1222