### PR TITLE
Variable assignments syntax highlighting

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1358,10 +1358,15 @@ By default it's enabled. >
 <
                                       *'g:go_highlight_variable_declarations'*
 
-Highlight variable declarations (`:=`). Variable assignments (`=`) are not
-highlighted. By default it's disabled. >
+Highlight variable declarations (`:=`). By default it's disabled. >
 
   let g:go_highlight_variable_declarations = 0
+<
+                                      *'g:go_highlight_variable_assignments'*
+
+Highlight variable assignments (`=`). By default it's disabled. >
+
+  let g:go_highlight_variable_assignments = 0
 <
                                                     *'g:go_autodetect_gopath'*
 

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -89,6 +89,10 @@ if !exists("g:go_highlight_generate_tags")
   let g:go_highlight_generate_tags = 0
 endif
 
+if !exists("g:go_highlight_variable_assignments")
+  let g:go_highlight_variable_assignments = 0
+endif
+
 if !exists("g:go_highlight_variable_declarations")
   let g:go_highlight_variable_declarations = 0
 endif
@@ -403,6 +407,12 @@ hi def link     goTypeConstructor   Type
 hi def link     goTypeName          Type
 hi def link     goTypeDecl          Keyword
 hi def link     goDeclType          Keyword
+
+" Variable Assignments
+if g:go_highlight_variable_assignments != 0
+  syn match goVarAssign /\v[_.[:alnum:]]+(,\s*[_.[:alnum:]]+)*\ze(\s*\=)/
+  hi def link   goVarAssign         Special
+endif
 
 " Variable Declarations
 if g:go_highlight_variable_declarations != 0


### PR DESCRIPTION
Currently `g:go_highlight_variable_declarations` allows to highlight variables with the short variable declaration syntax. This change adds the possibility to highlight variables assigned with the standard assignment operator e.g.:

```go
a, b = foo()
struct.field, _ = bar()
```

It introduces `g:go_highlight_variable_assignments` to allow enabling/disabling the behaviour.