### PR TITLE
Add go#util#Exec()

### DIFF
--- a/autoload/go/fillstruct.vim
+++ b/autoload/go/fillstruct.vim
@@ -1,22 +1,17 @@
 function! go#fillstruct#FillStruct() abort
-  let binpath = go#path#CheckBinPath('fillstruct')
-  if empty(binpath)
-    return
-  endif
-
-  let l:cmd = [binpath,
+  let l:cmd = ['fillstruct',
       \ '-file', bufname(''),
       \ '-offset', go#util#OffsetCursor()]
 
   " Read from stdin if modified.
   if &modified
     call add(l:cmd, '-modified')
-    let l:out = go#util#System(go#util#Shelljoin(l:cmd), go#util#archive())
+    let [l:out, l:err] = go#util#Exec(l:cmd, go#util#archive())
   else
-    let l:out = go#util#System(go#util#Shelljoin(l:cmd))
+    let [l:out, l:err] = go#util#Exec(l:cmd)
   endif
 
-  if go#util#ShellError() != 0
+  if l:err
     call go#util#EchoError(l:out)
     return
   endif

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -179,7 +179,6 @@ function! go#path#CheckBinPath(binpath) abort
   " just get the basename
   let basename = fnamemodify(binpath, ":t")
   if !executable(basename)
-
     call go#util#EchoError(printf("could not find '%s'. Run :GoInstallBinaries to fix it", basename))
 
     " restore back!

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -110,25 +110,22 @@ function! go#util#osarch() abort
   return go#util#env("goos") . '_' . go#util#env("goarch")
 endfunction
 
-" System runs a shell command "str". Every arguments after "str" are passed to
-" stdin.
-" If possible, it will temporary set the shell to /bin/sh for Unix-like systems
-" providing a Bourne POSIX like environment.
-function! go#util#System(str, ...) abort
+" Run a shell command.
+"
+" It will temporary set the shell to /bin/sh for Unix-like systems if possible,
+" so that we always use a standard POSIX-compatible Bourne shell (and not e.g.
+" csh, fish, etc.) See #988 and #1276.
+function! s:system(cmd, ...) abort
   " Preserve original shell and shellredir values
   let l:shell = &shell
   let l:shellredir = &shellredir
 
-  " Use a Bourne POSIX like shell. Some parts of vim-go expect
-  " commands to be executed using bourne semantics #988 and #1276.
-  " Alter shellredir to match bourne. Especially important if login shell
-  " is set to any of the csh or zsh family #1276.
   if !go#util#IsWin() && executable('/bin/sh')
       set shell=/bin/sh shellredir=>%s\ 2>&1
   endif
 
   try
-    return call('system', [a:str] + a:000)
+    return call('system', [a:cmd] + a:000)
   finally
     " Restore original values
     let &shell = l:shell
@@ -136,42 +133,29 @@ function! go#util#System(str, ...) abort
   endtry
 endfunction
 
+" System runs a shell command "str". Every arguments after "str" is passed to
+" stdin.
+function! go#util#System(str, ...) abort
+  return call('s:system', [a:str] + a:000)
+endfunction
+
 " Exec runs a shell command "cmd", which must be a list, one argument per item.
 " Every list entry will be automatically shell-escaped
 " Every other argument is passed to stdin.
 function! go#util#Exec(cmd, ...) abort
   if len(a:cmd) == 0
-    call go#util#EchoError "Exec called with empty command?"
+    call go#util#EchoError("go#util#Exec() called with empty a:cmd")
     return
   endif
 
+  " CheckBinPath will show a warning for us.
   let l:bin = go#path#CheckBinPath(a:cmd[0])
   if empty(l:bin)
     return ["", 1]
   endif
 
-  let l:cmd = go#util#Shelljoin([l:bin] + a:cmd[1:])
-
-  " Preserve original shell and shellredir values
-  let l:shell = &shell
-  let l:shellredir = &shellredir
-
-  " Use a Bourne POSIX like shell. Some parts of vim-go expect
-  " commands to be executed using bourne semantics #988 and #1276.
-  " Alter shellredir to match bourne. Especially important if login shell
-  " is set to any of the csh or zsh family #1276.
-  if !go#util#IsWin() && executable('/bin/sh')
-      set shell=/bin/sh shellredir=>%s\ 2>&1
-  endif
-
-  try
-    let l:out = call('system', [l:cmd] + a:000)
-    return [l:out, go#util#ShellError()]
-  finally
-    " Restore original values
-    let &shell = l:shell
-    let &shellredir = l:shellredir
-  endtry
+  let l:out = call('s:system', [go#util#Shelljoin([l:bin] + a:cmd[1:])] + a:000)
+  return [l:out, go#util#ShellError()]
 endfunction
 
 function! go#util#ShellError() abort


### PR DESCRIPTION
This is intended as a replacement for `go#util#System()`. The main
difference is that this will accept a list instead of a string as the
command, and that every item in the list will be automatically
shell-escaped.

This means you can just do:

	echo go#util#Exec(['printf', 'look "quotes" and spaces and stuff!'])

and not worry about escaping and stuff.

This approach makes much more sense IMHO, and is also what Go's os/exec
and Python subprocess do. It's especially useful with the jobs API,
since that *doesn't* need escaping, so it makes things easier all round.
Vim still needs to use the shell unfortunately; it can't run programs
directly.

I added a new function instead of modifying `System()` so we can migrate
slowly and carefully; double escaping will break stuff! I just converted
`FillStruct()` as an test/example.

While I'm making a new function anyway I also changed the signature a
bit to something that seems a bit easier to use. I can change that back
if people don't like it or prefer something else.