### PR TITLE
Fold package-level comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,8 @@ BUG FIXES:
 
 FEATURES:
 
-* We now have folding support based on Go syntax. Check out the
-  [demo](https://twitter.com/fatih/status/893843722093330433) to see it in
-  action. To enable it you have to set the following vim setting: `set
-  foldmethod=syntax`. Currently it folds at block (`{ }`), var and const level.
-  These can be individually disabled/enabled if wished. For more info please
-  read the documentation for the `g:go_fold_enable` setting. [gh-1339] 
-* `:GoFiles` accepts now an argument to change the type of files it can show.
-  By default it shows`.go source files` but now it can be changed to show
-  various kind of files. The full list can be seen via `go list --help` under
-  the `// Source Files` section [gh-1372] i.e:
+* We now have folding support based on Go syntax. To enable it you have to set the following Vim setting: `set foldmethod=syntax`. Currently it folds blocks (`{ }`), `import`, `var`, and `const` blocks, and package-level comments. These can be individually disabled/enabled if desired. For more info please read the documentation for the `g:go_fold_enable` setting. [gh-1339] [gh-1377]
+* `:GoFiles` accepts now an argument to change the type of files it can show. By default it shows`.go source files` but now it can be changed to show various kind of files. The full list can be seen via `go list --help` under the `// Source Files` section [gh-1372] i.e:
 
 ```
 :GoFiles CgoFiles        // shows .go sources files that import "C"

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1618,13 +1618,14 @@ Control syntax-based folding which takes effect when 'foldmethod' is set to
 `syntax`.
 You can enable specific fold regions by setting an array. Possible values are:
 
-- "block"       `{` .. `}` blocks.
-- "import"      `import` block.
-- "varconst"    `var` and `const` blocks.
+- "block"            `{` .. `}` blocks.
+- "import"           `import` block.
+- "varconst"         `var` and `const` blocks.
+- "package_comment"  The package comment.
 
 By default they're all enabled:
 >
-  let g:go_fold_enable = ['block', 'import', 'varconst']
+  let g:go_fold_enable = ['block', 'import', 'varconst', 'package_comment']
 <
 Enable folding of only imports:
 >

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -92,6 +92,7 @@ endif
 let s:fold_block = 1
 let s:fold_import = 1
 let s:fold_varconst = 1
+let s:fold_package_comment = 1
 if exists("g:go_fold_enable")
   if index(g:go_fold_enable, 'block') == -1
     let s:fold_block = 0
@@ -101,6 +102,9 @@ if exists("g:go_fold_enable")
   endif
   if index(g:go_fold_enable, 'varconst') == -1
     let s:fold_varconst = 0
+  endif
+  if index(g:go_fold_enable, 'package_comment') == -1
+    let s:fold_package_comment = 0
   endif
 endif
 
@@ -403,15 +407,22 @@ if g:go_highlight_build_constraints != 0
   hi def link goBuildCommentStart Comment
   hi def link goBuildDirectives   Type
   hi def link goBuildKeyword      PreProc
+endif
 
+if g:go_highlight_build_constraints != 0 || s:fold_package_comment
   " One or more line comments that are followed immediately by a "package"
   " declaration are treated like package documentation, so these must be
   " matched as comments to avoid looking like working build constraints.
   " The he, me, and re options let the "package" itself be highlighted by
   " the usual rules.
-  syn region  goPackageComment    start=/\v(\/\/.*\n)+\s*package/
-        \ end=/\v\n\s*package/he=e-7,me=e-7,re=e-7
-        \ contains=@goCommentGroup,@Spell
+  exe 'syn region  goPackageComment    start=/\v(\/\/.*\n)+\s*package/'
+        \ . ' end=/\v\n\s*package/he=e-7,me=e-7,re=e-7'
+        \ . ' contains=@goCommentGroup,@Spell'
+        \ . (s:fold_package_comment ? ' fold' : '')
+  exe 'syn region  goPackageComment    start=/\v\/\*.*\n(.*\n)*\s*\*\/\npackage/'
+        \ . ' end=/\v\n\s*package/he=e-7,me=e-7,re=e-7'
+        \ . ' contains=@goCommentGroup,@Spell'
+        \ . (s:fold_package_comment ? ' fold' : '')
   hi def link goPackageComment    Comment
 endif
 


### PR DESCRIPTION
This enables folding of the `// Package foo` and `/* Package foo` comments at
the top of files.

Ideally I'd also like to fold the `package ...` line in here, but this is kind
of hard to do... Maybe I'll take a look at that in a future date. For now, this
will do :-)