### PR TITLE
Allow comments in import blocks

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -218,9 +218,9 @@ endif
 
 " import
 if s:fold_import
-  syn region    goImport            start='import (' end=')' transparent fold contains=goImport,goString
+  syn region    goImport            start='import (' end=')' transparent fold contains=goImport,goString,goComment
 else
-  syn region    goImport            start='import (' end=')' transparent contains=goImport,goString
+  syn region    goImport            start='import (' end=')' transparent contains=goImport,goString,goComment
 endif
 
 " var, const


### PR DESCRIPTION
Otherwise they won't get highlighted and folding won't work correctly if an
`import` block contains a comment.

e.g.:

![2017-07-26-113553_508x91_scrot](https://user-images.githubusercontent.com/1032692/28617136-12b32f90-71f7-11e7-9bbb-de7f6703772d.png)

----

![2017-07-26-113721_623x239_scrot](https://user-images.githubusercontent.com/1032692/28617137-12d26c16-71f7-11e7-9364-439d6dbc4e3c.png)
