### PR TITLE
support for customizable lists types

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -31,6 +31,7 @@ function! go#cmd#Build(bang, ...) abort
     call s:cmd_job({
           \ 'cmd': ['go'] + args,
           \ 'bang': a:bang,
+          \ 'for': 'GoBuild',
           \})
     return
   elseif has('nvim')
@@ -39,7 +40,7 @@ function! go#cmd#Build(bang, ...) abort
     endif
 
     " if we have nvim, call it asynchronously and return early ;)
-    call go#jobcontrol#Spawn(a:bang, "build", args)
+    call go#jobcontrol#Spawn(a:bang, "build", "GoBuild", args)
     return
   endif
 
@@ -48,7 +49,7 @@ function! go#cmd#Build(bang, ...) abort
   let default_makeprg = &makeprg
   let &makeprg = "go " . join(args, ' ')
 
-  let l:listtype = go#list#Type("quickfix")
+  let l:listtype = go#list#Type("GoBuild", "quickfix")
   " execute make inside the source folder so we can parse the errors
   " correctly
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
@@ -149,7 +150,7 @@ function! go#cmd#Run(bang, ...) abort
     let &makeprg = "go run " . go#util#Shelljoin(map(copy(a:000), "expand(v:val)"), 1)
   endif
 
-  let l:listtype = go#list#Type("quickfix")
+  let l:listtype = go#list#Type("GoRun", "quickfix")
 
   if l:listtype == "locationlist"
     exe 'lmake!'
@@ -186,6 +187,7 @@ function! go#cmd#Install(bang, ...) abort
     call s:cmd_job({
           \ 'cmd': ['go', 'install'] + goargs,
           \ 'bang': a:bang,
+          \ 'for': 'GoInstall',
           \})
     return
   endif
@@ -198,7 +200,7 @@ function! go#cmd#Install(bang, ...) abort
   let goargs = go#util#Shelljoin(map(copy(a:000), "expand(v:val)"), 1)
   let &makeprg = "go install " . goargs
 
-  let l:listtype = go#list#Type("quickfix")
+  let l:listtype = go#list#Type("GoInstall", "quickfix")
   " execute make inside the source folder so we can parse the errors
   " correctly
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
@@ -243,7 +245,7 @@ function! go#cmd#Generate(bang, ...) abort
     let &makeprg = "go generate " . goargs . ' ' . gofiles
   endif
 
-  let l:listtype = go#list#Type("quickfix")
+  let l:listtype = go#list#Type("GoGenerate", "quickfix")
 
   echon "vim-go: " | echohl Identifier | echon "generating ..."| echohl None
   if l:listtype == "locationlist"

--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -53,6 +53,7 @@ function! go#coverage#Buffer(bang, ...) abort
           \ 'cmd': ['go', 'test', '-coverprofile', l:tmpname] + a:000,
           \ 'custom_cb': function('s:coverage_callback', [l:tmpname]),
           \ 'bang': a:bang,
+          \ 'for': 'GoTest',
           \ })
     return
   endif
@@ -108,6 +109,7 @@ function! go#coverage#Browser(bang, ...) abort
           \ 'cmd': ['go', 'test', '-coverprofile', l:tmpname],
           \ 'custom_cb': function('s:coverage_browser_callback', [l:tmpname]),
           \ 'bang': a:bang,
+          \ 'for': 'GoTest',
           \ })
     return
   endif

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -127,17 +127,20 @@ function! go#fmt#update_file(source, target)
   let &fileformat = old_fileformat
   let &syntax = &syntax
 
-
   " the title information was introduced with 7.4-2200
   " https://github.com/vim/vim/commit/d823fa910cca43fec3c31c030ee908a14c272640
   if !has('patch-7.4-2200')
     return
   endif
 
-  " clean up previous location list
-  let l:list_title = getqflist({'title': 1})
+  " clean up previous list
+  let l:listtype = go#list#Type("GoFmt", "locationlist")
+  if l:listtype == "quickfix"
+    let l:list_title = getqflist({'title': 1})
+  else
+    let l:list_title = getloclist(0, {'title': 1})
+  endif
   if has_key(l:list_title, "title") && l:list_title['title'] == "Format"
