### PR TITLE
Clarify documentation for g:go_play_browser_command

### DIFF
--- a/autoload/go/play.vim
+++ b/autoload/go/play.vim
@@ -75,14 +75,16 @@ endfunction
 function! s:get_browser_command() abort
   let go_play_browser_command = get(g:, 'go_play_browser_command', '')
   if go_play_browser_command == ''
-    if has('win32') || has('win64')
+    if go#util#IsWin()
       let go_play_browser_command = '!start rundll32 url.dll,FileProtocolHandler %URL%'
-    elseif has('mac') || has('macunix') || has('gui_macvim') || go#util#System('uname') =~? '^darwin'
+    elseif go#util#IsMac()
       let go_play_browser_command = 'open %URL%'
     elseif executable('xdg-open')
       let go_play_browser_command = 'xdg-open %URL%'
     elseif executable('firefox')
       let go_play_browser_command = 'firefox %URL% &'
+    elseif executable('chromium')
+      let go_play_browser_command = 'chromium %URL% &'
     else
       let go_play_browser_command = ''
     endif

--- a/autoload/go/play.vim
+++ b/autoload/go/play.vim
@@ -70,26 +70,4 @@ function! s:get_visual_selection() abort
   return join(lines, "\n")
 endfunction
 
-" following two functions are from: https://github.com/mattn/gist-vim
-" thanks  @mattn
-function! s:get_browser_command() abort
-  let go_play_browser_command = get(g:, 'go_play_browser_command', '')
-  if go_play_browser_command == ''
-    if go#util#IsWin()
-      let go_play_browser_command = '!start rundll32 url.dll,FileProtocolHandler %URL%'
-    elseif go#util#IsMac()
-      let go_play_browser_command = 'open %URL%'
-    elseif executable('xdg-open')
-      let go_play_browser_command = 'xdg-open %URL%'
-    elseif executable('firefox')
-      let go_play_browser_command = 'firefox %URL% &'
-    elseif executable('chromium')
-      let go_play_browser_command = 'chromium %URL% &'
-    else
-      let go_play_browser_command = ''
-    endif
-  endif
-  return go_play_browser_command
-endfunction
-
 " vim: sw=2 ts=2 et

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -194,7 +194,6 @@ function! go#tool#Exists(importpath) abort
     return 0
 endfunction
 
-
 " following two functions are from: https://github.com/mattn/gist-vim
 " thanks  @mattn
 function! s:get_browser_command() abort
@@ -202,12 +201,14 @@ function! s:get_browser_command() abort
     if go_play_browser_command == ''
         if go#util#IsWin()
             let go_play_browser_command = '!start rundll32 url.dll,FileProtocolHandler %URL%'
-        elseif has('mac') || has('macunix') || has('gui_macvim') || go#util#System('uname') =~? '^darwin'
+        elseif go#util#isMac()
             let go_play_browser_command = 'open %URL%'
         elseif executable('xdg-open')
             let go_play_browser_command = 'xdg-open %URL%'
         elseif executable('firefox')
             let go_play_browser_command = 'firefox %URL% &'
+        elseif executable('chromium')
+            let go_play_browser_command = 'chromium %URL% &'
         else
             let go_play_browser_command = ''
         endif

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -43,6 +43,14 @@ function! go#util#IsWin() abort
   return 0
 endfunction
 
+" IsMac returns 1 if current OS is macOS or 0 otherwise.
+function! go#util#IsMac() abort
+  return has('mac') ||
+        \ has('macunix') ||
+        \ has('gui_macvim') ||
+        \ go#util#System('uname') =~? '^darwin'
+endfunction
+
  " Checks if using:
  " 1) Windows system,
  " 2) And has cygpath executable,

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1097,10 +1097,14 @@ set to 10 seconds . >
 <
                                                  *'g:go_play_browser_command'*
 
-Use this option to change the browser that is used to open the snippet url
-posted to play.golang.org with |:GoPlay| or for the relevant documentation
-used with |:GoDocBrowser|. By default it tries to find it automatically for
-the current OS. >
+Browser to use for |:GoPlay| or |:GoDocBrowser|. The url must be added with
+`%URL%`, and it's advisable to include `&` to make sure the shell returns. For
+example:
+>
+  let g:go_play_browser_command = 'firefox-developer %URL% &'
+<
+
+By default it tries to find it automatically for the current OS. >
 
   let g:go_play_browser_command = ''
 <


### PR DESCRIPTION
It never mentioned that you need to use `%URL%` or that you're expected
to return the shell yourself.

While I'm here also add `chromium` to list (the binary for Chrome proper
seems to differ a lot per Linux distro) and move the macOS detection to
a function.

Fixes #1487