### PR TITLE
Fix #1484  GoDecls break when motion returns empty

### DIFF
--- a/autoload/fzf/decls.vim
+++ b/autoload/fzf/decls.vim
@@ -96,7 +96,7 @@ function! s:source(mode,...) abort
 
   let result = eval(out)
   if type(result) != 4 || !has_key(result, 'decls')
-    return
+    return ret_decls
   endif
 
   let decls = result.decls


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/3127847/30999153-b6a8aae6-a4a9-11e7-9c6c-4e4e3f8abf89.png)
After:
![image](https://user-images.githubusercontent.com/3127847/30999177-f1e5cf8a-a4a9-11e7-856a-921d1c47f698.png)
