### PR TITLE
Don't use `v:t_list`.

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -288,7 +288,7 @@ endfunction
 " The message can be a list or string; every line with be :echomsg'd separately.
 function! s:echo(msg, hi)
   let l:msg = a:msg
-  if type(l:msg) != v:t_list
+  if type(l:msg) != type([])
     let l:msg = split(l:msg, "\n")
   endif
 


### PR DESCRIPTION
It's "only" a year old (7.4.2071), and older Vim 7.4 versions don't have
it.

Fixes #1477