-    let l:listtype = go#list#Type("quickfix")
     call go#list#Clean(l:listtype)
     call go#list#Window(l:listtype)
   endif
@@ -245,7 +248,7 @@ endfunction
 " show_errors opens a location list and shows the given errors. If the given
 " errors is empty, it closes the the location list
 function! s:show_errors(errors) abort
-  let l:listtype = go#list#Type("quickfix")
+  let l:listtype = go#list#Type("GoFmt", "locationlist")
   if !empty(a:errors)
     call go#list#Populate(l:listtype, a:errors, 'Format')
     echohl Error | echomsg "Gofmt returned error" | echohl None

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -583,11 +583,12 @@ function! s:parse_guru_output(exit_val, output, title) abort
 
   let old_errorformat = &errorformat
   let errformat = "%f:%l.%c-%[%^:]%#:\ %m,%f:%l:%c:\ %m"
-  call go#list#ParseFormat("locationlist", errformat, a:output, a:title)
+  let l:listtype = go#list#Type("_guru", "locationlist")
+  call go#list#ParseFormat(l:listtype, errformat, a:output, a:title)
   let &errorformat = old_errorformat
 
-  let errors = go#list#Get("locationlist")
-  call go#list#Window("locationlist", len(errors))
+  let errors = go#list#Get(l:listtype)
+  call go#list#Window(l:listtype, len(errors))
 endfun
 
 function! go#guru#Scope(...) abort

--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -10,10 +10,15 @@ function go#job#Spawn(args)
         \ 'messages': [],
         \ 'args': a:args.cmd,
         \ 'bang': 0,
+        \ 'for': "quickfix",
         \ }
 
   if has_key(a:args, 'bang')
     let cbs.bang = a:args.bang
+  endif
+
+  if has_key(a:args, 'for')
+    let cbs.for = a:args.for
   endif
 
   " add final callback to be called if async job is finished
@@ -47,7 +52,7 @@ function go#job#Spawn(args)
       call self.custom_cb(a:job, a:exitval, self.messages)
     endif
 
-    let l:listtype = go#list#Type("quickfix")
+    let l:listtype = go#list#Type(self.for, "quickfix")
     if a:exitval == 0
       call go#list#Clean(l:listtype)
       call go#list#Window(l:listtype)

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -9,11 +9,11 @@ let s:handlers = {}
 " Spawn is a wrapper around s:spawn. It can be executed by other files and
 " scripts if needed. Desc defines the description for printing the status
 " during the job execution (useful for statusline integration).
-function! go#jobcontrol#Spawn(bang, desc, args) abort
+function! go#jobcontrol#Spawn(bang, desc, for, args) abort
   " autowrite is not enabled for jobs
   call go#cmd#autowrite()
 
-  let job = s:spawn(a:bang, a:desc, a:args)
+  let job = s:spawn(a:bang, a:desc, a:for, a:args)
   return job.id
 endfunction
 
@@ -37,7 +37,7 @@ endfunction
 " a job is started a reference will be stored inside s:jobs. spawn changes the
 " GOPATH when g:go_autodetect_gopath is enabled. The job is started inside the
 " current files folder.
-function! s:spawn(bang, desc, args) abort
+function! s:spawn(bang, desc, args, for) abort
   let status_type = a:args[0]
   let status_dir = expand('%:p:h')
   let started_at = reltime()
@@ -62,6 +62,7 @@ function! s:spawn(bang, desc, args) abort
         \ 'status_type' : status_type,
         \ 'status_dir' : status_dir,
         \ 'started_at' : started_at,
+        \ 'for' : a:for,
         \ }
 
   " modify GOPATH if needed
@@ -129,7 +130,7 @@ function! s:on_exit(job_id, exit_status, event) dict abort
 
   call s:callback_handlers_on_exit(s:jobs[a:job_id], a:exit_status, std_combined)
 
