### PR TITLE
Fix go#package#FromPath()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ type foo struct{
 * Run `:GoMetaLinter` against the package of the open file #1414.
 * The `g:go_doc_command` and `g:go_doc_options` to configure the command for
   `:GoDoc` were documented but never referenced #1420.
+* `go#package#FromPath()` didn't work correctly #1435.
 
 BACKWARDS INCOMPATIBILITIES:
 

--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -80,6 +80,7 @@ function! go#package#FromPath(arg) abort
   for dir in dirs
     if len(dir) && match(path, dir) == 0
       let workspace = dir
+      break
     endif
   endfor
 
@@ -87,10 +88,12 @@ function! go#package#FromPath(arg) abort
     return -1
   endif
 
+  let path = substitute(path, '/*$', '', '')
+  let workspace = substitute(workspace . '/src/', '/+', '', '')
   if isdirectory(path)
-    return substitute(path, workspace . 'src/', '', '')
+    return substitute(path, workspace, '', '')
   else
-    return substitute(substitute(path, workspace . 'src/', '', ''),
+    return substitute(substitute(path, workspace, '', ''),
           \ '/' . fnamemodify(path, ':t'), '', '')
   endif
 endfunction


### PR DESCRIPTION
This didn't work at all on my system. Turned out the problem was that on
my system (Linux) some paths didn't have a trailing slash, so
`workspace` would be `/home/martin/gosrc`.

This makes sure that it always works, no matter if a trailing slash is
present or not.

Also `break` from the loop on the first match, so it selects the
*first* package found in GOPATH rather than the *last*. This is also how
imports in Go behave.