### PR TITLE
[GoDoc] Fix: don not resize GoDoc window if its still visible

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -80,6 +80,7 @@ endfunction
 
 function! s:GodocView(newposition, position, content) abort
   " reuse existing buffer window if it exists otherwise create a new one
+  let is_visible = bufexists(s:buf_nr) && bufwinnr(s:buf_nr) != -1
   if !bufexists(s:buf_nr)
     execute a:newposition
     sil file `="[Godoc]"`
@@ -91,20 +92,23 @@ function! s:GodocView(newposition, position, content) abort
     execute bufwinnr(s:buf_nr) . 'wincmd w'
   endif
 
-  if a:position == "split"
-    " cap window height to 20, but resize it for smaller contents
-    let max_height = get(g:, "go_doc_max_height", 20)
-    let content_height = len(split(a:content, "\n"))
-    if content_height > max_height
-      exe 'resize ' . max_height
+  " if window was not visible then resize it
+  if !is_visible
+    if a:position == "split"
+      " cap window height to 20, but resize it for smaller contents
+      let max_height = get(g:, "go_doc_max_height", 20)
+      let content_height = len(split(a:content, "\n"))
+      if content_height > max_height
+        exe 'resize ' . max_height
+      else
+        exe 'resize ' . content_height
+      endif
     else
-      exe 'resize ' . content_height
+      " set a sane maximum width for vertical splits. In this case the minimum
+      " that fits the godoc for package http without extra linebreaks and line
+      " numbers on
+      exe 'vertical resize 84'
     endif
-  else
-    " set a sane maximum width for vertical splits. In this case the minimum
-    " that fits the godoc for package http without extra linebreaks and line
-    " numbers on
-    exe 'vertical resize 84'
   endif
 
   setlocal filetype=godoc


### PR DESCRIPTION
Hello. First of all sorry for my english.

I am encounter an issue.

The steps to recreate it:
1. Call `:GoDoc os`
2. Move GoDoc window to the right
3. And then call `:GoDoc io`

Result looks like this:
![vim](https://user-images.githubusercontent.com/5111565/31048692-59b1d91a-a62b-11e7-9cda-2fb3697af15b.png)