### PR TITLE
Add support for unite.vim about :GoDecls / :GoDeclsDir

### DIFF
--- a/autoload/unite/sources/decls.vim
+++ b/autoload/unite/sources/decls.vim
@@ -1,0 +1,63 @@
+let s:save_cpo = &cpoptions
+set cpoptions&vim
+
+let s:source = {
+      \ 'name': 'decls',
+      \ 'description': 'GoDecls implementation for unite',
+      \ 'syntax': 'uniteSource__Decls',
+      \ 'action_table': {},
+      \ 'hooks': {},
+      \ }
+
+function! unite#sources#decls#define()
+  return s:source
+endfunction
+
+function! s:source.gather_candidates(args, context) abort
+  let l:bin_path = go#path#CheckBinPath('motion')
+  if empty(l:bin_path)
+    return []
+  endif
+
+  let l:path = expand(get(a:args, 0, '%:p:h'))
+  if isdirectory(l:path)
+    let l:mode = 'dir'
+  elseif filereadable(l:path)
+    let l:mode = 'file'
+  else
+    return []
+  endif
+
+  let l:include = get(g:, 'go_decls_includes', 'func,type')
+  let l:command = printf('%s -format vim -mode decls -include %s -%s %s', l:bin_path, l:include, l:mode, l:path)
+  let l:result = eval(unite#util#system(l:command))
+  let l:candidates = get(l:result, 'decls', [])
+
+  return map(l:candidates, "{
+        \ 'word': printf('%s :%d :%s', fnamemodify(v:val.filename, ':~:.'), v:val.line, v:val.full),
+        \ 'kind': 'jump_list',
+        \ 'action__path': v:val.filename,
+        \ 'action__line': v:val.line,
+        \ 'action__col': v:val.col,
+        \ }")
+endfunction
+
+function! s:source.hooks.on_syntax(args, context) abort
+  syntax match uniteSource__Decls_Filepath /[^:]*\ze:/ contained containedin=uniteSource__Decls
+  syntax match uniteSource__Decls_Line /\d\+\ze :/ contained containedin=uniteSource__Decls
+  syntax match uniteSource__Decls_WholeFunction /\vfunc %(\([^)]+\) )?[^(]+/ contained containedin=uniteSource__Decls
+  syntax match uniteSource__Decls_Function /\S\+\ze(/ contained containedin=uniteSource__Decls_WholeFunction
+  syntax match uniteSource__Decls_WholeType /type \S\+/ contained containedin=uniteSource__Decls
+  syntax match uniteSource__Decls_Type /\v( )@<=\S+/ contained containedin=uniteSource__Decls_WholeType
+  highlight default link uniteSource__Decls_Filepath Comment
+  highlight default link uniteSource__Decls_Line LineNr
+  highlight default link uniteSource__Decls_Function Function
+  highlight default link uniteSource__Decls_Type Type
+
+  syntax match uniteSource__Decls_Separator /:/ contained containedin=uniteSource__Decls conceal
+  syntax match uniteSource__Decls_SeparatorFunction /func / contained containedin=uniteSource__Decls_WholeFunction conceal
+  syntax match uniteSource__Decls_SeparatorType /type / contained containedin=uniteSource__Decls_WholeType conceal
+endfunction
+
+let &cpoptions = s:save_cpo
+unlet s:save_cpo

--- a/autoload/unite/sources/decls.vim
+++ b/autoload/unite/sources/decls.vim
@@ -30,8 +30,13 @@ function! s:source.gather_candidates(args, context) abort
 
   let l:include = get(g:, 'go_decls_includes', 'func,type')
   let l:command = printf('%s -format vim -mode decls -include %s -%s %s', l:bin_path, l:include, l:mode, l:path)
-  let l:result = eval(unite#util#system(l:command))
-  let l:candidates = get(l:result, 'decls', [])
+  let l:candidates = []
+  try
+    let l:result = eval(unite#util#system(l:command))
+    let l:candidates = get(l:result, 'decls', [])
+  catch
+    call unite#print_source_error(['command returned invalid response.', v:exception], s:source.name)
+  endtry
 
   return map(l:candidates, "{
         \ 'word': printf('%s :%d :%s', fnamemodify(v:val.filename, ':~:.'), v:val.line, v:val.full),

--- a/autoload/unite/sources/decls.vim
+++ b/autoload/unite/sources/decls.vim
@@ -29,7 +29,7 @@ function! s:source.gather_candidates(args, context) abort
   endif
 
   let l:include = get(g:, 'go_decls_includes', 'func,type')
-  let l:command = printf('%s -format vim -mode decls -include %s -%s %s', l:bin_path, l:include, l:mode, l:path)
+  let l:command = printf('%s -format vim -mode decls -include %s -%s %s', l:bin_path, l:include, l:mode, shellescape(l:path))
   let l:candidates = []
   try
     let l:result = eval(unite#util#system(l:command))

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -666,6 +666,22 @@ CTRL-t
     type declarations for the current directory. If [dir] is given it parses
     the given directory.
 
+                                                                 *unite-decls*
+:Unite decls[:file or dir]
+
+    Only enabled if `unite.vim` is installed. If run shows declarations for
+    all functions and types on the current file or directory.  If [:file or
+    dir] is non empty, it parses the given one.
+>
+    " show declarations on the parent directory of the current file
+    :Unite decls
+
+    " show declarations on the file
+    :Unite decls:foo/bar.go
+
+    " show declarations on the directory
+    :Unite decls:foo
+<
                                                                      *:GoImpl*
 :GoImpl [receiver] [interface]
 
@@ -1558,8 +1574,9 @@ By default the template file specified by |'g:go_template_file'| is used.
 <
                                                        *'g:go_decls_includes'*
 
-Only useful if `ctrlp.vim` is installed. This sets which declarations to show
-for |:GoDecls|.  It is a Comma delimited list Possible options are:
+Only useful if `ctrlp.vim` or `unite.vim` are installed. This sets which
+declarations to show for |:GoDecls| (`ctrp.vim`) and |unite-decls|
+(`unite.vim`).  It is a Comma delimited list Possible options are:
 {func,type}.  The default is: >
 
       let g:go_decls_includes = 'func,type'


### PR DESCRIPTION
[unite.vim][] is a powerful "listing & selecting" plugin that looks like ctrlp.vim.  I want to use `:GoDeclsDir` feature with unite.vim and have implemented it.

[unite.vim]: https://github.com/Shougo/unite.vim

It has almost like `:GoDeclsDir / :GoDecls`, but differs at some points below.

* `:Unite decls` has features for both `:GoDeclsDir` and `:GoDecls`, but the main target is `:GoDeclsDir` because `unite.vim` has already `:Unite outline` that is similar to `:GoDecls`.
* `:Unite decls` does not conflict with the existent `:GoDecls / :GoDeclsDir`, so both of them can be used if both unite.vim and ctrp.vim are installed.

The document about this on `vim-go.txt` is the one I am worrying about.  I placed it at the next of `:GoDeclsDir`, but does anyone have an idea to place somewhere better?

| `:Unite decls` |
|---|
| <img width="766" alt="2017-07-27 20 38 20" src="https://user-images.githubusercontent.com/1239245/28668662-e2f4e29c-730b-11e7-8e54-f72fbbd3d372.png"> |

| `:Unite decls:appengine.go` |
|---|
| <img width="766" alt="2017-07-27 20 38 40" src="https://user-images.githubusercontent.com/1239245/28668677-f2fad566-730b-11e7-8107-a5484d9d269a.png"> |

| FYI: existing function from unite.vim `:Unite outline` |
|---|
| <img width="766" alt="2017-07-27 20 43 34" src="https://user-images.githubusercontent.com/1239245/28668791-805ecf52-730c-11e7-926e-2f480b39b064.png"> |