-  let l:listtype = go#list#Type("quickfix")
+  let l:listtype = go#list#Type(self.for, "quickfix")
   if a:exit_status == 0
     call go#list#Clean(l:listtype)
     call go#list#Window(l:listtype)

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -89,7 +89,7 @@ function! go#lint#Gometa(autosave, ...) abort
 
   let out = go#tool#ExecuteInDir(meta_command)
 
-  let l:listtype = "quickfix"
+  let l:listtype = go#list#Type("GoMetaLinter", "quickfix")
   if go#util#ShellError() == 0
     redraw | echo
     call go#list#Clean(l:listtype)
@@ -134,7 +134,7 @@ function! go#lint#Golint(...) abort
     return
   endif
 
-  let l:listtype = "quickfix"
+  let l:listtype = go#list#Type("GoLint", "quickfix")
   call go#list#Parse(l:listtype, out)
   let errors = go#list#Get(l:listtype)
   call go#list#Window(l:listtype, len(errors))
@@ -152,7 +152,7 @@ function! go#lint#Vet(bang, ...) abort
     let out = go#util#System('go tool vet ' . go#util#Shelljoin(a:000))
   endif
 
-  let l:listtype = "quickfix"
+  let l:listtype = go#list#Type("GoVet", "quickfix")
   if go#util#ShellError() != 0
     let errors = go#tool#ParseErrors(split(out, '\n'))
     call go#list#Populate(l:listtype, errors, 'Vet')
@@ -192,7 +192,7 @@ function! go#lint#Errcheck(...) abort
   let command =  go#util#Shellescape(bin_path) . ' -abspath ' . import_path
   let out = go#tool#ExecuteInDir(command)
 
-  let l:listtype = "quickfix"
+  let l:listtype = go#list#Type("GoErrCheck", "quickfix")
   if go#util#ShellError() != 0
     let errformat = "%f:%l:%c:\ %m, %f:%l:%c\ %#%m"
 
@@ -246,7 +246,7 @@ function s:lint_job(args)
   " autowrite is not enabled for jobs
   call go#cmd#autowrite()
 
-  let l:listtype = go#list#Type("quickfix")
+  let l:listtype = go#list#Type("GoMetaLinter", "quickfix")
   let l:errformat = '%f:%l:%c:%t%*[^:]:\ %m,%f:%l::%t%*[^:]:\ %m'
 
   function! s:callback(chan, msg) closure

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -12,7 +12,6 @@ endif
 " If no or zero height is given it closes the window by default.  
 " To prevent this, set g:go_list_autoclose = 0
 function! go#list#Window(listtype, ...) abort
-  let l:listtype = s:listtype(a:listtype)
   " we don't use lwindow to close the location list as we need also the
   " ability to resize the window. So, we are going to use lopen and lclose
   " for a better user experience. If the number of errors in a current
@@ -21,7 +20,7 @@ function! go#list#Window(listtype, ...) abort
   if !a:0 || a:1 == 0
     let autoclose_window = get(g:, 'go_list_autoclose', 1)
     if autoclose_window
-      if l:listtype == "locationlist"
+      if a:listtype == "locationlist"
         lclose
       else
         cclose
@@ -40,7 +39,7 @@ function! go#list#Window(listtype, ...) abort
     endif
   endif
 
-  if l:listtype == "locationlist"
+  if a:listtype == "locationlist"
     exe 'lopen ' . height
   else
     exe 'copen ' . height
@@ -48,20 +47,18 @@ function! go#list#Window(listtype, ...) abort
 endfunction
 
 
-" Get returns the current list of items from the location list
+" Get returns the current items from the list
 function! go#list#Get(listtype) abort
-  let l:listtype = s:listtype(a:listtype)
-  if l:listtype == "locationlist"
+  if a:listtype == "locationlist"
     return getloclist(0)
   else
     return getqflist()
   endif
 endfunction
 
