### PR TITLE
edit help file and function description

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -475,18 +475,21 @@ CTRL-t
 :GoInstallBinaries [binaries]
 
     Download and install all necessary Go tool binaries such as `godef`,
-    `goimports`, `gocode`, etc. under `g:go_bin_path`. If one or more
-    [binaries] are given then it will only install those. The default is to
-    update everything.
+    `goimports`, `gocode`, etc. under |'g:go_bin_path'|. If [binaries] is
+    supplied, then only the specified binaries will be installed. The default
+    is to install everything.
+
     Set |'g:go_get_update'| to disable updating dependencies.
 
                                                            *:GoUpdateBinaries*
 :GoUpdateBinaries [binaries]
 
     Download and update previously installed Go tool binaries such as `godef`,
-    `goimports`, `gocode`, etc. under `g:go_bin_path`. If one or more
-    [binaries] are given then it will only update those. The
-    default is to update everything.
+    `goimports`, `gocode`, etc. under |'g:go_bin_path'|. If [binaries] is
+    supplied, then only the specified binaries will be updated. The default is
+    to update everything.
+
+    Set |'g:go_get_update'| to disable updating dependencies.
 
                                                                *:GoImplements*
 :GoImplements

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -34,10 +34,11 @@ fun! s:complete(lead, cmdline, cursor)
   return filter(keys(s:packages), 'strpart(v:val, 0, len(a:lead)) == a:lead')
 endfun
 
-" GoInstallBinaries downloads and install all necessary binaries stated in the
-" packages variable. It uses by default $GOBIN or $GOPATH/bin as the binary
-" target install directory. GoInstallBinaries doesn't install binaries if they
-" exist, to update current binaries pass 1 to the argument.
+" GoInstallBinaries downloads and installs binaries defined in s:packages to
+" $GOBIN or $GOPATH/bin. GoInstallBinaries will update already installed
+" binaries only if updateBinaries = 1. By default, all packages in s:packages
+" will be installed, but the set can be limited by passing the desired
+" packages in the unnamed arguments.
 function! s:GoInstallBinaries(updateBinaries, ...)
   let err = s:CheckBinaries()
   if err != 0


### PR DESCRIPTION
Correct references to 'g:go_bin_path' in :GoInstallBinaries and
:GoUpateBinaries documentation, and make the references links to
documentation for 'g:go_bin_path'.

Clarify that :GoInstallBinaries and :GoUpdateBinaries do not take
multiple lists (they only take single lists) by making their
documentation congruent with other commands' documentation.

Edit the description comment GoInstallBinaries() for completeness.

Document that :GoUpdateBinaries respects 'g:go_get_update'.