### PR TITLE
Allow arguments for :Go{Install,Update}Binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ IMPROVEMENTS:
         let g:go_list_type_commands = {"GoBuild": "quickfix", "GoTest": "locationlist"}
 * Show unexpected errors better by expanding newlines and tabs
   [[GH-1456]](https://github.com/fatih/vim-go/pull/1456).
+* `:GoInstallBinaries` and `:GoUpdateBinaries` can now install/update only the
+  selected binaries (e.g. `:GoUpdateBinaries guru golint`)
+  [[GH-1467]](https://github.com/fatih/vim-go/pull/1467).
 
 BUG FIXES:
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -472,18 +472,21 @@ CTRL-t
     Show dependencies for the current package.
 
                                                           *:GoInstallBinaries*
-:GoInstallBinaries
+:GoInstallBinaries [binaries]
 
-    Download and Install all necessary Go tool binaries such as `godef`,
-    `goimports`, `gocode`, etc. under `g:go_bin_path`. Set
-    |'g:go_get_update'| to disable updating dependencies.
+    Download and install all necessary Go tool binaries such as `godef`,
+    `goimports`, `gocode`, etc. under `g:go_bin_path`. If one or more
+    [binaries] are given then it will only install those. The default is to
+    update everything.
+    Set |'g:go_get_update'| to disable updating dependencies.
 
                                                            *:GoUpdateBinaries*
-:GoUpdateBinaries
+:GoUpdateBinaries [binaries]
 
-    Download and Update previously installed Go tool binaries such as `godef`,
-    `goimports`, `gocode`, etc.. under `g:go_bin_path`. This can be used to
-    update the necessary Go binaries.
+    Download and update previously installed Go tool binaries such as `godef`,
+    `goimports`, `gocode`, etc. under `g:go_bin_path`. If one or more
+    [binaries] are given then it will only update those. The
+    default is to update everything.
 
                                                                *:GoImplements*
 :GoImplements

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -104,26 +104,27 @@ function! s:GoInstallBinaries(updateBinaries, ...)
     let l:platform = 'windows'
   endif
 
-  for [basename, pkg] in items(l:packages)
-    let binname = "go_" . basename . "_bin"
+  for [binary, pkg] in items(l:packages)
+    let l:importPath = pkg[0]
+    let l:goGetFlags = len(pkg) > 1 ? get(pkg[1], l:platform, '') : ''
 
-    let bin = basename
+    let binname = "go_" . binary . "_bin"
+
+    let bin = binary
     if exists("g:{binname}")
       let bin = g:{binname}
     endif
 
     if !executable(bin) || a:updateBinaries == 1
       if a:updateBinaries == 1
-        echo "vim-go: Updating ". basename .". Reinstalling ". pkg[0] . " to folder " . go_bin_path
+        echo "vim-go: Updating " . binary . ". Reinstalling ". importPath . " to folder " . go_bin_path
       else
-        echo "vim-go: ". basename ." not found. Installing ". pkg[0] . " to folder " . go_bin_path
+        echo "vim-go: ". binary ." not found. Installing ". importPath . " to folder " . go_bin_path
       endif
 
-      let out = go#util#System(cmd . 
-            \ (len(pkg) > 1 ? get(pkg[1], l:platform, '') : '') . ' ' .
-            \ shellescape(pkg[0]))
+      let out = go#util#System(cmd . l:goGetFlags . shellescape(importPath))
       if go#util#ShellError() != 0
-        echo "Error installing ". pkg[0] . ": " . out
+        echom "Error installing " . pkgimportPath . ": " . out
       endif
     endif
   endfor

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -6,35 +6,39 @@ let g:go_loaded_install = 1
 
 " these packages are used by vim-go and can be automatically installed if
 " needed by the user with GoInstallBinaries
-let s:packages = [
-      \ "github.com/nsf/gocode",
-      \ "github.com/alecthomas/gometalinter",
-      \ "golang.org/x/tools/cmd/goimports",
-      \ "golang.org/x/tools/cmd/guru",
-      \ "golang.org/x/tools/cmd/gorename",
-      \ "github.com/golang/lint/golint",
-      \ "github.com/rogpeppe/godef",
-      \ "github.com/kisielk/errcheck",
-      \ "github.com/jstemmer/gotags",
-      \ "github.com/klauspost/asmfmt/cmd/asmfmt",
-      \ "github.com/fatih/motion",
-      \ "github.com/fatih/gomodifytags",
-      \ "github.com/zmb3/gogetdoc",
-      \ "github.com/josharian/impl",
-      \ "github.com/dominikh/go-tools/cmd/keyify",
-      \ "github.com/davidrjenni/reftools/cmd/fillstruct",
-      \ ]
+let s:packages = {
+      \ 'asmfmt':        ['github.com/klauspost/asmfmt/cmd/asmfmt'],
+      \ 'errcheck':      ['github.com/kisielk/errcheck'],
+      \ 'fillstruct':    ['github.com/davidrjenni/reftools/cmd/fillstruct'],
+      \ 'gocode':        ['github.com/nsf/gocode', {'windows': '-ldflags -H=windowsgui'}],
+      \ 'godef':         ['github.com/rogpeppe/godef'],
+      \ 'gogetdoc':      ['github.com/zmb3/gogetdoc'],
+      \ 'goimports':     ['golang.org/x/tools/cmd/goimports'],
+      \ 'golint':        ['github.com/golang/lint/golint'],
+      \ 'gometalinter':  ['github.com/alecthomas/gometalinter'],
+      \ 'gomodifytags':  ['github.com/fatih/gomodifytags'],
+      \ 'gorename':      ['golang.org/x/tools/cmd/gorename'],
+      \ 'gotags':        ['github.com/jstemmer/gotags'],
+      \ 'guru':          ['golang.org/x/tools/cmd/guru'],
+      \ 'impl':          ['github.com/josharian/impl'],
+      \ 'keyify':        ['github.com/dominikh/go-tools/cmd/keyify'],
+      \ 'motion':        ['github.com/fatih/motion'],
+\ }
 
 " These commands are available on any filetypes
-command! GoInstallBinaries call s:GoInstallBinaries(-1)
-command! GoUpdateBinaries call s:GoInstallBinaries(1)
+command! -nargs=* -complete=customlist,s:complete GoInstallBinaries call s:GoInstallBinaries(-1, <f-args>)
+command! -nargs=* -complete=customlist,s:complete GoUpdateBinaries  call s:GoInstallBinaries(1, <f-args>)
 command! -nargs=? -complete=dir GoPath call go#path#GoPath(<f-args>)
+
+fun! s:complete(lead, cmdline, cursor)
+  return filter(keys(s:packages), 'strpart(v:val, 0, len(a:lead)) == a:lead')
+endfun
 
 " GoInstallBinaries downloads and install all necessary binaries stated in the
 " packages variable. It uses by default $GOBIN or $GOPATH/bin as the binary
 " target install directory. GoInstallBinaries doesn't install binaries if they
 " exist, to update current binaries pass 1 to the argument.
-function! s:GoInstallBinaries(updateBinaries)
+function! s:GoInstallBinaries(updateBinaries, ...)
   let err = s:CheckBinaries()
   if err != 0
     return
@@ -80,8 +84,27 @@ function! s:GoInstallBinaries(updateBinaries)
     let cmd .= "-f "
   endif
 
-  for pkg in s:packages
-    let basename = fnamemodify(pkg, ":t")
+  " Filter packages from arguments (if any).
+  let l:packages = {}
+  if a:0 > 0
+    for l:bin in a:000
+      let l:pkg = get(s:packages, l:bin, [])
+      if len(l:pkg) == 0
+        call go#util#EchoError('unknown binary: ' . l:bin)
+        return
+      endif
+      let l:packages[l:bin] = l:pkg
+    endfor
+  else
+    let l:packages = s:packages
+  endif
+
+  let l:platform = ''
+  if go#util#IsWin()
+    let l:platform = 'windows'
+  endif
+
+  for [basename, pkg] in items(l:packages)
     let binname = "go_" . basename . "_bin"
 
     let bin = basename
@@ -91,15 +114,16 @@ function! s:GoInstallBinaries(updateBinaries)
 
     if !executable(bin) || a:updateBinaries == 1
       if a:updateBinaries == 1
-        echo "vim-go: Updating ". basename .". Reinstalling ". pkg . " to folder " . go_bin_path
+        echo "vim-go: Updating ". basename .". Reinstalling ". pkg[0] . " to folder " . go_bin_path
       else
-        echo "vim-go: ". basename ." not found. Installing ". pkg . " to folder " . go_bin_path
+        echo "vim-go: ". basename ." not found. Installing ". pkg[0] . " to folder " . go_bin_path
       endif
 
-
-      let out = go#util#System(cmd . shellescape(pkg))
+      let out = go#util#System(cmd . 
+            \ (len(pkg) > 1 ? get(pkg[1], l:platform, '') : '') . ' ' .
+            \ shellescape(pkg[0]))
       if go#util#ShellError() != 0
-        echo "Error installing ". pkg . ": " . out
+        echo "Error installing ". pkg[0] . ": " . out
       endif
     endif
   endfor


### PR DESCRIPTION
- Support arguments; fixes #1438
- Add `-ldflags -H=windowsgui` when installing `gocode` on Windows; fixes #1454