-" Populate populate the location list with the given items
+" Populate populate the list with the given items
 function! go#list#Populate(listtype, items, title) abort
-  let l:listtype = s:listtype(a:listtype)
-  if l:listtype == "locationlist"
+  if a:listtype == "locationlist"
     call setloclist(0, a:items, 'r')
 
     " The last argument ({what}) is introduced with 7.4.2200:
@@ -73,20 +70,15 @@ function! go#list#Populate(listtype, items, title) abort
   endif
 endfunction
 
-function! go#list#PopulateWin(winnr, items) abort
-  call setloclist(a:winnr, a:items, 'r')
-endfunction
-
 " Parse parses the given items based on the specified errorformat and
-" populates the location list.
+" populates the list.
 function! go#list#ParseFormat(listtype, errformat, items, title) abort
-  let l:listtype = s:listtype(a:listtype)
   " backup users errorformat, will be restored once we are finished
   let old_errorformat = &errorformat
 
   " parse and populate the location list
   let &errorformat = a:errformat
-  if l:listtype == "locationlist"
+  if a:listtype == "locationlist"
     lgetexpr a:items
     if has("patch-7.4.2200") | call setloclist(0, [], 'a', {'title': a:title}) | endif
   else
@@ -99,10 +91,9 @@ function! go#list#ParseFormat(listtype, errformat, items, title) abort
 endfunction
 
 " Parse parses the given items based on the global errorformat and
-" populates the location list.
+" populates the list.
 function! go#list#Parse(listtype, items) abort
-  let l:listtype = s:listtype(a:listtype)
-  if l:listtype == "locationlist"
+  if a:listtype == "locationlist"
     lgetexpr a:items
   else
     cgetexpr a:items
@@ -111,8 +102,7 @@ endfunction
 
 " JumpToFirst jumps to the first item in the location list
 function! go#list#JumpToFirst(listtype) abort
-  let l:listtype = s:listtype(a:listtype)
-  if l:listtype == "locationlist"
+  if a:listtype == "locationlist"
     ll 1
   else
     cc 1
@@ -121,8 +111,7 @@ endfunction
 
 " Clean cleans the location list
 function! go#list#Clean(listtype) abort
-  let l:listtype = s:listtype(a:listtype)
-  if l:listtype == "locationlist"
+  if a:listtype == "locationlist"
     lex []
   else
     cex []

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -2,13 +2,17 @@ if !exists("g:go_list_type")
   let g:go_list_type = ""
 endif
 
+if !exists("g:go_list_type_commands")
+  let g:go_list_type_commands = {}
+endif
+
 " Window opens the list with the given height up to 10 lines maximum.
 " Otherwise g:go_loclist_height is used. 
 "
 " If no or zero height is given it closes the window by default.  
 " To prevent this, set g:go_list_autoclose = 0
 function! go#list#Window(listtype, ...) abort
-  let l:listtype = go#list#Type(a:listtype)
+  let l:listtype = s:listtype(a:listtype)
   " we don't use lwindow to close the location list as we need also the
   " ability to resize the window. So, we are going to use lopen and lclose
   " for a better user experience. If the number of errors in a current
@@ -46,7 +50,7 @@ endfunction
 
 " Get returns the current list of items from the location list
 function! go#list#Get(listtype) abort
-  let l:listtype = go#list#Type(a:listtype)
+  let l:listtype = s:listtype(a:listtype)
   if l:listtype == "locationlist"
     return getloclist(0)
   else
@@ -56,7 +60,7 @@ endfunction
 
 " Populate populate the location list with the given items
 function! go#list#Populate(listtype, items, title) abort
-  let l:listtype = go#list#Type(a:listtype)
+  let l:listtype = s:listtype(a:listtype)
   if l:listtype == "locationlist"
     call setloclist(0, a:items, 'r')
 
@@ -76,7 +80,7 @@ endfunction
 " Parse parses the given items based on the specified errorformat and
 " populates the location list.
 function! go#list#ParseFormat(listtype, errformat, items, title) abort
