### PR TITLE
Set environment variable to allow focused ginkgo tests to be ran inside an editor

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -212,4 +212,7 @@ augroup vim-go
   autocmd BufWinEnter *.go call go#guru#ClearSameIds()
 augroup END
 
+" set environment variable to allow ginkgo to be ran inside an editor
+let $GINKGO_EDITOR_INTEGRATION = "true"
+
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
This allows focused ginkgo tests to be ran inside vim. Without this environment variable ginkgo will return an exit code when test are ran that are focused.

Related PR in ginkgo: https://github.com/onsi/ginkgo/pull/367

I wasn't quite sure where to add this. I attempted to use the `env` job option to `job_start` but that isn't available in my vim version (`VIM - Vi IMproved 8.0 (2016 Sep 12, compiled Mar  1 2017 18:53:35)`). I tried shelling out and setting the variable as an argument but I figured you would not want to add a shell process to the mix. This seemed to be the least invasive and works. I'm open to ideas though.

