### PR TITLE
Better prefill and completion for :GoRename

### DIFF
--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -2,13 +2,20 @@ if !exists("g:go_gorename_bin")
   let g:go_gorename_bin = "gorename"
 endif
 
-if !exists("g:go_gorename_prefill")
-  let g:go_gorename_prefill = 'expand("<cword>") =~# "^[A-Z]"' .
-        \ '? go#util#camelcaseExported(expand("<cword>"))' .
-        \ ': go#util#camelcase(expand("<cword>"))'
-endif
+" Set the default value. A value of "1" is a shortcut for this, for
+" compatibility reasons.
+function! s:default() abort
+  if !exists("g:go_gorename_prefill") || g:go_gorename_prefill == 1
+    let g:go_gorename_prefill = 'expand("<cword>") =~# "^[A-Z]"' .
+          \ '? go#util#pascalcase(expand("<cword>"))' .
+          \ ': go#util#camelcase(expand("<cword>"))'
+  endif
+endfunction
+call s:default()
 
 function! go#rename#Rename(bang, ...) abort
+  call s:default()
+
   let to_identifier = ""
   if a:0 == 0
     let ask = printf("vim-go: rename '%s' to: ", expand("<cword>"))
@@ -152,7 +159,7 @@ endfunction
 function! go#rename#Complete(lead, cmdline, cursor)
   let l:word = expand('<cword>')
   return filter(uniq(sort(
-        \ [l:word, go#util#camelcase(l:word), go#util#camelcaseExported(l:word)])),
+        \ [l:word, go#util#camelcase(l:word), go#util#pascalcase(l:word)])),
         \ 'strpart(v:val, 0, len(a:lead)) == a:lead')
 endfunction
 

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -264,23 +264,31 @@ endfunction
 " snakecase converts a string to snake case. i.e: FooBar -> foo_bar
 " Copied from tpope/vim-abolish
 function! go#util#snakecase(word) abort
-  let word = substitute(a:word,'::','/','g')
-  let word = substitute(word,'\(\u\+\)\(\u\l\)','\1_\2','g')
-  let word = substitute(word,'\(\l\|\d\)\(\u\)','\1_\2','g')
-  let word = substitute(word,'[.-]','_','g')
+  let word = substitute(a:word, '::', '/', 'g')
+  let word = substitute(word, '\(\u\+\)\(\u\l\)', '\1_\2', 'g')
+  let word = substitute(word, '\(\l\|\d\)\(\u\)', '\1_\2', 'g')
+  let word = substitute(word, '[.-]', '_', 'g')
   let word = tolower(word)
   return word
 endfunction
 
-" camelcase converts a string to camel case. i.e: FooBar -> fooBar
-" Copied from tpope/vim-abolish
+" camelcase converts a string to camel case. e.g. FooBar or foo_bar will become
+" fooBar.
+" Copied from tpope/vim-abolish.
 function! go#util#camelcase(word) abort
   let word = substitute(a:word, '-', '_', 'g')
   if word !~# '_' && word =~# '\l'
-    return substitute(word,'^.','\l&','')
+    return substitute(word, '^.', '\l&', '')
   else
-    return substitute(word,'\C\(_\)\=\(.\)','\=submatch(1)==""?tolower(submatch(2)) : toupper(submatch(2))','g')
+    return substitute(word, '\C\(_\)\=\(.\)', '\=submatch(1)==""?tolower(submatch(2)) : toupper(submatch(2))','g')
   endif
+endfunction
+
+" camelcaseExported converts a string to exported camel case. e.g. fooBar or
+" foo_bar will become FooBar.
+function! go#util#camelcaseExported(word) abort
+  let word = go#util#camelcase(a:word)
+  return toupper(word[0]) . word[1:]
 endfunction
 
 " Echo a message to the screen and highlight it with the group in a:hi.

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -284,9 +284,9 @@ function! go#util#camelcase(word) abort
   endif
 endfunction
 
-" camelcaseExported converts a string to exported camel case. e.g. fooBar or
-" foo_bar will become FooBar.
-function! go#util#camelcaseExported(word) abort
+" pascalcase converts a string to 'PascalCase'. e.g. fooBar or foo_bar will
+" become FooBar.
+function! go#util#pascalcase(word) abort
   let word = go#util#camelcase(a:word)
   return toupper(word[0]) . word[1:]
 endfunction

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1474,7 +1474,7 @@ default it converts the identifier to camelCase or CamelCase, depending on
 whether the identifier is exported.
 >
   let g:go_gorename_prefill = 'expand("<cword>") =~# "^[A-Z]"' .
-        \ '? go#util#camelcaseExported(expand("<cword>"))' .
+        \ '? go#util#pascalcase(expand("<cword>"))' .
         \ ': go#util#camelcase(expand("<cword>"))'
 <
                                                      *'g:go_gocode_autobuild'*

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1470,8 +1470,9 @@ By default it is set to edit.
 
 Expression to prefill the new identifier when using |:GoRename| without any
 arguments. Use an empty string if you don't want to prefill anything. By
-default it converts the identifier to camelCase or CamelCase, depending on
-whether the identifier is exported.
+default it converts the identifier to camel case but preserves the
+capitalisation of the first letter to ensure that the exported state stays the
+same.
 >
   let g:go_gorename_prefill = 'expand("<cword>") =~# "^[A-Z]"' .
         \ '? go#util#pascalcase(expand("<cword>"))' .

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1468,10 +1468,14 @@ By default it is set to edit.
 <
                                                      *'g:go_gorename_prefill'*
 
-Specifies whether |:GoRename| prefills the new identifier name with the
-word under the cursor. By default it is enabled.
+Expression to prefill the new identifier when using |:GoRename| without any
+arguments. Use an empty string if you don't want to prefill anything. By
+default it converts the identifier to camelCase or CamelCase, depending on
+whether the identifier is exported.
 >
-  let g:go_gorename_prefill = 1
+  let g:go_gorename_prefill = 'expand("<cword>") =~# "^[A-Z]"' .
+        \ '? go#util#camelcaseExported(expand("<cword>"))' .
+        \ ': go#util#camelcase(expand("<cword>"))'
 <
                                                      *'g:go_gocode_autobuild'*
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -1,5 +1,5 @@
 " -- gorename
-command! -nargs=? GoRename call go#rename#Rename(<bang>0,<f-args>)
+command! -nargs=? -complete=customlist,go#rename#Complete GoRename call go#rename#Rename(<bang>0, <f-args>)
 
 " -- guru
 command! -nargs=* -complete=customlist,go#package#Complete GoGuruScope call go#guru#Scope(<f-args>)


### PR DESCRIPTION
1. Repurpose `g:go_gorename_prefill` to be an expression, which can
   transform the value that is pre-filled to the most common forms.
   The default is to use camelCase when the identifiers starts with a
   lowercase letter, and CamelCase when it starts with an uppercase
   letter, which sounds like a reasonable guess to me.
2. Add completion support, so you can use `:GoRename <Tab>` to get the
   most common options.

Both of these changes make it a bit easier/faster to use, especially if
you need to rename a bunch of identifiers in a project that doesn't
follow Go standards (like I had to do last week).