### PR TITLE
Show multiline errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,17 @@ IMPROVEMENTS:
   easier to use [[GH-1386]](https://github.com/fatih/vim-go/pull/1386)
 * `:GoDef` sets the path of new buffers as relative to the current directory
   when appropriate, instead of always using the full path [[GH-1277]](https://github.com/fatih/vim-go/pull/1277).
-* Syntax highlighting for variable declarations (disabled by default) [[GH-1426]](https://github.com/fatih/vim-go/pull/1426).
+* Syntax highlighting for variable declarations and assignments (disabled by default)
+  [[GH-1426]](https://github.com/fatih/vim-go/pull/1426) and
+  [[GH-1458]](https://github.com/fatih/vim-go/pull/1458).
+
 * Add support for `:GoDecls[Dir]` in [unite.vim](https://github.com/Shougo/unite.vim) [[GH-1391]](https://github.com/fatih/vim-go/pull/1391).
 * Support relative imports for `:GoImpl` [[GH-1322]](https://github.com/fatih/vim-go/pull/1322).
 * A new `g:go_list_type_commands` setting is added to individually set the list type for each command [[GH-1415]](https://github.com/fatih/vim-go/pull/1415). As en example:
 
         let g:go_list_type_commands = {"GoBuild": "quickfix", "GoTest": "locationlist"}
-
-* Variable assignments are highlighted when `g:go_highlight_variable_assignments` is enabled [[GH-1458]](https://github.com/fatih/vim-go/pull/1458)
+* Show unexpected errors better by expanding newlines and tabs
+  [[GH-1456]](https://github.com/fatih/vim-go/pull/1456).
 
 BUG FIXES:
 

--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -74,8 +74,7 @@ function go#job#Spawn(args)
 
     if !len(errors)
       " failed to parse errors, output the original content
-      call go#util#EchoError(join(self.messages, " "))
-      call go#util#EchoError(self.dir)
+      call go#util#EchoError(self.messages + [self.dir])
       return
     endif
 

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -127,7 +127,7 @@ function s:parse_errors(exit_val, bang, out)
       call go#list#JumpToFirst(l:listtype)
     elseif empty(errors)
       " failed to parse errors, output the original content
-      call go#util#EchoError(join(a:out, ""))
+      call go#util#EchoError(a:out)
     endif
 
     return

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -237,7 +237,7 @@ function! s:show_errors(args, exit_val, messages) abort
 
   if !len(errors)
     " failed to parse errors, output the original content
-    call go#util#EchoError(join(a:messages, " "))
+    call go#util#EchoError(a:messages)
     call go#util#EchoError(a:args.dir)
     return
   endif

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -280,11 +280,21 @@ function! s:echo(msg, hi)
   echohl None
 endfunction
 
-fu! go#util#EchoSuccess(msg)  | call s:echo(a:msg, 'Function')   | endfu
-fu! go#util#EchoError(msg)    | call s:echo(a:msg, 'ErrorMsg')   | endfu
-fu! go#util#EchoWarning(msg)  | call s:echo(a:msg, 'WarningMsg') | endfu
-fu! go#util#EchoProgress(msg) | call s:echo(a:msg, 'Identifier') | endfu
-fu! go#util#EchoInfo(msg)     | call s:echo(a:msg, 'Debug')      | endfu
+function! go#util#EchoSuccess(msg)
+  call s:echo(a:msg, 'Function')
+endfunction
+function! go#util#EchoError(msg)
+  call s:echo(a:msg, 'ErrorMsg')
+endfunction
+function! go#util#EchoWarning(msg)
+  call s:echo(a:msg, 'WarningMsg')
+endfunction
+function! go#util#EchoProgress(msg)
+  call s:echo(a:msg, 'Identifier')
+endfunction
+function! go#util#EchoInfo(msg)
+  call s:echo(a:msg, 'Debug')
+endfunction
 
 function! go#util#GetLines()
   let buf = getline(1, '$')

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -261,30 +261,30 @@ function! go#util#camelcase(word) abort
   endif
 endfunction
 
-" TODO(arslan): I couldn't parameterize the highlight types. Check if we can
-" simplify the following functions
+" Echo a message to the screen and highlight it with the group in a:hi.
 "
-" NOTE(arslan): echon doesn't work well with redraw, thus echo doesn't print
-" even though we order it. However echom seems to be work fine.
-function! go#util#EchoSuccess(msg)
-  redraw | echohl Function | echom "vim-go: " . a:msg | echohl None
+" The message can be a list or string; every line with be :echomsg'd separately.
+function! s:echo(msg, hi)
+  let l:msg = a:msg
+  if type(l:msg) != v:t_list
+    let l:msg = split(l:msg, "\n")
+  endif
+
+  " Tabs display as ^I or <09>, so manually expand them.
+  let l:msg = map(l:msg, 'substitute(v:val, "\t", "        ", "")')
+
+  exe 'echohl ' . a:hi
+  for line in l:msg
+    echom "vim-go: " . line
+  endfor
+  echohl None
 endfunction
 
-function! go#util#EchoError(msg)
-  redraw | echohl ErrorMsg | echom "vim-go: " . a:msg | echohl None
-endfunction
-
-function! go#util#EchoWarning(msg)
-  redraw | echohl WarningMsg | echom "vim-go: " . a:msg | echohl None
-endfunction
-
-function! go#util#EchoProgress(msg)
-  redraw | echohl Identifier | echom "vim-go: " . a:msg | echohl None
-endfunction
-
-function! go#util#EchoInfo(msg)
-  redraw | echohl Debug | echom "vim-go: " . a:msg | echohl None
-endfunction
+fu! go#util#EchoSuccess(msg)  | call s:echo(a:msg, 'Function')   | endfu
+fu! go#util#EchoError(msg)    | call s:echo(a:msg, 'ErrorMsg')   | endfu
+fu! go#util#EchoWarning(msg)  | call s:echo(a:msg, 'WarningMsg') | endfu
+fu! go#util#EchoProgress(msg) | call s:echo(a:msg, 'Identifier') | endfu
+fu! go#util#EchoInfo(msg)     | call s:echo(a:msg, 'Debug')      | endfu
 
 function! go#util#GetLines()
   let buf = getline(1, '$')


### PR DESCRIPTION
Unlike `:echo`, `:echom` is rather stupid. It will display a newline as
`^@` or `<00>` and tabs as `^I` or `<09>` (depending on the `display`
setting).

This some messages display nicer, for example `:GoBuild --` looked
rather confusing before, and looks as expected now.

Before:
![2017-09-15-081920_1920x1080_scrot](https://user-images.githubusercontent.com/1032692/30471364-68ac0342-99f0-11e7-93fb-24fb6155d9ab.png)

After:
![2017-09-15-081934_1920x1080_scrot](https://user-images.githubusercontent.com/1032692/30471366-68cac12e-99f0-11e7-99bc-1f1b8cbb8279.png)

Needs some more testing (Vim 7.4, Neovim), but seems to work well.

This fixes some – but not all – of #1429.