### PR TITLE
Consolidate list type command keys

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -49,7 +49,7 @@ function! go#cmd#Build(bang, ...) abort
   let default_makeprg = &makeprg
   let &makeprg = "go " . join(args, ' ')
 
-  let l:listtype = go#list#Type("GoBuild", "quickfix")
+  let l:listtype = go#list#Type("GoBuild")
   " execute make inside the source folder so we can parse the errors
   " correctly
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
@@ -150,7 +150,7 @@ function! go#cmd#Run(bang, ...) abort
     let &makeprg = "go run " . go#util#Shelljoin(map(copy(a:000), "expand(v:val)"), 1)
   endif
 
-  let l:listtype = go#list#Type("GoRun", "quickfix")
+  let l:listtype = go#list#Type("GoRun")
 
   if l:listtype == "locationlist"
     exe 'lmake!'
@@ -200,7 +200,7 @@ function! go#cmd#Install(bang, ...) abort
   let goargs = go#util#Shelljoin(map(copy(a:000), "expand(v:val)"), 1)
   let &makeprg = "go install " . goargs
 
-  let l:listtype = go#list#Type("GoInstall", "quickfix")
+  let l:listtype = go#list#Type("GoInstall")
   " execute make inside the source folder so we can parse the errors
   " correctly
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
@@ -245,7 +245,7 @@ function! go#cmd#Generate(bang, ...) abort
     let &makeprg = "go generate " . goargs . ' ' . gofiles
   endif
 
-  let l:listtype = go#list#Type("GoGenerate", "quickfix")
+  let l:listtype = go#list#Type("GoGenerate")
 
   echon "vim-go: " | echohl Identifier | echon "generating ..."| echohl None
   if l:listtype == "locationlist"

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -134,7 +134,7 @@ function! go#fmt#update_file(source, target)
   endif
 
   " clean up previous list
-  let l:listtype = go#list#Type("GoFmt", "locationlist")
+  let l:listtype = go#list#Type("GoFmt")
   if l:listtype == "quickfix"
     let l:list_title = getqflist({'title': 1})
   else
@@ -248,7 +248,7 @@ endfunction
 " show_errors opens a location list and shows the given errors. If the given
 " errors is empty, it closes the the location list
 function! s:show_errors(errors) abort
-  let l:listtype = go#list#Type("GoFmt", "locationlist")
+  let l:listtype = go#list#Type("GoFmt")
   if !empty(a:errors)
     call go#list#Populate(l:listtype, a:errors, 'Format')
     echohl Error | echomsg "Gofmt returned error" | echohl None

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -590,7 +590,7 @@ function! s:parse_guru_output(exit_val, output, title) abort
 
   let old_errorformat = &errorformat
   let errformat = "%f:%l.%c-%[%^:]%#:\ %m,%f:%l:%c:\ %m"
-  let l:listtype = go#list#Type("_guru", "locationlist")
+  let l:listtype = go#list#Type("_guru")
   call go#list#ParseFormat(l:listtype, errformat, a:output, a:title)
   let &errorformat = old_errorformat
 

--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -10,7 +10,7 @@ function go#job#Spawn(args)
         \ 'messages': [],
         \ 'args': a:args.cmd,
         \ 'bang': 0,
-        \ 'for': "quickfix",
+        \ 'for': "_job",
         \ }
 
   if has_key(a:args, 'bang')
@@ -52,7 +52,7 @@ function go#job#Spawn(args)
       call self.custom_cb(a:job, a:exitval, self.messages)
     endif
 
-    let l:listtype = go#list#Type(self.for, "quickfix")
+    let l:listtype = go#list#Type(self.for)
     if a:exitval == 0
       call go#list#Clean(l:listtype)
       call go#list#Window(l:listtype)

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -130,7 +130,7 @@ function! s:on_exit(job_id, exit_status, event) dict abort
 
   call s:callback_handlers_on_exit(s:jobs[a:job_id], a:exit_status, std_combined)
 
-  let l:listtype = go#list#Type(self.for, "quickfix")
+  let l:listtype = go#list#Type(self.for)
   if a:exit_status == 0
     call go#list#Clean(l:listtype)
     call go#list#Window(l:listtype)

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -89,7 +89,7 @@ function! go#lint#Gometa(autosave, ...) abort
 
   let out = go#util#System(meta_command)
 
-  let l:listtype = go#list#Type("GoMetaLinter", "quickfix")
+  let l:listtype = go#list#Type("GoMetaLinter")
   if go#util#ShellError() == 0
     redraw | echo
     call go#list#Clean(l:listtype)
@@ -134,7 +134,7 @@ function! go#lint#Golint(...) abort
     return
   endif
 
-  let l:listtype = go#list#Type("GoLint", "quickfix")
+  let l:listtype = go#list#Type("GoLint")
   call go#list#Parse(l:listtype, out)
   let errors = go#list#Get(l:listtype)
   call go#list#Window(l:listtype, len(errors))
@@ -152,7 +152,7 @@ function! go#lint#Vet(bang, ...) abort
     let out = go#util#System('go tool vet ' . go#util#Shelljoin(a:000))
   endif
 
-  let l:listtype = go#list#Type("GoVet", "quickfix")
+  let l:listtype = go#list#Type("GoVet")
   if go#util#ShellError() != 0
     let errors = go#tool#ParseErrors(split(out, '\n'))
     call go#list#Populate(l:listtype, errors, 'Vet')
@@ -192,7 +192,7 @@ function! go#lint#Errcheck(...) abort
   let command =  go#util#Shellescape(bin_path) . ' -abspath ' . import_path
   let out = go#tool#ExecuteInDir(command)
 
