### PR TITLE
silent gofmt when autosave

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -165,7 +165,7 @@ endfunction
 function! s:fmt_autosave()
   " Go code formatting on save
   if get(g:, "go_fmt_autosave", 1)
-    call go#fmt#Format(-1)
+    silent! call go#fmt#Format(-1)
   endif
 endfunction
 


### PR DESCRIPTION
Hi, when i save file which has syntax error, the autosave fmt work like this:
![vim-go-before](https://user-images.githubusercontent.com/4957677/28953700-8512e4ba-790c-11e7-9174-f298bce40727.gif)
it will break  vim window so i think set it silent will be better