-  let l:listtype = go#list#Type(a:listtype)
+  let l:listtype = s:listtype(a:listtype)
   " backup users errorformat, will be restored once we are finished
   let old_errorformat = &errorformat
 
@@ -97,7 +101,7 @@ endfunction
 " Parse parses the given items based on the global errorformat and
 " populates the location list.
 function! go#list#Parse(listtype, items) abort
-  let l:listtype = go#list#Type(a:listtype)
+  let l:listtype = s:listtype(a:listtype)
   if l:listtype == "locationlist"
     lgetexpr a:items
   else
@@ -107,7 +111,7 @@ endfunction
 
 " JumpToFirst jumps to the first item in the location list
 function! go#list#JumpToFirst(listtype) abort
-  let l:listtype = go#list#Type(a:listtype)
+  let l:listtype = s:listtype(a:listtype)
   if l:listtype == "locationlist"
     ll 1
   else
@@ -117,7 +121,7 @@ endfunction
 
 " Clean cleans the location list
 function! go#list#Clean(listtype) abort
-  let l:listtype = go#list#Type(a:listtype)
+  let l:listtype = s:listtype(a:listtype)
   if l:listtype == "locationlist"
     lex []
   else
@@ -125,14 +129,18 @@ function! go#list#Clean(listtype) abort
   endif
 endfunction
 
-function! go#list#Type(listtype) abort
+function! s:listtype(listtype) abort
   if g:go_list_type == "locationlist"
     return "locationlist"
   elseif g:go_list_type == "quickfix"
     return "quickfix"
-  else
-    return a:listtype
   endif
+
+  return a:listtype
 endfunction
 
+function! go#list#Type(for, default) abort
+  let l:listtype = s:listtype(a:default)
+  return get(g:go_list_type_commands, a:for, l:listtype)
+endfunction
 " vim: sw=2 ts=2 et

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -117,7 +117,7 @@ function s:parse_errors(exit_val, bang, out)
   silent! checktime
   let &autoread = current_autoread
 
-  let l:listtype = "quickfix"
+  let l:listtype = go#list#Type("GoRename", "quickfix")
   if a:exit_val != 0
     call go#util#EchoError("FAILED")
     let errors = go#tool#ParseErrors(a:out)

--- a/autoload/go/tags.vim
+++ b/autoload/go/tags.vim
@@ -95,7 +95,7 @@ func s:write_out(out) abort
 
   if has_key(result, 'errors')
     let l:winnr = winnr()
-    let l:listtype = go#list#Type("quickfix")
+    let l:listtype = go#list#TypeFor("GoModifyTags", "quickfix")
     call go#list#ParseFormat(l:listtype, "%f:%l:%c:%m", result['errors'], "gomodifytags")
     call go#list#Window(l:listtype, len(result['errors']))
 

--- a/autoload/go/tags.vim
+++ b/autoload/go/tags.vim
@@ -95,7 +95,7 @@ func s:write_out(out) abort
 
   if has_key(result, 'errors')
     let l:winnr = winnr()
-    let l:listtype = go#list#TypeFor("GoModifyTags", "quickfix")
+    let l:listtype = go#list#Type("GoModifyTags", "quickfix")
     call go#list#ParseFormat(l:listtype, "%f:%l:%c:%m", result['errors'], "gomodifytags")
     call go#list#Window(l:listtype, len(result['errors']))
 

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -104,7 +104,7 @@ function! s:on_exit(job_id, exit_status, event) dict abort
   endif
   let job = s:jobs[a:job_id]
 
-  let l:listtype = "locationlist"
+  let l:listtype = go#list#Type("_term", "locationlist")
 
   " usually there is always output so never branch into this clause
   if empty(job.stdout)

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -69,7 +69,7 @@ function! go#test#Test(bang, compile, ...) abort
   let command = "go " . join(args, ' ')
   let out = go#tool#ExecuteInDir(command)
 
