### PR TITLE
fix default command list types dictionary

### DIFF
--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -135,26 +135,26 @@ endfunction
 " single file or buffer. Keys that begin with an underscore are not supported
 " in g:go_list_type_commands.
 let s:default_list_type_commands = {
-  "GoBuild": "quickfix",
-  "GoErrCheck": "quickfix",
-  "GoFmt": "locationlist",
-  "GoGenerate": "quickfix",
-  "GoInstall": "quickfix",
-  "GoLint": "quickfix",
-  "GoMetaLinter": "quickfix",
-  "GoModifyTags": "locationlist",
-  "GoRename": "quickfix",
-  "GoRun": "quickfix",
-  "GoTest", "quickfix",
-  "GoVet": "quickfix",
-  "_guru", "locationlist",
-  "_term": "locationlist",
-}
+\  "GoBuild": "quickfix",
+\  "GoErrCheck": "quickfix",
+\  "GoFmt": "locationlist",
+\  "GoGenerate": "quickfix",
+\  "GoInstall": "quickfix",
+\  "GoLint": "quickfix",
+\  "GoMetaLinter": "quickfix",
+\  "GoModifyTags": "locationlist",
+\  "GoRename": "quickfix",
+\  "GoRun": "quickfix",
+\  "GoTest": "quickfix",
+\  "GoVet": "quickfix",
+\  "_guru": "locationlist",
+\  "_term": "locationlist",
+\}
 
 function! go#list#Type(for) abort
-  let l:listtype = s:listtype(get(s:default_list_type_commands, a:for))
-  if l:listtype == 0
-    call go#util#EchoError(printf("unknown list type command value found ('%s)'. Please open a bug report in the vim-go repo.", a:for))
+  let l:listtype = s:listtype(get(s:default_list_type_commands, a:for, ""))
+  if l:listtype == ""
+    call go#util#EchoError(printf("unknown list type command value found ('%s'). Please open a bug report in the vim-go repo.", a:for))
     let l:listtype = "quickfix"
   endif
 


### PR DESCRIPTION
Fixes #1452 

Sorry about that. When I was testing the changes for #1449, I forgot to update my runtimepath to test from the repo instead of my normal copy of vim-go.