-  let l:listtype = go#list#Type("GoErrCheck", "quickfix")
+  let l:listtype = go#list#Type("GoErrCheck")
   if go#util#ShellError() != 0
     let errformat = "%f:%l:%c:\ %m, %f:%l:%c\ %#%m"
 
@@ -246,7 +246,7 @@ function s:lint_job(args)
   " autowrite is not enabled for jobs
   call go#cmd#autowrite()
 
-  let l:listtype = go#list#Type("GoMetaLinter", "quickfix")
+  let l:listtype = go#list#Type("GoMetaLinter")
   let l:errformat = '%f:%l:%c:%t%*[^:]:\ %m,%f:%l::%t%*[^:]:\ %m'
 
   function! s:callback(chan, msg) closure

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -128,8 +128,37 @@ function! s:listtype(listtype) abort
   return a:listtype
 endfunction
 
-function! go#list#Type(for, default) abort
-  let l:listtype = s:listtype(a:default)
+" s:default_list_type_commands is the defaults that will be used for each of
+" the supported commands (see documentation for g:go_list_type_commands). When
+" defining a default, quickfix should be used if the command operates on
+" multiple files, while locationlist should be used if the command operates on a
+" single file or buffer. Keys that begin with an underscore are not supported
+" in g:go_list_type_commands.
+let s:default_list_type_commands = {
+  "GoBuild": "quickfix",
+  "GoErrCheck": "quickfix",
+  "GoFmt": "locationlist",
+  "GoGenerate": "quickfix",
+  "GoInstall": "quickfix",
+  "GoLint": "quickfix",
+  "GoMetaLinter": "quickfix",
+  "GoModifyTags": "quickfix",
+  "GoRename": "quickfix",
+  "GoRun": "quickfix",
+  "GoTest", "quickfix",
+  "GoVet": "quickfix",
+  "_guru", "locationlist",
+  "_term": "locationlist",
+}
+
+function! go#list#Type(for) abort
+  let l:listtype = s:listtype(get(s:default_list_type_commands, a:for))
+  if l:listtype == 0
+    call go#util#EchoError(printf("unknown list type command value found ('%s)'. Please open a bug report in the vim-go repo.", a:for))
+    let l:listtype = "quickfix"
+  endif
+
   return get(g:go_list_type_commands, a:for, l:listtype)
 endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -142,7 +142,7 @@ let s:default_list_type_commands = {
   "GoInstall": "quickfix",
   "GoLint": "quickfix",
   "GoMetaLinter": "quickfix",
-  "GoModifyTags": "quickfix",
+  "GoModifyTags": "locationlist",
   "GoRename": "quickfix",
   "GoRun": "quickfix",
   "GoTest", "quickfix",

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -117,7 +117,7 @@ function s:parse_errors(exit_val, bang, out)
   silent! checktime
   let &autoread = current_autoread
 
-  let l:listtype = go#list#Type("GoRename", "quickfix")
+  let l:listtype = go#list#Type("GoRename")
   if a:exit_val != 0
     call go#util#EchoError("FAILED")
     let errors = go#tool#ParseErrors(a:out)

--- a/autoload/go/tags.vim
+++ b/autoload/go/tags.vim
@@ -95,7 +95,7 @@ func s:write_out(out) abort
 
   if has_key(result, 'errors')
     let l:winnr = winnr()
-    let l:listtype = go#list#Type("GoModifyTags", "quickfix")
+    let l:listtype = go#list#Type("GoModifyTags")
     call go#list#ParseFormat(l:listtype, "%f:%l:%c:%m", result['errors'], "gomodifytags")
     call go#list#Window(l:listtype, len(result['errors']))
 

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -105,7 +105,7 @@ function! s:on_exit(job_id, exit_status, event) dict abort
   endif
   let job = s:jobs[a:job_id]
 
-  let l:listtype = go#list#Type("_term", "locationlist")
+  let l:listtype = go#list#Type("_term")
 
   " usually there is always output so never branch into this clause
   if empty(job.stdout)

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -69,7 +69,7 @@ function! go#test#Test(bang, compile, ...) abort
   let command = "go " . join(args, ' ')
   let out = go#tool#ExecuteInDir(command)
 
-  let l:listtype = go#list#Type("GoTest", "quickfix")
+  let l:listtype = go#list#Type("GoTest")
 
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
   let dir = getcwd()
@@ -188,7 +188,7 @@ function s:test_job(args) abort
 
     call go#statusline#Update(status_dir, status)
 
-    let l:listtype = go#list#Type("GoTest", "quickfix")
+    let l:listtype = go#list#Type("GoTest")
     if a:exitval == 0
       call go#list#Clean(l:listtype)
       call go#list#Window(l:listtype)
@@ -224,7 +224,7 @@ endfunction
 " a quickfix compatible list of errors. It's intended to be used only for go
 " test output. 
 function! s:show_errors(args, exit_val, messages) abort
-  let l:listtype = go#list#Type("GoTest", "quickfix")
+  let l:listtype = go#list#Type("GoTest")
 
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
   try


### PR DESCRIPTION
Refactor go#list#Type for maintainability. Instead of having the
supported keys (both internally and externally supported) spread
throughout the code, use a single map that contains the keys and their
defaults in autoload/go/list.vim.

Refactor go#list#Type so that it is aware of the map of default values
and does not need its second parameter.

After refactoring, I realized that the default list type for `GoAddTags` and `GoRemoveTags` should be `locationlist` instead of `quickfix`, so I made that change, too.