-  let l:listtype = go#list#TypeFor("GoTest", "quickfix")
+  let l:listtype = go#list#Type("GoTest", "quickfix")
 
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
   let dir = getcwd()
@@ -188,7 +188,7 @@ function s:test_job(args) abort
 
     call go#statusline#Update(status_dir, status)
 
-    let l:listtype = go#list#TypeFor("GoTest", "quickfix")
+    let l:listtype = go#list#Type("GoTest", "quickfix")
     if a:exitval == 0
       call go#list#Clean(l:listtype)
       call go#list#Window(l:listtype)
@@ -224,7 +224,7 @@ endfunction
 " a quickfix compatible list of errors. It's intended to be used only for go
 " test output. 
 function! s:show_errors(args, exit_val, messages) abort
-  let l:listtype = go#list#TypeFor("GoTest", "quickfix")
+  let l:listtype = go#list#Type("GoTest", "quickfix")
 
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
   try

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -57,7 +57,7 @@ function! go#test#Test(bang, compile, ...) abort
     if get(g:, 'go_term_enabled', 0)
       let id = go#term#new(a:bang, ["go"] + args)
     else
-      let id = go#jobcontrol#Spawn(a:bang, "test", args)
+      let id = go#jobcontrol#Spawn(a:bang, "test", "GoTest", args)
     endif
 
     return id
@@ -69,7 +69,7 @@ function! go#test#Test(bang, compile, ...) abort
   let command = "go " . join(args, ' ')
   let out = go#tool#ExecuteInDir(command)
 
-  let l:listtype = "quickfix"
+  let l:listtype = go#list#TypeFor("GoTest", "quickfix")
 
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
   let dir = getcwd()
@@ -188,7 +188,7 @@ function s:test_job(args) abort
 
     call go#statusline#Update(status_dir, status)
 
-    let l:listtype = go#list#Type("quickfix")
+    let l:listtype = go#list#TypeFor("GoTest", "quickfix")
     if a:exitval == 0
       call go#list#Clean(l:listtype)
       call go#list#Window(l:listtype)
@@ -224,7 +224,7 @@ endfunction
 " a quickfix compatible list of errors. It's intended to be used only for go
 " test output. 
 function! s:show_errors(args, exit_val, messages) abort
-  let l:listtype = go#list#Type("quickfix")
+  let l:listtype = go#list#TypeFor("GoTest", "quickfix")
 
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
   try

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1134,7 +1134,7 @@ The dictionary version allows you to define options for multiple binaries:
 <
                                                     *'g:go_fmt_fail_silently'*
 
-Use this option to disable showing a quickfix list when |'g:go_fmt_command'|
+Use this option to disable showing a location list when |'g:go_fmt_command'|
 fails. By default the location list is shown. >
 
   let g:go_fmt_fail_silently = 0
@@ -1418,11 +1418,25 @@ explicitly overrides this behavior. For standard Vim behavior, set it to 10.
                                                             *'g:go_list_type'*
 
 Specifies the type of list to use for command outputs (such as errors from
-builds, results from static analysis commands, etc...). The default value
+builds, results from static analysis commands, etc...) when a value is not
+specified for the command in g:go_list_type_commands. The default value
 (empty) will use the appropriate kind of list for the command that was called.
 Supported values are "", "quickfix", and "locationlist". >
 
   let g:go_list_type = ""
+<
+
+                                                   *'g:go_list_type_commands'*
+
+Specifies the type of list to use for command outputs (such as errors from
+builds, results from static analysis commands, etc...). The default value
+(an empty dictionary) will use the appropriate kind of list for the command
+that was called. Supported keys are "GoBuild", "GoErrCheck", "GoFmt",
+"GoInstall", "GoLint", "GoMetaLinter", "GoModifyTags", "GoRun", and "GoTest".
+Supported values for each command are "quickfix" and "locationlist".
+
+>
+  let g:go_list_type_commands = {}
 <
 
                                                        *'g:go_list_autoclose'*

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1432,8 +1432,9 @@ Specifies the type of list to use for command outputs (such as errors from
 builds, results from static analysis commands, etc...). The default value
 (an empty dictionary) will use the appropriate kind of list for the command
 that was called. Supported keys are "GoBuild", "GoErrCheck", "GoFmt",
