### PR TITLE
Show message when using :GoDef and opening a new buffer

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -97,6 +97,7 @@ function! s:jump_to_declaration_cb(mode, bin_name, job, exit_status, data) abort
   endif
 
   call go#def#jump_to_declaration(a:data[0], a:mode, a:bin_name)
+  call go#util#EchoSuccess(a:data[0])
 endfunction
 
 function! go#def#jump_to_declaration(out, mode, bin_name) abort

--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -31,10 +31,6 @@ function go#job#Spawn(args)
   endfunction
 
   function cbs.exit_cb(job, exitval) dict
-    if has_key(self, 'custom_cb')
-      call self.custom_cb(a:job, a:exitval, self.messages)
-    endif
-
     if has_key(self, 'error_info_cb')
       call self.error_info_cb(a:job, a:exitval, self.messages)
     endif
@@ -45,6 +41,10 @@ function go#job#Spawn(args)
       else
         call go#util#EchoError("FAILED")
       endif
+    endif
+
+    if has_key(self, 'custom_cb')
+      call self.custom_cb(a:job, a:exitval, self.messages)
     endif
 
     let l:listtype = go#list#Type("quickfix")


### PR DESCRIPTION
Instead of:

	vim-go: SUCCESS

We now show:

	vim-go: /usr/lib/go/src/strings/strings.go:340:6: defined here as func strings.Join

Showing the output of the command is optional; if we remove it we get the old
behaviour with the output of an `:edit` command:

	"/usr/lib/go/src/strings/strings.go" [readonly] 777L, 20971C

Showing the command output seemed more useful to me personally though,

I moved the `custom_cb()` invocation after the message; this has no real effect
as far as I can see (it's used in only two places) and it allows us output
messages after the SUCCESS.

Fixes #1207