### PR TITLE
teach goVarAssign about all assignment operators

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -410,7 +410,7 @@ hi def link     goDeclType          Keyword
 
 " Variable Assignments
 if g:go_highlight_variable_assignments != 0
-  syn match goVarAssign /\v[_.[:alnum:]]+(,\s*[_.[:alnum:]]+)*\ze(\s*(\+|\-|\||\^|\*|\/|\%|\<\<|\>\>|\&|\&\^)?\=[^\=])/
+  syn match goVarAssign /\v[_.[:alnum:]]+(,\s*[_.[:alnum:]]+)*\ze(\s*([-^+|^\/%&]|\*|\<\<|\>\>|\&\^)?\=[^=])/
   hi def link   goVarAssign         Special
 endif
 

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -410,7 +410,7 @@ hi def link     goDeclType          Keyword
 
 " Variable Assignments
 if g:go_highlight_variable_assignments != 0
-  syn match goVarAssign /\v[_.[:alnum:]]+(,\s*[_.[:alnum:]]+)*\ze(\s*\=)/
+  syn match goVarAssign /\v[_.[:alnum:]]+(,\s*[_.[:alnum:]]+)*\ze(\s*(\+|\-|\||\^|\*|\/|\%|\<\<|\>\>|\&|\&\^)?\=[^\=])/
   hi def link   goVarAssign         Special
 endif
 


### PR DESCRIPTION
Add regular expression branches so that all assignment operators will be
highlighted (e.g. +=, |=, et al.).

Add a match for character other than '=' at the end of the goVarAssign
match expression so that equality comparision (i.e. '==') won't match.