-"GoInstall", "GoLint", "GoMetaLinter", "GoModifyTags", "GoRun", and "GoTest".
-Supported values for each command are "quickfix" and "locationlist".
+"GoInstall", "GoLint", "GoMetaLinter", "GoModifyTags" (used for both
+:GoAddTags and :GoRemoveTags), "GoRename", "GoRun", and "GoTest".  Supported
+values for each command are "quickfix" and "locationlist".
 
 >
   let g:go_list_type_commands = {}

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1418,24 +1418,23 @@ explicitly overrides this behavior. For standard Vim behavior, set it to 10.
                                                             *'g:go_list_type'*
 
 Specifies the type of list to use for command outputs (such as errors from
-builds, results from static analysis commands, etc...) when a value is not
-specified for the command in g:go_list_type_commands. The default value
-(empty) will use the appropriate kind of list for the command that was called.
-Supported values are "", "quickfix", and "locationlist". >
-
+builds, results from static analysis commands, etc...). The list type for
+specific commands can be overridden with |'g:go_list_type_commands'|. The
+default value (empty) will use the appropriate kind of list for the command
+that was called. Supported values are "", "quickfix", and "locationlist". 
+>
   let g:go_list_type = ""
 <
 
                                                    *'g:go_list_type_commands'*
 
 Specifies the type of list to use for command outputs (such as errors from
-builds, results from static analysis commands, etc...). The default value
-(an empty dictionary) will use the appropriate kind of list for the command
-that was called. Supported keys are "GoBuild", "GoErrCheck", "GoFmt",
-"GoInstall", "GoLint", "GoMetaLinter", "GoModifyTags" (used for both
-:GoAddTags and :GoRemoveTags), "GoRename", "GoRun", and "GoTest".  Supported
-values for each command are "quickfix" and "locationlist".
-
+builds, results from static analysis commands, etc...). When an expected key
+is not present in the dictionary, |'g:go_list_type'| will be used instead.
+Supported keys are "GoBuild", "GoErrCheck", "GoFmt", "GoInstall", "GoLint",
+"GoMetaLinter", "GoModifyTags" (used for both :GoAddTags and :GoRemoveTags),
+"GoRename", "GoRun", and "GoTest".  Supported values for each command are
+"quickfix" and "locationlist".
 >
   let g:go_list_type_commands = {}
 <


### PR DESCRIPTION
Add a new setting, `g:go_list_type_commands`: a dictionary
whose entries allows users to customize whether to use the quickfix list
or the location list for each command. The dictionary does not require
an entry for every command; only those the user wants to specify.

When g:go_list_type is set and g:go_list_type_commands contains an entry
for a command, go:go_list_type_commands takes precedence.

I'm not totally happy with the keys for the commands in the `g:go_list_type_commands` dictionary. Currently the entries map very closely to the commands (e.g. `:GoBuild`), providing an easy to understand set of keys for most users. Unfortunately, the `GoModifyTags` entry applies to both `:GoRemoveTags` and `:GoAddTags` commands, because the way those two commands are implemented makes it a little difficult to vary the key used and also because it seemed strange to allow those two commands to use different lists since they are each other's inverse.

I considered using a smaller set of keys that are more closely aligned with the general class of command that needs to use the key (e.g. `build`, `install`, `fmt`, `lint`, `modifytags`) instead of the specific command that needs to use the key. Such a scheme would use a single key, `lint`, for all linting commands (e.g. `:GoMetaLinter`, `:GoLint`, `:GoErrCheck`)...

I'm open to suggestions on the key names and how much documentation there should be for them.

I could also use some help testing this, since there's different code paths for Vim 7, Vim 8, and Neovim.

Fixes #1408