### PR TITLE
term: exit insert mode

### DIFF
--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -77,6 +77,7 @@ function! go#term#newmode(bang, cmd, mode) abort
   call jobresize(id, width, height)
 
   let s:jobs[id] = job
+  stopinsert
   return id
 endfunction
 


### PR DESCRIPTION
When triggering commands in term mode we enter insert mode. This is really frustrating. This fixes this behaviour and quits insert mode after entering it.