### PR TITLE
disable g:go_autodetect_gopath by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ IMPROVEMENTS:
   gets pre-filled can be configured with `g:go_gorename_prefill` option.
   In addition `:GoRename <Tab>` now lists some common options.
   [[GH-1465]](https://github.com/fatih/vim-go/pull/1465).
+* Disable `g:go_autodetect_gopath` by default. [[GH-1461]](https://github.com/fatih/vim-go/pull/1461).
 
 ## 1.15 - (October 3, 2017)
 

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -73,7 +73,7 @@ function! go#path#Detect() abort
   let gopath = go#path#Default()
 
   " don't lookup for godeps if autodetect is disabled.
-  if !get(g:, "go_autodetect_gopath", 1)
+  if !get(g:, "go_autodetect_gopath", 0)
     return gopath
   endif
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1312,9 +1312,9 @@ the tool `godep` which has his own dependencies via the `Godeps` folder. What
 this means is that all tools are now working with the newly modified GOPATH.
 So |:GoDef| for example jumps to the source inside the `Godeps` (vendored)
 source. Currently `godep` and `gb` is supported, in the near future more tool
-supports will be added. By default it's enabled. >
+supports will be added. By default it's disabled. >
 
-  let g:go_autodetect_gopath = 1
+  let g:go_autodetect_gopath = 0
 <
                                                       *'g:go_textobj_enabled'*
 


### PR DESCRIPTION
Disable g:go_autodetect_gopath by default since first class support for
vendoring was enabled in Go by default a year and a half ago in Go 1.6
and most vendoring tools use it. At this point, there is a greatly
reduced need to detect whether the old method used by Godep and gb is in
effect.