### PR TITLE
Fix to fails of GoMetalinter result filepath in subdir. resolve #1413

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -87,7 +87,7 @@ function! go#lint#Gometa(autosave, ...) abort
 
   let meta_command = join(cmd, " ")
 
-  let out = go#tool#ExecuteInDir(meta_command)
+  let out = go#util#System(meta_command)
 
   let l:listtype = "quickfix"
   if go#util#ShellError() == 0

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -60,7 +60,7 @@ function! go#lint#Gometa(autosave, ...) abort
   " For async mode (s:lint_job), we want to override the default deadline only
   " if we have a deadline configured.
   "
-  " For sync mode (go#tool#ExecuteInDir), always explicitly pass the 5 seconds
+  " For sync mode (go#util#System), always explicitly pass the 5 seconds
   " deadline if there is no other deadline configured. If a deadline is
   " configured, then use it.
 

--- a/tags
+++ b/tags
@@ -1,0 +1,529 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.8	//
+$GOPATH	autoload/go/cmd.vim	/^  let $GOPATH = go#path#Detect()$/;"	v
+$GOPATH	autoload/go/cmd.vim	/^  let $GOPATH = old_gopath$/;"	v
+$GOPATH	autoload/go/coverage.vim	/^  let $GOPATH = go#path#Detect()$/;"	v
+$GOPATH	autoload/go/coverage.vim	/^  let $GOPATH = old_gopath$/;"	v
+$GOPATH	autoload/go/rename.vim	/^  let $GOPATH = go#path#Detect()$/;"	v
+$GOPATH	autoload/go/rename.vim	/^  let $GOPATH = old_gopath$/;"	v
+$GOPATH	autoload/go/test.vim	/^  let $GOPATH = go#path#Detect()$/;"	v
+$GOPATH	autoload/go/test.vim	/^  let $GOPATH = old_gopath$/;"	v
+<C-LeftMouse>	ftplugin/go.vim	/^  nnoremap <buffer> <silent> <C-LeftMouse> <LeftMouse>:GoDef<cr>$/;"	m
+<C-]>	ftplugin/go.vim	/^  nnoremap <buffer> <silent> <C-]> :GoDef<cr>$/;"	m
+<C-t>	ftplugin/go.vim	/^  nnoremap <buffer> <silent> <C-t> :<C-U>call go#def#StackPop(v:count1)<cr>$/;"	m
+<C-w><C-]>	ftplugin/go.vim	/^  nnoremap <buffer> <silent> <C-w><C-]> :<C-u>call go#def#Jump("split")<CR>$/;"	m
+<C-w>]	ftplugin/go.vim	/^  nnoremap <buffer> <silent> <C-w>] :<C-u>call go#def#Jump("split")<CR>$/;"	m
+<Plug>(go-alternate-edit)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-alternate-edit) :<C-u>call go#alternate#Switch(0, "edit")<CR>$/;"	m
+<Plug>(go-alternate-split)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-alternate-split) :<C-u>call go#alternate#Switch(0, "split")<CR>$/;"	m
+<Plug>(go-alternate-vertical)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-alternate-vertical) :<C-u>call go#alternate#Switch(0, "vsplit")<CR>$/;"	m
+<Plug>(go-build)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-build) :<C-u>call go#cmd#Build(!g:go_jump_to_error)<CR>$/;"	m
+<Plug>(go-callees)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-callees) :<C-u>call go#guru#Callees(-1)<CR>$/;"	m
+<Plug>(go-callers)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-callers) :<C-u>call go#guru#Callers(-1)<CR>$/;"	m
+<Plug>(go-callstack)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-callstack) :<C-u>call go#guru#Callstack(-1)<CR>$/;"	m
+<Plug>(go-channelpeers)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-channelpeers) :<C-u>call go#guru#ChannelPeers(-1)<CR>$/;"	m
+<Plug>(go-coverage)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-coverage) :<C-u>call go#coverage#Buffer(!g:go_jump_to_error)<CR>$/;"	m
+<Plug>(go-coverage-browser)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-coverage-browser) :<C-u>call go#coverage#Browser(!g:go_jump_to_error)<CR>$/;"	m
+<Plug>(go-coverage-clear)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-coverage-clear) :<C-u>call go#coverage#Clear()<CR>$/;"	m
+<Plug>(go-coverage-toggle)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-coverage-toggle) :<C-u>call go#coverage#BufferToggle(!g:go_jump_to_error)<CR>$/;"	m
+<Plug>(go-def)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-def) :<C-u>call go#def#Jump('')<CR>$/;"	m
+<Plug>(go-def-pop)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-def-pop) :<C-u>call go#def#StackPop()<CR>$/;"	m
+<Plug>(go-def-split)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-def-split) :<C-u>call go#def#Jump("split")<CR>$/;"	m
+<Plug>(go-def-stack)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-def-stack) :<C-u>call go#def#Stack()<CR>$/;"	m
+<Plug>(go-def-stack-clear)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-def-stack-clear) :<C-u>call go#def#StackClear()<CR>$/;"	m
+<Plug>(go-def-tab)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-def-tab) :<C-u>call go#def#Jump("tab")<CR>$/;"	m
+<Plug>(go-def-vertical)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-def-vertical) :<C-u>call go#def#Jump("vsplit")<CR>$/;"	m
+<Plug>(go-deps)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-deps) :<C-u>call go#tool#Deps()<CR>$/;"	m
+<Plug>(go-describe)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-describe) :<C-u>call go#guru#Describe(-1)<CR>$/;"	m
+<Plug>(go-doc)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-doc) :<C-u>call go#doc#Open("new", "split")<CR>$/;"	m
+<Plug>(go-doc-browser)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-doc-browser) :<C-u>call go#doc#OpenBrowser()<CR>$/;"	m
+<Plug>(go-doc-split)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-doc-split) :<C-u>call go#doc#Open("new", "split")<CR>$/;"	m
+<Plug>(go-doc-tab)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-doc-tab) :<C-u>call go#doc#Open("tabnew", "tabe")<CR>$/;"	m
+<Plug>(go-doc-vertical)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-doc-vertical) :<C-u>call go#doc#Open("vnew", "vsplit")<CR>$/;"	m
+<Plug>(go-files)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-files) :<C-u>call go#tool#Files()<CR>$/;"	m
+<Plug>(go-generate)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-generate) :<C-u>call go#cmd#Generate(!g:go_jump_to_error)<CR>$/;"	m
+<Plug>(go-implements)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-implements) :<C-u>call go#guru#Implements(-1)<CR>$/;"	m
+<Plug>(go-import)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-import) :<C-u>call go#import#SwitchImport(1, '', expand('<cword>'), '')<CR>$/;"	m
+<Plug>(go-imports)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-imports) :<C-u>call go#fmt#Format(1)<CR>$/;"	m
+<Plug>(go-info)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-info) :<C-u>call go#tool#Info(0)<CR>$/;"	m
+<Plug>(go-install)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-install) :<C-u>call go#cmd#Install(!g:go_jump_to_error)<CR>$/;"	m
+<Plug>(go-lint)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-lint) :<C-u>call go#lint#Golint()<CR>$/;"	m
+<Plug>(go-metalinter)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-metalinter) :<C-u>call go#lint#Gometa(0)<CR>$/;"	m
+<Plug>(go-referrers)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-referrers) :<C-u>call go#guru#Referrers(-1)<CR>$/;"	m
+<Plug>(go-rename)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-rename) :<C-u>call go#rename#Rename(!g:go_jump_to_error)<CR>$/;"	m
+<Plug>(go-run)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-run) :<C-u>call go#cmd#Run(!g:go_jump_to_error)<CR>$/;"	m
+<Plug>(go-run-split)	ftplugin/go/mappings.vim	/^  nnoremap <silent> <Plug>(go-run-split) :<C-u>call go#cmd#RunTerm(!g:go_jump_to_error, 'split', [])<CR>$/;"	m
+<Plug>(go-run-tab)	ftplugin/go/mappings.vim	/^  nnoremap <silent> <Plug>(go-run-tab) :<C-u>call go#cmd#RunTerm(!g:go_jump_to_error, 'tabe', [])<CR>$/;"	m
+<Plug>(go-run-vertical)	ftplugin/go/mappings.vim	/^  nnoremap <silent> <Plug>(go-run-vertical) :<C-u>call go#cmd#RunTerm(!g:go_jump_to_error, 'vsplit', [])<CR>$/;"	m
+<Plug>(go-sameids)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-sameids) :<C-u>call go#guru#SameIds()<CR>$/;"	m
+<Plug>(go-sameids-toggle)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-sameids-toggle) :<C-u>call go#guru#ToggleSameIds()<CR>$/;"	m
+<Plug>(go-test)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-test) :<C-u>call go#test#Test(!g:go_jump_to_error, 0)<CR>$/;"	m
+<Plug>(go-test-compile)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-test-compile) :<C-u>call go#test#Test(!g:go_jump_to_error, 1)<CR>$/;"	m
+<Plug>(go-test-func)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-test-func) :<C-u>call go#test#Func(!g:go_jump_to_error)<CR>$/;"	m
+<Plug>(go-vet)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-vet) :<C-u>call go#lint#Vet(!g:go_jump_to_error)<CR>$/;"	m
+<Plug>(go-whicherrs)	ftplugin/go/mappings.vim	/^nnoremap <silent> <Plug>(go-whicherrs) :<C-u>call go#guru#Whicherrs(-1)<CR>$/;"	m
+AsmFmt	ftplugin/asm.vim	/^command! -nargs=0 AsmFmt call go#asmfmt#Format()$/;"	c
+CheckBinaries	plugin/go.vim	/^function! s:CheckBinaries()$/;"	f
+CompilerSet	compiler/go.vim	/^  command -nargs=* CompilerSet setlocal <args>$/;"	c
+Error	autoload/go/import.vim	/^function! s:Error(s) abort$/;"	f
+GetGoHTMLTmplIndent	indent/gohtmltmpl.vim	/^function! GetGoHTMLTmplIndent(lnum)$/;"	f
+GoAddTags	ftplugin/go/commands.vim	/^command! -nargs=* -range GoAddTags call go#tags#Add(<line1>, <line2>, <count>, <f-args>)$/;"	c
+GoAlternate	ftplugin/go/commands.vim	/^command! -bang GoAlternate call go#alternate#Switch(<bang>0, '')$/;"	c
+GoAsmFmtAutoSaveToggle	ftplugin/go/commands.vim	/^command! -nargs=0 GoAsmFmtAutoSaveToggle call go#asmfmt#ToggleAsmFmtAutoSave()$/;"	c
+GoAutoTypeInfoToggle	ftplugin/go/commands.vim	/^command! -nargs=0 GoAutoTypeInfoToggle call go#complete#ToggleAutoTypeInfo()$/;"	c
+GoBuild	ftplugin/go/commands.vim	/^command! -nargs=* -bang GoBuild call go#cmd#Build(<bang>0,<f-args>)$/;"	c
+GoBuildTags	ftplugin/go/commands.vim	/^command! -nargs=? -bang GoBuildTags call go#cmd#BuildTags(<bang>0, <f-args>)$/;"	c
+GoCallees	ftplugin/go/commands.vim	/^command! -range=% GoCallees call go#guru#Callees(<count>)$/;"	c
+GoCallers	ftplugin/go/commands.vim	/^command! -range=% GoCallers call go#guru#Callers(<count>)$/;"	c
+GoCallstack	ftplugin/go/commands.vim	/^command! -range=% GoCallstack call go#guru#Callstack(<count>)$/;"	c
+GoChannelPeers	ftplugin/go/commands.vim	/^command! -range=% GoChannelPeers call go#guru#ChannelPeers(<count>)$/;"	c
+GoCoverage	ftplugin/go/commands.vim	/^command! -nargs=* -bang GoCoverage call go#coverage#Buffer(<bang>0, <f-args>)$/;"	c
+GoCoverageBrowser	ftplugin/go/commands.vim	/^command! -nargs=* -bang GoCoverageBrowser call go#coverage#Browser(<bang>0, <f-args>)$/;"	c
+GoCoverageClear	ftplugin/go/commands.vim	/^command! -nargs=* -bang GoCoverageClear call go#coverage#Clear()$/;"	c
+GoCoverageToggle	ftplugin/go/commands.vim	/^command! -nargs=* -bang GoCoverageToggle call go#coverage#BufferToggle(<bang>0, <f-args>)$/;"	c
+GoDecls	ftplugin/go/commands.vim	/^  command! -nargs=? -complete=file GoDecls call <SID>ctrlp_warning()$/;"	c
+GoDecls	ftplugin/go/commands.vim	/^  command! -nargs=? -complete=file GoDecls call ctrlp#init(ctrlp#decls#cmd(0, <q-args>))$/;"	c
+GoDeclsDir	ftplugin/go/commands.vim	/^  command! -nargs=? -complete=dir GoDeclsDir call ctrlp#init(ctrlp#decls#cmd(1, <q-args>))$/;"	c
+GoDeclsDir	ftplugin/go/commands.vim	/^  command! -nargs=? -complete=file GoDeclsDir call <SID>ctrlp_warning()$/;"	c
+GoDef	ftplugin/go/commands.vim	/^command! -nargs=* -range GoDef :call go#def#Jump('')$/;"	c
+GoDefPop	ftplugin/go/commands.vim	/^command! -nargs=? GoDefPop :call go#def#StackPop(<f-args>)$/;"	c
+GoDefStack	ftplugin/go/commands.vim	/^command! -nargs=? GoDefStack :call go#def#Stack(<f-args>)$/;"	c
+GoDefStackClear	ftplugin/go/commands.vim	/^command! -nargs=? GoDefStackClear :call go#def#StackClear(<f-args>)$/;"	c
+GoDeps	ftplugin/go/commands.vim	/^command! -nargs=0 GoDeps echo go#tool#Deps()$/;"	c
+GoDescribe	ftplugin/go/commands.vim	/^command! -range=% GoDescribe call go#guru#Describe(<count>)$/;"	c
+GoDoc	ftplugin/go/commands.vim	/^command! -nargs=* -range -complete=customlist,go#package#Complete GoDoc call go#doc#Open('new', 'split', <f-args>)$/;"	c
+GoDocBrowser	ftplugin/go/commands.vim	/^command! -nargs=* -range -complete=customlist,go#package#Complete GoDocBrowser call go#doc#OpenBrowser(<f-args>)$/;"	c
+GoDrop	ftplugin/go/commands.vim	/^command! -nargs=? -complete=customlist,go#package#Complete GoDrop call go#import#SwitchImport(0, '', <f-args>, '')$/;"	c
+GoErrCheck	ftplugin/go/commands.vim	/^command! -nargs=* -complete=customlist,go#package#Complete GoErrCheck call go#lint#Errcheck(<f-args>)$/;"	c
+GoFiles	ftplugin/go/commands.vim	/^command! -nargs=* -complete=customlist,go#tool#ValidFiles GoFiles echo go#tool#Files(<f-args>)$/;"	c
+GoFmt	ftplugin/go/commands.vim	/^command! -nargs=0 GoFmt call go#fmt#Format(-1)$/;"	c
+GoFmtAutoSaveToggle	ftplugin/go/commands.vim	/^command! -nargs=0 GoFmtAutoSaveToggle call go#fmt#ToggleFmtAutoSave()$/;"	c
+GoFreevars	ftplugin/go/commands.vim	/^command! -range=% GoFreevars call go#guru#Freevars(<count>)$/;"	c
+GoGenerate	ftplugin/go/commands.vim	/^command! -nargs=* -bang GoGenerate call go#cmd#Generate(<bang>0,<f-args>)$/;"	c
+GoGuruScope	ftplugin/go/commands.vim	/^command! -nargs=* -complete=customlist,go#package#Complete GoGuruScope call go#guru#Scope(<f-args>)$/;"	c
+GoImpl	ftplugin/go/commands.vim	/^command! -nargs=* -buffer -complete=customlist,go#impl#Complete GoImpl call go#impl#Impl(<f-args>)$/;"	c
+GoImplements	ftplugin/go/commands.vim	/^command! -range=% GoImplements call go#guru#Implements(<count>)$/;"	c
+GoImport	ftplugin/go/commands.vim	/^command! -nargs=1 -bang -complete=customlist,go#package#Complete GoImport call go#import#SwitchImport(1, '', <f-args>, '<bang>')$/;"	c
+GoImportAs	ftplugin/go/commands.vim	/^command! -nargs=* -bang -complete=customlist,go#package#Complete GoImportAs call go#import#SwitchImport(1, <f-args>, '<bang>')$/;"	c
+GoImports	ftplugin/go/commands.vim	/^command! -nargs=0 GoImports call go#fmt#Format(1)$/;"	c
+GoIndent	indent/go.vim	/^function! GoIndent(lnum)$/;"	f
+GoInfo	ftplugin/go/commands.vim	/^command! -nargs=* GoInfo call go#tool#Info(0)$/;"	c
+GoInstall	ftplugin/go/commands.vim	/^command! -nargs=* -bang GoInstall call go#cmd#Install(<bang>0, <f-args>)$/;"	c
+GoInstallBinaries	plugin/go.vim	/^command! GoInstallBinaries call s:GoInstallBinaries(-1)$/;"	c
+GoInstallBinaries	plugin/go.vim	/^function! s:GoInstallBinaries(updateBinaries)$/;"	f
+GoKeyify	ftplugin/go/commands.vim	/^command! -nargs=0 GoKeyify call go#keyify#Keyify()$/;"	c
+GoLint	ftplugin/go/commands.vim	/^command! -nargs=* GoLint call go#lint#Golint(<f-args>)$/;"	c
+GoMetaLinter	ftplugin/go/commands.vim	/^command! -nargs=* GoMetaLinter call go#lint#Gometa(0, <f-args>)$/;"	c
+GoMetaLinterAutoSaveToggle	ftplugin/go/commands.vim	/^command! -nargs=0 GoMetaLinterAutoSaveToggle call go#lint#ToggleMetaLinterAutoSave()$/;"	c
+GoNeosnippet	ftplugin/go/snippets.vim	/^function! s:GoNeosnippet()$/;"	f
+GoPath	plugin/go.vim	/^command! -nargs=? -complete=dir GoPath call go#path#GoPath(<f-args>)$/;"	c
+GoPlay	ftplugin/go/commands.vim	/^command! -nargs=0 -range=% GoPlay call go#play#Share(<count>, <line1>, <line2>)$/;"	c
+GoReferrers	ftplugin/go/commands.vim	/^command! -range=% GoReferrers call go#guru#Referrers(<count>)$/;"	c
+GoRemoveTags	ftplugin/go/commands.vim	/^command! -nargs=* -range GoRemoveTags call go#tags#Remove(<line1>, <line2>, <count>, <f-args>)$/;"	c
+GoRename	ftplugin/go/commands.vim	/^command! -nargs=? GoRename call go#rename#Rename(<bang>0,<f-args>)$/;"	c
+GoRun	ftplugin/go/commands.vim	/^command! -nargs=* -bang -complete=file GoRun call go#cmd#Run(<bang>0,<f-args>)$/;"	c
+GoSameIds	ftplugin/go/commands.vim	/^command! -range=0 GoSameIds call go#guru#SameIds()$/;"	c
+GoSameIdsAutoToggle	ftplugin/go/commands.vim	/^command! -range=0 GoSameIdsAutoToggle call go#guru#AutoToogleSameIds()$/;"	c
+GoSameIdsClear	ftplugin/go/commands.vim	/^command! -range=0 GoSameIdsClear call go#guru#ClearSameIds()$/;"	c
+GoSameIdsToggle	ftplugin/go/commands.vim	/^command! -range=0 GoSameIdsToggle call go#guru#ToggleSameIds()$/;"	c
+GoTemplateAutoCreateToggle	ftplugin/go/commands.vim	/^command! -nargs=0 GoTemplateAutoCreateToggle call go#template#ToggleAutoCreate()$/;"	c
+GoTest	ftplugin/go/commands.vim	/^command! -nargs=* -bang GoTest call go#test#Test(<bang>0, 0, <f-args>)$/;"	c
+GoTestCompile	ftplugin/go/commands.vim	/^command! -nargs=* -bang GoTestCompile call go#test#Test(<bang>0, 1, <f-args>)$/;"	c
+GoTestFunc	ftplugin/go/commands.vim	/^command! -nargs=* -bang GoTestFunc call go#test#Func(<bang>0, <f-args>)$/;"	c
+GoUltiSnips	ftplugin/go/snippets.vim	/^function! s:GoUltiSnips()$/;"	f
+GoUpdateBinaries	plugin/go.vim	/^command! GoUpdateBinaries call s:GoInstallBinaries(1)$/;"	c
+GoVet	ftplugin/go/commands.vim	/^command! -nargs=* -bang GoVet call go#lint#Vet(<bang>0, <f-args>)$/;"	c
+GoWhicherrs	ftplugin/go/commands.vim	/^command! -range=% GoWhicherrs call go#guru#Whicherrs(<count>)$/;"	c
+GodocView	autoload/go/doc.vim	/^function! s:GodocView(newposition, position, content) abort$/;"	f
+K	ftplugin/go.vim	/^  nnoremap <buffer> <silent> K :GoDoc<cr>$/;"	m
+SetTagbar	ftplugin/go/tagbar.vim	/^function! s:SetTagbar()$/;"	f
+Test_add_tags	autoload/go/tags_test.vim	/^func Test_add_tags()$/;"	f
+Test_goimports	autoload/go/fmt_test.vim	/^func Test_goimports()$/;"	f
+Test_jump_to_declaration_godef	autoload/go/def_test.vim	/^func Test_jump_to_declaration_godef()$/;"	f
+Test_jump_to_declaration_guru	autoload/go/def_test.vim	/^func Test_jump_to_declaration_guru()$/;"	f
+Test_remove_tags	autoload/go/tags_test.vim	/^func Test_remove_tags()$/;"	f
+Test_run_fmt	autoload/go/fmt_test.vim	/^func Test_run_fmt()$/;"	f
+Test_update_file	autoload/go/fmt_test.vim	/^func Test_update_file()$/;"	f
+[[	ftplugin/go.vim	/^  nnoremap <buffer> <silent> [[ :<c-u>call go#textobj#FunctionJump('n', 'prev')<cr>$/;"	m
+[[	ftplugin/go.vim	/^  onoremap <buffer> <silent> [[ :<c-u>call go#textobj#FunctionJump('o', 'prev')<cr>$/;"	m
+]]	ftplugin/go.vim	/^  nnoremap <buffer> <silent> ]] :<c-u>call go#textobj#FunctionJump('n', 'next')<cr>$/;"	m
+]]	ftplugin/go.vim	/^  onoremap <buffer> <silent> ]] :<c-u>call go#textobj#FunctionJump('o', 'next')<cr>$/;"	m
+a:args	autoload/go/cmd.vim	/^  let a:args.error_info_cb = funcref('s:error_info_cb')$/;"	v
+a:args	autoload/go/coverage.vim	/^  let a:args.error_info_cb = funcref('s:error_info_cb')$/;"	v
+a:args	autoload/go/def.vim	/^  let a:args.error_info_cb = funcref('s:error_info_cb')$/;"	v
+af	ftplugin/go.vim	/^  onoremap <buffer> <silent> af :<c-u>call go#textobj#Function('a')<cr>$/;"	m
+args	autoload/go/guru.vim	/^  let args = {$/;"	v
+asmfmt_autosave	plugin/go.vim	/^function! s:asmfmt_autosave()$/;"	f
+async_guru	autoload/go/guru.vim	/^function! s:async_guru(args) abort$/;"	f
+auto_sameids	plugin/go.vim	/^function! s:auto_sameids()$/;"	f
+auto_type_info	plugin/go.vim	/^function! s:auto_type_info()$/;"	f
+b:current_syntax	syntax/go.vim	/^let b:current_syntax = "go"$/;"	v
+b:current_syntax	syntax/godefstack.vim	/^let b:current_syntax = "godefstack"$/;"	v
+b:current_syntax	syntax/gohtmltmpl.vim	/^let b:current_syntax = "gohtmltmpl"$/;"	v
+b:current_syntax	syntax/gotexttmpl.vim	/^let b:current_syntax = "gotexttmpl"$/;"	v
+b:current_syntax	syntax/vimgo.vim	/^let b:current_syntax = "vimgo"$/;"	v
+b:did_ftplugin	ftplugin/asm.vim	/^let b:did_ftplugin = 1$/;"	v
+b:did_ftplugin	ftplugin/go.vim	/^let b:did_ftplugin = 1$/;"	v
+b:did_ftplugin	ftplugin/gohtmltmpl.vim	/^let b:did_ftplugin = 1$/;"	v
+b:did_indent	indent/go.vim	/^let b:did_indent = 1$/;"	v
+b:undo_ftplugin	ftplugin/asm.vim	/^let b:undo_ftplugin = "setl fo< com< cms<"$/;"	v
+b:undo_ftplugin	ftplugin/go.vim	/^let b:undo_ftplugin = "setl fo< com< cms<"$/;"	v
+callback_handlers_on_exit	autoload/go/jobcontrol.vim	/^function! s:callback_handlers_on_exit(job, exit_status, data) abort$/;"	f
+callbacks	autoload/go/cmd.vim	/^  let callbacks = go#job#Spawn(a:args)$/;"	v
+callbacks	autoload/go/coverage.vim	/^  let callbacks = go#job#Spawn(a:args)$/;"	v
+callbacks	autoload/go/def.vim	/^  let callbacks = go#job#Spawn(a:args)$/;"	v
+cbs	autoload/go/job.vim	/^    let cbs.callback = a:args.callback$/;"	v
+cbs	autoload/go/job.vim	/^    let cbs.exit_cb = a:args.exit_cb$/;"	v
+cbs.exit_cb	autoload/go/job.vim	/^  function cbs.exit_cb(job, exitval) dict$/;"	f
+cbs.show_errors	autoload/go/job.vim	/^  function cbs.show_errors(listtype) dict$/;"	f
+cd	autoload/go/cmd.vim	/^  let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '$/;"	v
+cd	autoload/go/coverage.vim	/^  let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '$/;"	v
+cd	autoload/go/test.vim	/^  let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '$/;"	v
+cd	scripts/runtest.vim	/^let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '$/;"	v
+chomp	autoload/go/keyify.vim	/^function! s:chomp(string)$/;"	f
+cmd_job	autoload/go/cmd.vim	/^function s:cmd_job(args) abort$/;"	f
+coverage_browser_callback	autoload/go/coverage.vim	/^function! s:coverage_browser_callback(coverfile, job, exit_status, data)$/;"	f
+coverage_browser_handler	autoload/go/coverage.vim	/^function! s:coverage_browser_handler(job, exit_status, data) abort$/;"	f
+coverage_callback	autoload/go/coverage.vim	/^function! s:coverage_callback(coverfile, job, exit_status, data)$/;"	f
+coverage_handler	autoload/go/coverage.vim	/^function! s:coverage_handler(job, exit_status, data) abort$/;"	f
+coverage_job	autoload/go/coverage.vim	/^function s:coverage_job(args)$/;"	f
+create_cmd	autoload/go/tags.vim	/^func s:create_cmd(args) abort$/;"	f
+ctrlp#decls#accept	autoload/ctrlp/decls.vim	/^function! ctrlp#decls#accept(mode, str) abort$/;"	f
+ctrlp#decls#cmd	autoload/ctrlp/decls.vim	/^function! ctrlp#decls#cmd(mode, ...) abort$/;"	f
+ctrlp#decls#enter	autoload/ctrlp/decls.vim	/^function! ctrlp#decls#enter() abort$/;"	f
+ctrlp#decls#exit	autoload/ctrlp/decls.vim	/^function! ctrlp#decls#exit() abort$/;"	f
+ctrlp#decls#init	autoload/ctrlp/decls.vim	/^function! ctrlp#decls#init() abort$/;"	f
+ctrlp_warning	ftplugin/go/commands.vim	/^  function! s:ctrlp_warning()$/;"	f
+current_compiler	compiler/go.vim	/^let current_compiler = "go"$/;"	v
+def_job	autoload/go/def.vim	/^function s:def_job(args) abort$/;"	f
+dir	autoload/go/cmd.vim	/^  let dir = getcwd()$/;"	v
+dir	autoload/go/coverage.vim	/^  let dir = getcwd()$/;"	v
+dir	autoload/go/test.vim	/^  let dir = getcwd()$/;"	v
+dir	scripts/runtest.vim	/^let dir = getcwd()$/;"	v
+echo_go_info	plugin/go.vim	/^function! s:echo_go_info()$/;"	f
+elapsed_time	scripts/runtest.vim	/^  let elapsed_time = reltimestr(reltime(started))$/;"	v
+elapsed_time	scripts/runtest.vim	/^  let elapsed_time = substitute(elapsed_time, '^\\s*\\(.\\{-}\\)\\s*$', '\\1', '')$/;"	v
+enable_syntax	autoload/ctrlp/decls.vim	/^function! s:enable_syntax() abort$/;"	f
+exit_cb	autoload/go/guru.vim	/^  function! s:exit_cb(job, exitval) closure$/;"	f
+exit_cb	autoload/go/lint.vim	/^  function! s:exit_cb(job, exitval) closure$/;"	f
+exit_cb	autoload/go/rename.vim	/^  function! s:exit_cb(job, exitval) closure$/;"	f
+exit_cb	autoload/go/test.vim	/^  function! s:exit_cb(job, exitval) closure$/;"	f
+fmt_autosave	plugin/go.vim	/^function! s:fmt_autosave()$/;"	f
+fmt_cmd	autoload/go/fmt.vim	/^function! s:fmt_cmd(bin_name, source, target)$/;"	f
+g:ctrlp_ext_vars	autoload/ctrlp/decls.vim	/^  let g:ctrlp_ext_vars = [s:go_decls_var]$/;"	v
+g:ctrlp_ext_vars	autoload/ctrlp/decls.vim	/^  let g:ctrlp_ext_vars = add(g:ctrlp_ext_vars, s:go_decls_var)$/;"	v
+g:go_alternate_mode	autoload/go/alternate.vim	/^  let g:go_alternate_mode = "edit"$/;"	v
+g:go_doc_command	autoload/go/doc.vim	/^  let g:go_doc_command = "godoc"$/;"	v
+g:go_doc_options	autoload/go/doc.vim	/^  let g:go_doc_options = ""$/;"	v
+g:go_errcheck_bin	autoload/go/lint.vim	/^  let g:go_errcheck_bin = "errcheck"$/;"	v
+g:go_fmt_command	autoload/go/fmt.vim	/^  let g:go_fmt_command = "gofmt"$/;"	v
+g:go_fmt_experimental	autoload/go/fmt.vim	/^  let g:go_fmt_experimental = 0$/;"	v
+g:go_fmt_fail_silently	autoload/go/fmt.vim	/^  let g:go_fmt_fail_silently = 0$/;"	v
+g:go_fmt_options	autoload/go/fmt.vim	/^  let g:go_fmt_options = ''$/;"	v
+g:go_golint_bin	autoload/go/lint.vim	/^  let g:go_golint_bin = "golint"$/;"	v
+g:go_gorename_bin	autoload/go/rename.vim	/^  let g:go_gorename_bin = "gorename"$/;"	v
+g:go_gorename_prefill	autoload/go/rename.vim	/^  let g:go_gorename_prefill = 1$/;"	v
+g:go_gotags_bin	ftplugin/go/tagbar.vim	/^  let g:go_gotags_bin = "gotags"$/;"	v
+g:go_highlight_array_whitespace_error	syntax/go.vim	/^  let g:go_highlight_array_whitespace_error = 0$/;"	v
+g:go_highlight_build_constraints	syntax/go.vim	/^  let g:go_highlight_build_constraints = 0$/;"	v
+g:go_highlight_chan_whitespace_error	syntax/go.vim	/^  let g:go_highlight_chan_whitespace_error = 0$/;"	v
+g:go_highlight_extra_types	syntax/go.vim	/^  let g:go_highlight_extra_types = 0$/;"	v
+g:go_highlight_fields	syntax/go.vim	/^  let g:go_highlight_fields = 0$/;"	v
+g:go_highlight_format_strings	syntax/go.vim	/^  let g:go_highlight_format_strings = 1$/;"	v
+g:go_highlight_functions	syntax/go.vim	/^  let g:go_highlight_functions = 0$/;"	v
+g:go_highlight_generate_tags	syntax/go.vim	/^  let g:go_highlight_generate_tags = 0$/;"	v
+g:go_highlight_methods	syntax/go.vim	/^  let g:go_highlight_methods = 0$/;"	v
+g:go_highlight_operators	syntax/go.vim	/^  let g:go_highlight_operators = 0$/;"	v
+g:go_highlight_space_tab_error	syntax/go.vim	/^  let g:go_highlight_space_tab_error = 0$/;"	v
+g:go_highlight_string_spellcheck	syntax/go.vim	/^  let g:go_highlight_string_spellcheck = 1$/;"	v
+g:go_highlight_trailing_whitespace_error	syntax/go.vim	/^  let g:go_highlight_trailing_whitespace_error = 0$/;"	v
+g:go_highlight_types	syntax/go.vim	/^  let g:go_highlight_types = 0$/;"	v
+g:go_jump_to_error	ftplugin/go/mappings.vim	/^  let g:go_jump_to_error = 1$/;"	v
+g:go_list_type	autoload/go/list.vim	/^  let g:go_list_type = ""$/;"	v
+g:go_loaded_gosnippets	ftplugin/go/snippets.vim	/^let g:go_loaded_gosnippets = 1$/;"	v
+g:go_loaded_install	plugin/go.vim	/^let g:go_loaded_install = 1$/;"	v
+g:go_metalinter_autosave_enabled	autoload/go/lint.vim	/^  let g:go_metalinter_autosave_enabled = ['vet', 'golint']$/;"	v
+g:go_metalinter_command	autoload/go/lint.vim	/^  let g:go_metalinter_command = ""$/;"	v
+g:go_metalinter_enabled	autoload/go/lint.vim	/^  let g:go_metalinter_enabled = ['vet', 'golint', 'errcheck']$/;"	v
+g:go_metalinter_excludes	autoload/go/lint.vim	/^  let g:go_metalinter_excludes = []$/;"	v
+g:go_play_open_browser	autoload/go/play.vim	/^  let g:go_play_open_browser = 1$/;"	v
+g:go_snippet_engine	ftplugin/go/snippets.vim	/^  let g:go_snippet_engine = "ultisnips"$/;"	v
+g:go_term_mode	autoload/go/term.vim	/^  let g:go_term_mode = 'vsplit'$/;"	v
+g:go_textobj_enabled	autoload/go/textobj.vim	/^  let g:go_textobj_enabled = 1$/;"	v
+g:go_textobj_include_function_doc	autoload/go/textobj.vim	/^  let g:go_textobj_include_function_doc = 1$/;"	v
+g:go_textobj_include_variable	autoload/go/textobj.vim	/^  let g:go_textobj_include_variable = 1$/;"	v
+g:testname	scripts/runtest.vim	/^let g:testname = expand('%')$/;"	v
+g<LeftMouse>	ftplugin/go.vim	/^  nnoremap <buffer> <silent> g<LeftMouse> <LeftMouse>:GoDef<cr>$/;"	m
+gd	ftplugin/go.vim	/^  nnoremap <buffer> <silent> gd :GoDef<cr>$/;"	m
+get_browser_command	autoload/go/play.vim	/^function! s:get_browser_command() abort$/;"	f
+get_browser_command	autoload/go/tool.vim	/^function! s:get_browser_command() abort$/;"	f
+get_visual_content	autoload/go/play.vim	/^function! s:get_visual_content() abort$/;"	f
+get_visual_selection	autoload/go/play.vim	/^function! s:get_visual_selection() abort$/;"	f
+git_root_path	scripts/runtest.vim	/^let git_root_path = system("git rev-parse --show-toplevel | tr -d '\\\\n'")$/;"	v
+go#alternate#Switch	autoload/go/alternate.vim	/^function! go#alternate#Switch(bang, cmd) abort$/;"	f
+go#asmfmt#Format	autoload/go/asmfmt.vim	/^function! go#asmfmt#Format() abort$/;"	f
+go#asmfmt#ToggleAsmFmtAutoSave	autoload/go/asmfmt.vim	/^function! go#asmfmt#ToggleAsmFmtAutoSave() abort$/;"	f
+go#cmd#Build	autoload/go/cmd.vim	/^function! go#cmd#Build(bang, ...) abort$/;"	f
+go#cmd#BuildTags	autoload/go/cmd.vim	/^function! go#cmd#BuildTags(bang, ...) abort$/;"	f
+go#cmd#Generate	autoload/go/cmd.vim	/^function! go#cmd#Generate(bang, ...) abort$/;"	f
+go#cmd#Install	autoload/go/cmd.vim	/^function! go#cmd#Install(bang, ...) abort$/;"	f
+go#cmd#Run	autoload/go/cmd.vim	/^function! go#cmd#Run(bang, ...) abort$/;"	f
+go#cmd#RunTerm	autoload/go/cmd.vim	/^function! go#cmd#RunTerm(bang, mode, files) abort$/;"	f
+go#cmd#autowrite	autoload/go/cmd.vim	/^function! go#cmd#autowrite() abort$/;"	f
+go#complete#Complete	autoload/go/complete.vim	/^function! go#complete#Complete(findstart, base) abort$/;"	f
+go#complete#GetInfo	autoload/go/complete.vim	/^function! go#complete#GetInfo() abort$/;"	f
+go#complete#Info	autoload/go/complete.vim	/^function! go#complete#Info(auto) abort$/;"	f
+go#complete#ToggleAutoTypeInfo	autoload/go/complete.vim	/^function! go#complete#ToggleAutoTypeInfo() abort$/;"	f
+go#coverage#Browser	autoload/go/coverage.vim	/^function! go#coverage#Browser(bang, ...) abort$/;"	f
+go#coverage#Buffer	autoload/go/coverage.vim	/^function! go#coverage#Buffer(bang, ...) abort$/;"	f
+go#coverage#BufferToggle	autoload/go/coverage.vim	/^function! go#coverage#BufferToggle(bang, ...) abort$/;"	f
+go#coverage#Clear	autoload/go/coverage.vim	/^function! go#coverage#Clear() abort$/;"	f
+go#coverage#genmatch	autoload/go/coverage.vim	/^function! go#coverage#genmatch(cov) abort$/;"	f
+go#coverage#overlay	autoload/go/coverage.vim	/^function! go#coverage#overlay(file) abort$/;"	f
+go#coverage#parsegocoverline	autoload/go/coverage.vim	/^function! go#coverage#parsegocoverline(line) abort$/;"	f
+go#def#Jump	autoload/go/def.vim	/^function! go#def#Jump(mode) abort$/;"	f
+go#def#SelectStackEntry	autoload/go/def.vim	/^function! go#def#SelectStackEntry() abort$/;"	f
+go#def#Stack	autoload/go/def.vim	/^function! go#def#Stack(...) abort$/;"	f
+go#def#StackClear	autoload/go/def.vim	/^function! go#def#StackClear(...) abort$/;"	f
+go#def#StackPop	autoload/go/def.vim	/^function! go#def#StackPop(...) abort$/;"	f
+go#def#StackUI	autoload/go/def.vim	/^function! go#def#StackUI() abort$/;"	f
+go#def#jump_to_declaration	autoload/go/def.vim	/^function! go#def#jump_to_declaration(out, mode, bin_name) abort$/;"	f
+go#doc#Open	autoload/go/doc.vim	/^function! go#doc#Open(newmode, mode, ...) abort$/;"	f
+go#doc#OpenBrowser	autoload/go/doc.vim	/^function! go#doc#OpenBrowser(...) abort$/;"	f
+go#fmt#Format	autoload/go/fmt.vim	/^function! go#fmt#Format(withGoimport) abort$/;"	f
+go#fmt#ToggleFmtAutoSave	autoload/go/fmt.vim	/^function! go#fmt#ToggleFmtAutoSave() abort$/;"	f
+go#fmt#run	autoload/go/fmt.vim	/^function! go#fmt#run(bin_name, source, target)$/;"	f
+go#fmt#update_file	autoload/go/fmt.vim	/^function! go#fmt#update_file(source, target)$/;"	f
+go#guru#AutoToogleSameIds	autoload/go/guru.vim	/^function! go#guru#AutoToogleSameIds() abort$/;"	f
+go#guru#Callees	autoload/go/guru.vim	/^function! go#guru#Callees(selected) abort$/;"	f
+go#guru#Callers	autoload/go/guru.vim	/^function! go#guru#Callers(selected) abort$/;"	f
+go#guru#Callstack	autoload/go/guru.vim	/^function! go#guru#Callstack(selected) abort$/;"	f
+go#guru#ChannelPeers	autoload/go/guru.vim	/^function! go#guru#ChannelPeers(selected) abort$/;"	f
+go#guru#ClearSameIds	autoload/go/guru.vim	/^function! go#guru#ClearSameIds() abort$/;"	f
+go#guru#Describe	autoload/go/guru.vim	/^function! go#guru#Describe(selected) abort$/;"	f
+go#guru#DescribeInfo	autoload/go/guru.vim	/^function! go#guru#DescribeInfo() abort$/;"	f
+go#guru#Freevars	autoload/go/guru.vim	/^function! go#guru#Freevars(selected) abort$/;"	f
+go#guru#Implements	autoload/go/guru.vim	/^function! go#guru#Implements(selected) abort$/;"	f
+go#guru#Referrers	autoload/go/guru.vim	/^function! go#guru#Referrers(selected) abort$/;"	f
+go#guru#SameIds	autoload/go/guru.vim	/^function! go#guru#SameIds() abort$/;"	f
+go#guru#SameIdsTimer	autoload/go/guru.vim	/^function! go#guru#SameIdsTimer() abort$/;"	f
+go#guru#Scope	autoload/go/guru.vim	/^function! go#guru#Scope(...) abort$/;"	f
+go#guru#ToggleSameIds	autoload/go/guru.vim	/^function! go#guru#ToggleSameIds() abort$/;"	f
+go#guru#Whicherrs	autoload/go/guru.vim	/^function! go#guru#Whicherrs(selected) abort$/;"	f
+go#impl#Complete	autoload/go/impl.vim	/^function! go#impl#Complete(arglead, cmdline, cursorpos) abort$/;"	f
+go#impl#Impl	autoload/go/impl.vim	/^function! go#impl#Impl(...) abort$/;"	f
+go#import#SwitchImport	autoload/go/import.vim	/^function! go#import#SwitchImport(enabled, localname, path, bang) abort$/;"	f
+go#job#Spawn	autoload/go/job.vim	/^function go#job#Spawn(args)$/;"	f
+go#jobcontrol#AddHandler	autoload/go/jobcontrol.vim	/^function! go#jobcontrol#AddHandler(handler) abort$/;"	f
+go#jobcontrol#RemoveHandler	autoload/go/jobcontrol.vim	/^function! go#jobcontrol#RemoveHandler(id) abort$/;"	f
+go#jobcontrol#Spawn	autoload/go/jobcontrol.vim	/^function! go#jobcontrol#Spawn(bang, desc, args) abort$/;"	f
+go#keyify#Keyify	autoload/go/keyify.vim	/^function! go#keyify#Keyify()$/;"	f
+go#lint#Errcheck	autoload/go/lint.vim	/^function! go#lint#Errcheck(...) abort$/;"	f
+go#lint#Golint	autoload/go/lint.vim	/^function! go#lint#Golint(...) abort$/;"	f
+go#lint#Gometa	autoload/go/lint.vim	/^function! go#lint#Gometa(autosave, ...) abort$/;"	f
+go#lint#ToggleMetaLinterAutoSave	autoload/go/lint.vim	/^function! go#lint#ToggleMetaLinterAutoSave() abort$/;"	f
+go#lint#Vet	autoload/go/lint.vim	/^function! go#lint#Vet(bang, ...) abort$/;"	f
+go#list#Clean	autoload/go/list.vim	/^function! go#list#Clean(listtype) abort$/;"	f
+go#list#Get	autoload/go/list.vim	/^function! go#list#Get(listtype) abort$/;"	f
+go#list#JumpToFirst	autoload/go/list.vim	/^function! go#list#JumpToFirst(listtype) abort$/;"	f
+go#list#Parse	autoload/go/list.vim	/^function! go#list#Parse(listtype, items) abort$/;"	f
+go#list#ParseFormat	autoload/go/list.vim	/^function! go#list#ParseFormat(listtype, errformat, items, title) abort$/;"	f
+go#list#Populate	autoload/go/list.vim	/^function! go#list#Populate(listtype, items, title) abort$/;"	f
+go#list#PopulateWin	autoload/go/list.vim	/^function! go#list#PopulateWin(winnr, items) abort$/;"	f
+go#list#Type	autoload/go/list.vim	/^function! go#list#Type(listtype) abort$/;"	f
+go#list#Window	autoload/go/list.vim	/^function! go#list#Window(listtype, ...) abort$/;"	f
+go#package#Complete	autoload/go/package.vim	/^function! go#package#Complete(ArgLead, CmdLine, CursorPos) abort$/;"	f
+go#package#CompleteMembers	autoload/go/package.vim	/^function! go#package#CompleteMembers(package, member) abort$/;"	f
+go#package#FromPath	autoload/go/package.vim	/^function! go#package#FromPath(arg) abort$/;"	f
+go#package#ImportPath	autoload/go/package.vim	/^function! go#package#ImportPath() abort$/;"	f
+go#package#Paths	autoload/go/package.vim	/^function! go#package#Paths() abort$/;"	f
+go#path#BinPath	autoload/go/path.vim	/^function! go#path#BinPath() abort$/;"	f
+go#path#CheckBinPath	autoload/go/path.vim	/^function! go#path#CheckBinPath(binpath) abort$/;"	f
+go#path#CygwinPath	autoload/go/path.vim	/^function! go#path#CygwinPath(path)$/;"	f
+go#path#Default	autoload/go/path.vim	/^function! go#path#Default() abort$/;"	f
+go#path#Detect	autoload/go/path.vim	/^function! go#path#Detect() abort$/;"	f
+go#path#GoPath	autoload/go/path.vim	/^function! go#path#GoPath(...) abort$/;"	f
+go#path#HasPath	autoload/go/path.vim	/^function! go#path#HasPath(path) abort$/;"	f
+go#play#Share	autoload/go/play.vim	/^function! go#play#Share(count, line1, line2) abort$/;"	f
+go#rename#Rename	autoload/go/rename.vim	/^function! go#rename#Rename(bang, ...) abort$/;"	f
+go#statusline#Clear	autoload/go/statusline.vim	/^function! go#statusline#Clear(timer_id) abort$/;"	f
+go#statusline#Show	autoload/go/statusline.vim	/^function! go#statusline#Show() abort$/;"	f
+go#statusline#Update	autoload/go/statusline.vim	/^function! go#statusline#Update(status_dir, status) abort$/;"	f
+go#tags#Add	autoload/go/tags.vim	/^function! go#tags#Add(start, end, count, ...) abort$/;"	f
+go#tags#Remove	autoload/go/tags.vim	/^function! go#tags#Remove(start, end, count, ...) abort$/;"	f
+go#tags#run	autoload/go/tags.vim	/^function! go#tags#run(start, end, offset, mode, fname, test_mode, ...) abort$/;"	f
+go#template#ToggleAutoCreate	autoload/go/template.vim	/^function! go#template#ToggleAutoCreate() abort$/;"	f
+go#template#create	autoload/go/template.vim	/^function! go#template#create() abort$/;"	f
+go#term#new	autoload/go/term.vim	/^function! go#term#new(bang, cmd) abort$/;"	f
+go#term#newmode	autoload/go/term.vim	/^function! go#term#newmode(bang, cmd, mode) abort$/;"	f
+go#test#Func	autoload/go/test.vim	/^function! go#test#Func(bang, ...) abort$/;"	f
+go#test#Test	autoload/go/test.vim	/^function! go#test#Test(bang, compile, ...) abort$/;"	f
+go#textobj#Function	autoload/go/textobj.vim	/^function! go#textobj#Function(mode) abort$/;"	f
+go#textobj#FunctionJump	autoload/go/textobj.vim	/^function! go#textobj#FunctionJump(mode, direction) abort$/;"	f
+go#tool#Deps	autoload/go/tool.vim	/^function! go#tool#Deps() abort$/;"	f
+go#tool#ExecuteInDir	autoload/go/tool.vim	/^function! go#tool#ExecuteInDir(cmd) abort$/;"	f
+go#tool#Exists	autoload/go/tool.vim	/^function! go#tool#Exists(importpath) abort$/;"	f
+go#tool#Files	autoload/go/tool.vim	/^function! go#tool#Files(...) abort$/;"	f
+go#tool#FilterValids	autoload/go/tool.vim	/^function! go#tool#FilterValids(items) abort$/;"	f
+go#tool#Imports	autoload/go/tool.vim	/^function! go#tool#Imports() abort$/;"	f
+go#tool#Info	autoload/go/tool.vim	/^function! go#tool#Info(auto) abort$/;"	f
+go#tool#OpenBrowser	autoload/go/tool.vim	/^function! go#tool#OpenBrowser(url) abort$/;"	f
+go#tool#PackageName	autoload/go/tool.vim	/^function! go#tool#PackageName() abort$/;"	f
+go#tool#ParseErrors	autoload/go/tool.vim	/^function! go#tool#ParseErrors(lines) abort$/;"	f
+go#tool#ValidFiles	autoload/go/tool.vim	/^function! go#tool#ValidFiles(...)$/;"	f
+go#ui#CloseWindow	autoload/go/ui.vim	/^function! go#ui#CloseWindow() abort$/;"	f
+go#ui#GetReturnWindow	autoload/go/ui.vim	/^function! go#ui#GetReturnWindow() abort$/;"	f
+go#ui#OpenDefinition	autoload/go/ui.vim	/^function! go#ui#OpenDefinition(filter) abort$/;"	f
+go#ui#OpenWindow	autoload/go/ui.vim	/^function! go#ui#OpenWindow(title, content, filetype) abort$/;"	f
+go#util#EchoError	autoload/go/util.vim	/^function! go#util#EchoError(msg)$/;"	f
+go#util#EchoInfo	autoload/go/util.vim	/^function! go#util#EchoInfo(msg)$/;"	f
+go#util#EchoProgress	autoload/go/util.vim	/^function! go#util#EchoProgress(msg)$/;"	f
+go#util#EchoSuccess	autoload/go/util.vim	/^function! go#util#EchoSuccess(msg)$/;"	f
+go#util#EchoWarning	autoload/go/util.vim	/^function! go#util#EchoWarning(msg)$/;"	f
+go#util#GetLines	autoload/go/util.vim	/^function! go#util#GetLines()$/;"	f
+go#util#IsUsingCygwinShell	autoload/go/util.vim	/^function! go#util#IsUsingCygwinShell()$/;"	f
+go#util#IsWin	autoload/go/util.vim	/^function! go#util#IsWin() abort$/;"	f
+go#util#Join	autoload/go/util.vim	/^function! go#util#Join(...) abort$/;"	f
+go#util#LineEnding	autoload/go/util.vim	/^function! go#util#LineEnding() abort$/;"	f
+go#util#Offset	autoload/go/util.vim	/^function! go#util#Offset(line, col) abort$/;"	f
+go#util#OffsetCursor	autoload/go/util.vim	/^function! go#util#OffsetCursor() abort$/;"	f
+go#util#PathListSep	autoload/go/util.vim	/^function! go#util#PathListSep() abort$/;"	f
+go#util#PathSep	autoload/go/util.vim	/^function! go#util#PathSep() abort$/;"	f
+go#util#ShellError	autoload/go/util.vim	/^function! go#util#ShellError() abort$/;"	f
+go#util#Shellescape	autoload/go/util.vim	/^fu! go#util#Shellescape(arg)$/;"	f
+go#util#Shelljoin	autoload/go/util.vim	/^function! go#util#Shelljoin(arglist, ...) abort$/;"	f
+go#util#Shelllist	autoload/go/util.vim	/^function! go#util#Shelllist(arglist, ...) abort$/;"	f
+go#util#StripPathSep	autoload/go/util.vim	/^function! go#util#StripPathSep(path) abort$/;"	f
+go#util#StripTrailingSlash	autoload/go/util.vim	/^function! go#util#StripTrailingSlash(paths) abort$/;"	f
+go#util#System	autoload/go/util.vim	/^function! go#util#System(str, ...) abort$/;"	f
+go#util#Windo	autoload/go/util.vim	/^function! go#util#Windo(command) abort$/;"	f
+go#util#camelcase	autoload/go/util.vim	/^function! go#util#camelcase(word) abort$/;"	f
+go#util#env	autoload/go/util.vim	/^function! go#util#env(key) abort$/;"	f
+go#util#goarch	autoload/go/util.vim	/^function! go#util#goarch() abort$/;"	f
+go#util#goos	autoload/go/util.vim	/^function! go#util#goos() abort$/;"	f
+go#util#gopath	autoload/go/util.vim	/^function! go#util#gopath() abort$/;"	f
+go#util#goroot	autoload/go/util.vim	/^function! go#util#goroot() abort$/;"	f
+go#util#has_job	autoload/go/util.vim	/^function! go#util#has_job() abort$/;"	f
+go#util#osarch	autoload/go/util.vim	/^function! go#util#osarch() abort$/;"	f
+go#util#snakecase	autoload/go/util.vim	/^function! go#util#snakecase(word) abort$/;"	f
+go#util#snippetcase	autoload/go/util.vim	/^function! go#util#snippetcase(word) abort$/;"	f
+go_packages	autoload/go/impl.vim	/^function! s:go_packages(dirs) abort$/;"	f
+gocodeAutocomplete	autoload/go/complete.vim	/^function! s:gocodeAutocomplete() abort$/;"	f
+gocodeCommand	autoload/go/complete.vim	/^function! s:gocodeCommand(cmd, preargs, args) abort$/;"	f
+gocodeCurrentBuffer	autoload/go/complete.vim	/^function! s:gocodeCurrentBuffer() abort$/;"	f
+gocodeCurrentBufferOpt	autoload/go/complete.vim	/^function! s:gocodeCurrentBufferOpt(filename) abort$/;"	f
+gocodeEnableOptions	autoload/go/complete.vim	/^function! s:gocodeEnableOptions() abort$/;"	f
+godocNotFound	autoload/go/doc.vim	/^function! s:godocNotFound(content) abort$/;"	f
+godocWord	autoload/go/doc.vim	/^function! s:godocWord(args) abort$/;"	f
+gofiletype_post	ftdetect/gofiletype.vim	/^function! s:gofiletype_post()$/;"	f
+gofiletype_pre	ftdetect/gofiletype.vim	/^function! s:gofiletype_pre(type)$/;"	f
+gogetdoc	autoload/go/doc.vim	/^function! s:gogetdoc(json) abort$/;"	f
+guru_cmd	autoload/go/guru.vim	/^function! s:guru_cmd(args) range abort$/;"	f
+hi	syntax/go.vim	/^function! s:hi()$/;"	f
+if	ftplugin/go.vim	/^  onoremap <buffer> <silent> if :<c-u>call go#textobj#Function('i')<cr>$/;"	m
+interface_list	autoload/go/impl.vim	/^function! s:interface_list(pkg) abort$/;"	f
+jobdir	autoload/go/cmd.vim	/^  let jobdir = fnameescape(expand("%:p:h"))$/;"	v
+jobdir	autoload/go/coverage.vim	/^  let jobdir = fnameescape(expand("%:p:h"))$/;"	v
+jobdir	autoload/go/test.vim	/^  let jobdir = fnameescape(expand("%:p:h"))$/;"	v
+jump_to_declaration_cb	autoload/go/def.vim	/^function! s:jump_to_declaration_cb(mode, bin_name, job, exit_status, data) abort$/;"	f
+l:start_options	autoload/go/def.vim	/^    let l:start_options.in_io = "file"$/;"	v
+l:start_options	autoload/go/def.vim	/^    let l:start_options.in_name = l:tmpname$/;"	v
+l:start_options	autoload/go/guru.vim	/^    let l:start_options.in_io = "file"$/;"	v
+l:start_options	autoload/go/guru.vim	/^    let l:start_options.in_name = l:tmpname$/;"	v
+l:tmpname	autoload/go/def.vim	/^    let l:tmpname = tempname()$/;"	v
+l:tmpname	autoload/go/guru.vim	/^    let l:tmpname = tempname()$/;"	v
+lint_job	autoload/go/lint.vim	/^function s:lint_job(args)$/;"	f
+main_syntax	syntax/gohtmltmpl.vim	/^  let main_syntax = 'html'$/;"	v
+message	scripts/runtest.vim	/^let message = 'Executed ' . s:done . (s:done > 1 ? ' tests' : ' test') . '. Total test time: '. total_elapsed_time .'s'$/;"	v
+metalinter_autosave	plugin/go.vim	/^function! s:metalinter_autosave()$/;"	f
+old_gopath	autoload/go/cmd.vim	/^  let old_gopath = $GOPATH$/;"	v
+old_gopath	autoload/go/coverage.vim	/^  let old_gopath = $GOPATH$/;"	v
+old_gopath	autoload/go/rename.vim	/^  let old_gopath = $GOPATH$/;"	v
+old_gopath	autoload/go/test.vim	/^  let old_gopath = $GOPATH$/;"	v
+on_exit	autoload/go/jobcontrol.vim	/^function! s:on_exit(job_id, exit_status, event) dict abort$/;"	f
+on_exit	autoload/go/term.vim	/^function! s:on_exit(job_id, exit_status, event) dict abort$/;"	f
+on_stderr	autoload/go/jobcontrol.vim	/^function! s:on_stderr(job_id, data, event) dict abort$/;"	f
+on_stderr	autoload/go/term.vim	/^function! s:on_stderr(job_id, data, event) dict abort$/;"	f
+on_stdout	autoload/go/jobcontrol.vim	/^function! s:on_stdout(job_id, data, event) dict abort$/;"	f
+on_stdout	autoload/go/term.vim	/^function! s:on_stdout(job_id, data, event) dict abort$/;"	f
+parse_errors	autoload/go/fmt.vim	/^function! s:parse_errors(filename, content) abort$/;"	f
+parse_errors	autoload/go/rename.vim	/^function s:parse_errors(exit_val, bang, out)$/;"	f
+parse_errors	autoload/go/test.vim	/^function! s:parse_errors(lines) abort$/;"	f
+parse_guru_output	autoload/go/guru.vim	/^function! s:parse_guru_output(exit_val, output, title) abort$/;"	f
+rename_job	autoload/go/rename.vim	/^function s:rename_job(args)$/;"	f
+root_dirs	autoload/go/impl.vim	/^function! s:root_dirs() abort$/;"	f
+run_guru	autoload/go/guru.vim	/^function! s:run_guru(args) abort$/;"	f
+s:buf_nr	autoload/go/doc.vim	/^let s:buf_nr = -1$/;"	v
+s:buf_nr	autoload/go/ui.vim	/^let s:buf_nr = -1$/;"	v
+s:coverage_browser_handler_jobs	autoload/go/coverage.vim	/^let s:coverage_browser_handler_jobs = {}$/;"	v
+s:coverage_handler_jobs	autoload/go/coverage.vim	/^let s:coverage_handler_jobs = {}$/;"	v
+s:current_file	autoload/go/template.vim	/^let s:current_file = expand("<sfile>")$/;"	v
+s:current_fileencodings	ftdetect/gofiletype.vim	/^let s:current_fileencodings = ''$/;"	v
+s:current_fileformats	ftdetect/gofiletype.vim	/^let s:current_fileformats = ''$/;"	v
+s:done	scripts/runtest.vim	/^  let s:done += 1$/;"	v
+s:done	scripts/runtest.vim	/^let s:done = 0$/;"	v
+s:env_cache	autoload/go/util.vim	/^let s:env_cache = {}$/;"	v
+s:fail	scripts/runtest.vim	/^    let s:fail += 1$/;"	v
+s:fail	scripts/runtest.vim	/^let s:fail = 0$/;"	v
+s:fold_block	syntax/go.vim	/^    let s:fold_block = 0$/;"	v
+s:fold_block	syntax/go.vim	/^let s:fold_block = 1$/;"	v
+s:fold_import	syntax/go.vim	/^    let s:fold_import = 0$/;"	v
+s:fold_import	syntax/go.vim	/^let s:fold_import = 1$/;"	v
+s:fold_varconst	syntax/go.vim	/^    let s:fold_varconst = 0$/;"	v
+s:fold_varconst	syntax/go.vim	/^let s:fold_varconst = 1$/;"	v
+s:go_decls_var	autoload/ctrlp/decls.vim	/^let s:go_decls_var = {$/;"	v
+s:go_stack	autoload/go/def.vim	/^let s:go_stack = []$/;"	v
+s:go_stack_level	autoload/go/def.vim	/^let s:go_stack_level = 0$/;"	v
+s:goarch	autoload/go/package.vim	/^    let s:goarch = '*'$/;"	v
+s:goarch	autoload/go/package.vim	/^    let s:goarch = g:golang_goarch$/;"	v
+s:goarch	autoload/go/package.vim	/^let s:goarch = $GOARCH$/;"	v
+s:goos	autoload/go/package.vim	/^    let s:goos = '*'$/;"	v
+s:goos	autoload/go/package.vim	/^    let s:goos = 'darwin'$/;"	v
+s:goos	autoload/go/package.vim	/^    let s:goos = 'windows'$/;"	v
+s:goos	autoload/go/package.vim	/^    let s:goos = g:golang_goos$/;"	v
+s:goos	autoload/go/package.vim	/^let s:goos = $GOOS$/;"	v
+s:got_fmt_error	autoload/go/asmfmt.vim	/^let s:got_fmt_error = 0$/;"	v
+s:handlers	autoload/go/jobcontrol.vim	/^let s:handlers = {}$/;"	v
+s:id	autoload/ctrlp/decls.vim	/^let s:id = g:ctrlp_builtins + len(g:ctrlp_ext_vars)$/;"	v
+s:initial_go_path	autoload/go/path.vim	/^let s:initial_go_path = ""$/;"	v
+s:jobs	autoload/go/jobcontrol.vim	/^let s:jobs = {}$/;"	v
+s:jobs	autoload/go/term.vim	/^let s:jobs = {}$/;"	v
+s:last_status	autoload/go/statusline.vim	/^let s:last_status = ""$/;"	v
+s:logs	scripts/runtest.vim	/^let s:logs = []$/;"	v
+s:optionsEnabled	autoload/go/complete.vim	/^let s:optionsEnabled = 0$/;"	v
+s:packages	plugin/go.vim	/^let s:packages = [$/;"	v
+s:save_cpo	compiler/go.vim	/^let s:save_cpo = &cpo$/;"	v
+s:sock_type	autoload/go/complete.vim	/^let s:sock_type = (has('win32') || has('win64')) ? 'tcp' : 'unix'$/;"	v
+s:statuses	autoload/go/statusline.vim	/^let s:statuses = {}$/;"	v
+s:tests	scripts/runtest.vim	/^let s:tests = split(substitute(@q, 'function \\(\\k*()\\)', '\\1', 'g'))$/;"	v
+s:timer_id	autoload/go/statusline.vim	/^let s:timer_id = 0$/;"	v
+s:toggle	autoload/go/coverage.vim	/^let s:toggle = 0$/;"	v
+same_ids_highlight	autoload/go/guru.vim	/^function! s:same_ids_highlight(exit_val, output) abort$/;"	f
+show_errors	autoload/go/fmt.vim	/^function! s:show_errors(errors) abort$/;"	f
+show_errors	autoload/go/test.vim	/^function! s:show_errors(args, exit_val, messages) abort$/;"	f
+spawn	autoload/go/jobcontrol.vim	/^function! s:spawn(bang, desc, args) abort$/;"	f
+start_options	autoload/go/cmd.vim	/^  let start_options = {$/;"	v
+start_options	autoload/go/coverage.vim	/^  let start_options = {$/;"	v
+start_options	autoload/go/def.vim	/^  let start_options = {$/;"	v
+start_options	autoload/go/guru.vim	/^  let start_options = {$/;"	v
+start_options	autoload/go/lint.vim	/^  let start_options = {$/;"	v
+start_options	autoload/go/rename.vim	/^  let start_options = {$/;"	v
+start_options	autoload/go/test.vim	/^  let start_options = {$/;"	v
+started	scripts/runtest.vim	/^  let started = reltime()$/;"	v
+status_dir	autoload/go/rename.vim	/^  let status_dir =  expand('%:p:h')$/;"	v
+sw	indent/go.vim	/^  func s:sw()$/;"	f
+sync_guru	autoload/go/guru.vim	/^function! s:sync_guru(args) abort$/;"	f
+template_autocreate	plugin/go.vim	/^function! s:template_autocreate()$/;"	f
+test_job	autoload/go/test.vim	/^function s:test_job(args) abort$/;"	f
+toBool	autoload/go/complete.vim	/^function! s:toBool(val) abort$/;"	f
+total_elapsed_time	scripts/runtest.vim	/^let total_elapsed_time = reltimestr(reltime(total_started))$/;"	v
+total_elapsed_time	scripts/runtest.vim	/^let total_elapsed_time = substitute(total_elapsed_time, '^\\s*\\(.\\{-}\\)\\s*$', '\\1', '')$/;"	v
+total_started	scripts/runtest.vim	/^let total_started = reltime()$/;"	v
+trim_bracket	autoload/go/complete.vim	/^function! s:trim_bracket(val) abort$/;"	f
+uniq	autoload/go/impl.vim	/^  function! s:uniq(list)$/;"	f
+vim	plugin/go.vim	/^augroup vim-go$/;"	a
+vim	syntax/go.vim	/^augroup vim-go-hi$/;"	a
+write_out	autoload/go/tags.vim	/^func s:write_out(out) abort$/;"	f


### PR DESCRIPTION
Execute `:GoMetalinter` in subdir, failed to parse filepath.

e.g.

Execute to `foo/bar.go`.
Now execute gometalinter in `foo/` dir.
So, result path will `bar.go` but want `foo/bar.go`
