### PR TITLE
Various fixes for paths and GOPATH with spaces

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -25,7 +25,8 @@ function! go#def#Jump(mode) abort
       let $GOPATH = old_gopath
       return
     endif
-    let command = printf("%s -f=%s -o=%s -t", bin_path, go#util#Shellescape(fname), go#util#OffsetCursor())
+    let command = printf("%s -f=%s -o=%s -t", go#util#Shellescape(bin_path),
+      \ go#util#Shellescape(fname), go#util#OffsetCursor())
     let out = go#util#System(command)
     if exists("l:tmpname")
       call delete(l:tmpname)

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -25,7 +25,7 @@ function! go#def#Jump(mode) abort
       let $GOPATH = old_gopath
       return
     endif
-    let command = printf("%s -f=%s -o=%s -t", bin_path, fname, go#util#OffsetCursor())
+    let command = printf("%s -f=%s -o=%s -t", bin_path, go#util#Shellescape(fname), go#util#OffsetCursor())
     let out = go#util#System(command)
     if exists("l:tmpname")
       call delete(l:tmpname)
@@ -164,7 +164,7 @@ function! go#def#jump_to_declaration(out, mode, bin_name) abort
       endif
 
       " open the file and jump to line and column
-      exec cmd filename
+      exec cmd fnameescape(filename)
     endif
   endif
   call cursor(line, col)

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -65,7 +65,7 @@ function! go#doc#Open(newmode, mode, ...) abort
       return
     endif
 
-    let command = printf("%s %s", bin_path, join(a:000, ' '))
+    let command = printf("%s %s", go#util#Shellescape(bin_path), join(a:000, ' '))
     let out = go#util#System(command)
   else
     let out = s:gogetdoc(0)
@@ -137,7 +137,7 @@ function! s:gogetdoc(json) abort
     return -1
   endif
 
-  let cmd =  [bin_path]
+  let cmd = [go#util#Shellescape(bin_path)]
 
   let offset = go#util#OffsetCursor()
   let fname = expand("%:p:gs!\\!/!")

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -171,6 +171,7 @@ function! s:fmt_cmd(bin_name, source, target)
   endif
 
   " start constructing the command
+  let bin_path = go#util#Shellescape(bin_path)
   let cmd = [bin_path]
   call add(cmd, "-w")
     

--- a/autoload/go/impl.vim
+++ b/autoload/go/impl.vim
@@ -33,7 +33,7 @@ function! go#impl#Impl(...) abort
     return
   endif
 
-  let result = go#util#System(printf("%s '%s' '%s'", binpath, recv, iface))
+  let result = go#util#System(join(go#util#Shelllist([binpath, recv, iface], ' ')))
   if go#util#ShellError() != 0
     call go#util#EchoError(result)
     return

--- a/autoload/go/keyify.vim
+++ b/autoload/go/keyify.vim
@@ -10,7 +10,8 @@ function! go#keyify#Keyify()
   endif
 
   " Get result of command as json, that contains `start`, `end` and `replacement`
-  let command = printf("%s -json %s:#%s", bin_path, fname, go#util#OffsetCursor())
+  let command = printf("%s -json %s:#%s", go#util#Shellescape(bin_path),
+    \ go#util#Shellescape(fname), go#util#OffsetCursor())
   let output = go#util#System(command)
   silent! let result = json_decode(output)
 

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -121,6 +121,7 @@ function! go#lint#Golint(...) abort
   if empty(bin_path)
     return
   endif
+  let bin_path = go#util#Shellescape(bin_path)
 
   if a:0 == 0
     let out = go#util#System(bin_path)
@@ -188,7 +189,7 @@ function! go#lint#Errcheck(...) abort
   echon "vim-go: " | echohl Identifier | echon "errcheck analysing ..." | echohl None
   redraw
 
-  let command = bin_path . ' -abspath ' . import_path
+  let command =  go#util#Shellescape(bin_path) . ' -abspath ' . import_path
   let out = go#tool#ExecuteInDir(command)
 
   let l:listtype = "quickfix"

--- a/autoload/go/tags.vim
+++ b/autoload/go/tags.vim
@@ -116,6 +116,7 @@ func s:create_cmd(args) abort
   if empty(bin_path)
     return {'err': "gomodifytags does not exist"}
   endif
+  let bin_path = go#util#Shellescape(bin_path)
 
   let l:start = a:args.start
   let l:end = a:args.end
@@ -127,7 +128,7 @@ func s:create_cmd(args) abort
   " start constructing the command
   let cmd = [bin_path]
   call extend(cmd, ["-format", "json"])
-  call extend(cmd, ["-file", a:args.fname])
+  call extend(cmd, ["-file", go#util#Shellescape(a:args.fname)])
   call extend(cmd, ["-transform", l:modifytags_transform])
 
   if l:offset != 0


### PR DESCRIPTION
Fixes #1288, as well as a number of other commands.

There may be other places as well; this is just the result from a quick test
with my personal default settings. Since there are a lot of if/else branches
relating to jobs etc. it's kind of hard to test everything without a full audit.

It's perhaps a good idea to refactor some of this in a slightly more structured
way at some point: instead of passing strings we should pass a list which is
always escaped (like `os.Exec()`, Python's subprocess, etc.)