### PR TITLE
Don't open the {quickfix,location}list when quitting

### DIFF
--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -12,6 +12,11 @@ endif
 " If no or zero height is given it closes the window by default.  
 " To prevent this, set g:go_list_autoclose = 0
 function! go#list#Window(listtype, ...) abort
+  " Don't open the list when quiting; prevents orphaned window and Vim bug #1497.
+  if exists('g:_go_quiting') && g:_go_quiting
+    return
+  endif
+
   " we don't use lwindow to close the location list as we need also the
   " ability to resize the window. So, we are going to use lopen and lclose
   " for a better user experience. If the number of errors in a current
@@ -58,6 +63,15 @@ endfunction
 
 " Populate populate the list with the given items
 function! go#list#Populate(listtype, items, title) abort
+  " Echo the errors when quiting; prevents orphaned window and Vim bug #1497.
+  if exists('g:_go_quiting') && g:_go_quiting
+    for l:item in a:items
+      call go#util#EchoError(printf('%s | %s col %s | %s',
+            \ l:item['filename'], l:item['lnum'], l:item['col'], l:item['text']))
+    endfor
+    return
+  endif
+
   if a:listtype == "locationlist"
     call setloclist(0, a:items, 'r')
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -229,6 +229,7 @@ augroup vim-go
     autocmd CompleteDone *.go call s:echo_go_info()
   endif
 
+  autocmd QuitPre *.go let g:_go_quiting = 1
   autocmd BufWritePre *.go call s:fmt_autosave()
   autocmd BufWritePre *.s call s:asmfmt_autosave()
   autocmd BufWritePost *.go call s:metalinter_autosave()


### PR DESCRIPTION
In Vim versions before [8.0.1190][1] it would open the new window *and*
leave Vim in the wrong terminal mode (making it unusable).

In later Vim versions it would close the window with the Go file, only
to have a new list popup. Whether this is the desired behaviour is a
matter of opinion, but considering the above bug I think it's better to
*not* open the list for now and simple echo any errors.

This continues from #1497.

[1]: https://github.com/vim/vim/commit/2c33d7bb69c4c2c5b0e39b03cc4b0c04cfdfbb0b