### PR TITLE
Don't show window if "gogetdoc" command isn't found

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -58,17 +58,21 @@ function! go#doc#OpenBrowser(...) abort
 endfunction
 
 function! go#doc#Open(newmode, mode, ...) abort
+  " With argument: run "godoc [arg]".
   if len(a:000)
-    " check if we have 'godoc' and use it automatically
     let bin_path = go#path#CheckBinPath('godoc')
     if empty(bin_path)
       return
     endif
 
-    let command = printf("%s %s", bin_path, join(a:000, ' '))
+    let command = printf("%s %s", go#util#Shellescape(bin_path), join(a:000, ' '))
     let out = go#util#System(command)
+  " Without argument: run gogetdoc on cursor position.
   else
     let out = s:gogetdoc(0)
+    if out == -1
+      return
+    endif
   endif
 
   if go#util#ShellError() != 0


### PR DESCRIPTION
When using `:GoGetDoc` without a `gogetdoc` binary it would still open the split
with the content `-1`. This fixes that.

An error message is not needed as `go#path#CheckBinPath` already shows that.

Related: #1346