### PR TITLE
Issue 1396 go#def#tab fails if file is already open

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -154,9 +154,11 @@ function! go#def#jump_to_declaration(out, mode, bin_name) abort
       endif
 
       if a:mode == "tab"
-        let &switchbuf = "usetab"
+        let &switchbuf = "useopen,usetab,newtab"
         if bufloaded(filename) == 0
           tab split
+        else
+           let cmd = 'sbuf'
         endif
       elseif a:mode == "split"
         split


### PR DESCRIPTION
Setting switchbuf=usetab only is not enough since switchbuf only works for buffer related commands.
If mode is tab, I made it to use sbuf as cmd, instead of edit since edit will ignore the value of switbuf