### PR TITLE
Fixes for folding var/const blocks

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -225,11 +225,15 @@ endif
 
 " var, const
 if s:fold_varconst
-  syn region    goVar               start='var (' end=')' transparent fold contains=ALLBUT,goParen,goBlock
-  syn region    goConst             start='const (' end=')' transparent fold contains=ALLBUT,goParen,goBlock
+  syn region    goVar               start='var ('   end='^\s*)$' transparent fold
+                        \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar
+  syn region    goConst             start='const (' end='^\s*)$' transparent fold
+                        \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar
 else
-  syn region    goVar               start='var (' end=')' transparent contains=ALLBUT,goParen,goBlock
-  syn region    goConst             start='const (' end=')' transparent contains=ALLBUT,goParen,goBlock
+  syn region    goVar               start='var ('   end='^\s*)$' transparent 
+                        \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar
+  syn region    goConst             start='const (' end='^\s*)$' transparent
+                        \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar
 endif
 
 " Single-line var, const, and import.


### PR DESCRIPTION
This fixes two things:

- Exclude some more syntax matches for `goVar` and `goConst` to prevent
  accidental matches inside these blocks. This fixes #1383.

- Change the end from `)` to `^\s*)$` so that it won't match function calls.
  Previously in this example:

		var (
			foo = "bar"
			bar = fun()
		)

  It would match on the first `)`; the closing `)` in `fun()`.

  This still isn't perfect, as this is valid as well:

		var (
			foo = "bar"
			bar = fun(
				"arg",
				"arg",
			)
		)

  I'm not sure how to fix this case as well though...