### PR TITLE
 Suppress formatting error messages on quitting

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -75,7 +75,7 @@ function! go#fmt#Format(withGoimport) abort
 
   if go#util#ShellError() == 0
     call go#fmt#update_file(l:tmpname, expand('%'))
-  elseif g:go_fmt_fail_silently == 0
+  elseif g:go_fmt_fail_silently == 0 && !(exists('g:go_fmt_suppress_errors_quitting') && g:go_fmt_suppress_errors_quitting == 1)
     let errors = s:parse_errors(expand('%'), out)
     call s:show_errors(errors)
   endif

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -188,6 +188,11 @@ function! s:auto_sameids()
   endif
 endfunction
 
+function! s:fmt_quit()
+  " Setting a flag for suppressing formatting errors on quitting
+  let g:go_fmt_suppress_errors_quitting = 1
+endfunction
+
 function! s:fmt_autosave()
   " Go code formatting on save
   if get(g:, "go_fmt_autosave", 1)
@@ -228,6 +233,7 @@ augroup vim-go
     autocmd CompleteDone *.go call s:echo_go_info()
   endif
 
+  autocmd QuitPre *.go call s:fmt_quit()
   autocmd BufWritePre *.go call s:fmt_autosave()
   autocmd BufWritePre *.s call s:asmfmt_autosave()
   autocmd BufWritePost *.go call s:metalinter_autosave()


### PR DESCRIPTION
Please note that I am absolute vim noob, so these changes may be far from perfect.
The issue I experience is following.

Steps to reproduce:
1. Open go file in vim,
2. Make it invalid by introducing a syntax error,
3. `:wq`.

This results in opened window with errors.
But this window is totally unusable.
If you try to type a command it is shown just over a text, etc.

So I'm just suppressing this window.
Please note that it is implemented only for go files not asm (I didn't check the issue for them).

Environment:
Vi IMproved 8.0 (Included patches: 1-95),
Ubuntu 17.04.