### PR TITLE
Vim syntax match for variable definitions

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1332,6 +1332,13 @@ By default it's enabled. >
 
   let g:go_highlight_format_strings = 1
 <
+                                      *'g:go_highlight_variable_declarations'*
+
+Highlight variable declarations (`:=`). Variable assignments (`=`) are not
+highlighted. By default it's disabled. >
+
+  let g:go_highlight_variable_declarations = 0
+<
                                                     *'g:go_autodetect_gopath'*
 
 Automatically modifies GOPATH for certain directory structures, such as for

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -389,6 +389,7 @@ hi def link     goDeclType          Keyword
 " Variable Declarations
 if g:go_highlight_variable_declarations != 0
   syn match goVarDefs /\v\w+(,\s*\w+)*\ze(\s*:\=)/
+  hi def link   goVarDefs           Special
 endif
 
 " Build Constraints

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -388,7 +388,7 @@ hi def link     goDeclType          Keyword
 
 " Variable Declarations
 if g:go_highlight_variable_declarations != 0
-  syn match goVarDefs /\w\+\(,\s*\w+\)*\s*\ze:=/
+  syn match goVarDefs /\v\w+(,\s*\w+)*\ze(\s*:\=)/
 endif
 
 " Build Constraints

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -89,6 +89,10 @@ if !exists("g:go_highlight_generate_tags")
   let g:go_highlight_generate_tags = 0
 endif
 
+if !exists("g:go_highlight_variable_declarations")
+  let g:go_highlight_variable_declarations = 0
+endif
+
 let s:fold_block = 1
 let s:fold_import = 1
 let s:fold_varconst = 1
@@ -383,7 +387,9 @@ hi def link     goTypeDecl          Keyword
 hi def link     goDeclType          Keyword
 
 " Variable Declarations
-syn match goVarDefs /\w\+\(,\s*\w+\)*\s*\ze:=/
+if g:go_highlight_variable_declarations != 0
+  syn match goVarDefs /\w\+\(,\s*\w+\)*\s*\ze:=/
+endif
 
 " Build Constraints
 if g:go_highlight_build_constraints != 0


### PR DESCRIPTION
This adds a match for variable definitions so that they can be highlighted using a color scheme. Variable definitions are the `foo` and `bar` in:

    foo := ...
    foo, bar := ...