### PR TITLE
edit documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ This plugin adds Go language support for Vim, with the following main features:
 
 ## Install
 
-Master branch is a **development** branch. Please use with caution.
-I recommend to use the [**latest stable release**](https://github.com/fatih/vim-go/releases/latest)
+The [**latest stable release**](https://github.com/fatih/vim-go/releases/latest) is the
+recommended version to use. If you choose to use the master branch instead,
+please do so with caution; it is a _development_ branch.
 
-Vim-go follows the standard runtime path structure. Below are some helper lines
+vim-go follows the standard runtime path structure. Below are some helper lines
 for popular package managers:
 
 * [Vim 8 packages](http://vimhelp.appspot.com/repeat.txt.html#packages)
@@ -47,10 +48,11 @@ for popular package managers:
 * [vim-plug](https://github.com/junegunn/vim-plug)
   * `Plug 'fatih/vim-go'`
 
-You will also need to install all necessary binaries. We have a handy command
-for it: `:GoInstallBinaries`.
+You will also need to install all the necessary binaries. vim-go makes it easy
+to install all of them by providing a command, `:GoInstallBinaries`, which will
+`go get` all the required binaries.
 
-Check out the "Install" section in [the documentation](doc/vim-go.txt) for more
+Check out the Install section in [the documentation](doc/vim-go.txt) for more
 detailed instructions (`:help go-install`).
 
 ## Usage
@@ -58,9 +60,9 @@ detailed instructions (`:help go-install`).
 The full documentation can be found at [doc/vim-go.txt](doc/vim-go.txt). You can
 display it from within Vim with `:help vim-go`.
 
-You may have to generate the plugin's
+Depending on your installation method, you may have to generate the plugin's
 [`help tags`](http://vimhelp.appspot.com/helphelp.txt.html#%3Ahelptags)
-manually (e.g. `:helptags ALL`) depending on your installation method.
+manually (e.g. `:helptags ALL`).
 
 We also have an [official vim-go tutorial](https://github.com/fatih/vim-go-tutorial).
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -30,11 +30,11 @@ CONTENTS                                                         *go-contents*
 ==============================================================================
 INTRO                                                               *go-intro*
 
-Go (golang) support for Vim. vim-go automatically installs all necessary
-binaries for providing a seamless Vim integration. It comes with pre-defined
-sensible settings (like automatic `gofmt` on save), has autocomplete, snippet
-support, improved syntax highlighting, go toolchain commands, etc. It's highly
-customizable and individual features can be disabled/enabled easily.
+Go (golang) support for Vim. vim-go comes with sensible predefined settings
+(e.g. automatic `gofmt` on save), has autocomplete, snippet support, improved
+syntax highlighting, go toolchain commands, etc. It is highly customizable,
+and individual features can be toggled easily. vim-go leverages a number of
+tools developed by the Go community to provide a seamless Vim experience.
 
   * Compile your package with |:GoBuild|, install it with |:GoInstall| or
     test it with |:GoTest|. Run a single tests with |:GoTestFunc|).
@@ -73,15 +73,16 @@ customizable and individual features can be disabled/enabled easily.
 ==============================================================================
 INSTALL                                                           *go-install*
 
-Master branch is a _development_ branch. Please use with caution. I recommend
-to use the latest stable release from
-https://github.com/fatih/vim-go/releases/latest
+The latest stable release, https://github.com/fatih/vim-go/releases/latest, is
+the recommended version to use. If you choose to use the master branch
+instead, please do so with caution; it is a _development_ branch.
 
-Vim-go follows the standard runtime path structure and should work with any of
+vim-go follows the standard runtime path structure and should work with any of
 the major plugin managers.
 
-For Pathogen or Vim |packages| just clone the repo, for other plugin managers
-add the appropriate lines and execute the plugin's install command.
+For Pathogen or Vim |packages|, just clone the repo. For other plugin managers
+you may also need to add the lines to your vimrc to execute the plugin
+manager's install command.
 
 *  Vim 8 |packages|
 >
@@ -108,11 +109,10 @@ add the appropriate lines and execute the plugin's install command.
 
     Copy all of the files into your `~/.vim` directory
 <
-You will also need to install all necessary binaries. We have a handy
-command for it: |:GoInstallBinaries|, which will `go get` all the required
-binaries.
-The binaries will be installed to `$GOPATH/bin` (default: `$HOME/go/bin`). It
-requires `git`.
+You will also need to install all the necessary binaries. vim-go makes it easy
+to install all of them by providing a command, |:GoInstallBinaries|, to
+`go get` all the required binaries. The binaries will be installed to $GOBIN
+or $GOPATH/bin (default: $HOME/go/bin). It requires `git`.
 
 Depending on your installation method, you may have to generate the plugin's
 |:helptags| manually (e.g. `:helptags ALL`).
@@ -827,8 +827,8 @@ CTRL-t
 MAPPINGS                                                        *go-mappings*
 
 vim-go has several <Plug> keys which can be used to create custom mappings
-For example, to create a mapping that `go run` for the current package, create
-a mapping for the `(go-run)`: >
+For example, to create a mapping that calls `go run` for the current package,
+create a mapping for the `(go-run)`: >
 
   au FileType go nmap <leader>r <Plug>(go-run)
 
@@ -1611,7 +1611,7 @@ By default "snakecase" is used. Current values are: ["snakecase",
 ==============================================================================
 SYNTAX HIGHLIGHTING                                 *ft-go-syntax* *go-syntax*
 
-Vim-go comes with an enhanced version of Vim's Go syntax highlighting. It
+vim-go comes with an enhanced version of Vim's Go syntax highlighting. It
 comes with a number of features, most of which are disabled by default.
 
 The recommended settings are the default values. If you're experiencing
@@ -1932,7 +1932,7 @@ by being a patreon at: https://www.patreon.com/fatih
 By being a patron, you are enabling vim-go to grow and mature, helping me to
 invest in bug fixes, new documentation, and improving both current and future
 features. It's completely optional and is just a direct way to support
-Vim-go's ongoing development. Thanks!
+vim-go's ongoing development. Thanks!
 
 Check it out: https://www.patreon.com/fatih
 


### PR DESCRIPTION
Edit the INTRO and INSTALL sections of the documentation. Edits mostly
consist of rewording some sentences and paragraphs to read more
naturally.

Consistently capitalize vim-go, even if it's the first word in a
sentence. This might not seem right to you at first, but think about how
other proper nouns that begin with a lower case letter (e.g.  iPhone)
are capitalized when used as the the first word in a sentence.

Make analogous edits to README.md