### PR TITLE
Fix :GoBuild shell escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ BUG FIXES:
 * The `gohtmltmpl` filetype now sources the `html` ftplugin, so that `matchit`,
   completion, and some other things work better.
   [[GH-1442]](https://github.com/fatih/vim-go/pull/1442)
+* Fix `:GoBuild` shell escaping [[GH-1450]](https://github.com/fatih/vim-go/pull/1450).
 
 BACKWARDS INCOMPATIBILITIES:
 


### PR DESCRIPTION
There was a stray `go#util#Shelllist()` in there. As near as I can tell
this isn't needed at all. Probably a left-over from some earlier
version?

Also move the non-async code in an `else`, I think this makes it a lot
clearer which code path does what. The two early returns were kinda
confusing.

Tested with Vim 8, 7.4, and Neovim, and seems to work well.

Fixes #1404