### PR TITLE
edit issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,25 +1,15 @@
-### Behavior
+### What did you do? (required. The issue will be **closed** when not provided.)
 
-Write here what's happening and what you're expecting instead of...
+Please provide a recipe to replicate your problem with a minimal `vimrc` with all plugins other than vim-go disabled.
 
-### Steps to reproduce:
+### What did you expect to happen?
 
-Please create a reproducible case of your problem. If this step is
-not provided, the issue will be **closed**
-
-Re produce it with a minimal `vimrc` with all plugins disabled and
-only `vim-go` enabled:
-
-1.
-2.
-3.
+### What happened instead?
 
 ### Configuration
 
-Add here your current configuration and additional information that might be
-useful, such as:
-
-* `vimrc` you used to reproduce
-* vim version:
+* vim version (major, minor, and included patches from `:version`):
 * vim-go version:
-* go version:
+* go version (`go version`):
+* operating system:
+* `vimrc` you used to reproduce:


### PR DESCRIPTION
Edit the issue template to more clearly walk issue submitters through
the process of providing a good report.

* Clearly prompt the submitter for what they did, what they expeted, and
  what they saw.
* Added an entry to the issue template configuration section to prompt
  submitters for their operating system.
* Added a parenthetical to let submitters know how to get their current
  Go version.
* Moved the vimrc prompt to the end of the configuration list since it
  is usually larger and spans multiple lines.