### PR TITLE
not execute cleaning up list when gofmt success with fail_silently option

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -75,9 +75,15 @@ function! go#fmt#Format(withGoimport) abort
 
   if go#util#ShellError() == 0
     call go#fmt#update_file(l:tmpname, expand('%'))
-  elseif g:go_fmt_fail_silently == 0
-    let errors = s:parse_errors(expand('%'), out)
-    call s:show_errors(errors)
+  endif
+
+  if g:go_fmt_fail_silently == 0
+    if go#util#ShellError() == 0
+      call go#fmt#cleanup_list()
+    else
+      let errors = s:parse_errors(expand('%'), out)
+      call s:show_errors(errors)
+    endif
   endif
 
   " We didn't use the temp file, so clean up
@@ -126,8 +132,10 @@ function! go#fmt#update_file(source, target)
 
   let &fileformat = old_fileformat
   let &syntax = &syntax
+endfunction
 
-  " clean up previous location list
+" crean up list
+function! go#fmt#cleanup_list()
   let l:listtype = go#list#Type("quickfix")
   call go#list#Clean(l:listtype)
   call go#list#Window(l:listtype)


### PR DESCRIPTION
[quickfix list clobbered on save · Issue #1389 · fatih/vim-go](https://github.com/fatih/vim-go/issues/1389)

I don't want to clean up quickfix when autosave.

As a solution, if you do not display an error with gofmt, why not stop clean up?