### PR TITLE
normalize message output

### DIFF
--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -33,9 +33,9 @@ function! go#test#Test(bang, compile, ...) abort
 
   if get(g:, 'go_echo_command_info', 1)
     if a:compile
-      echon "vim-go: " | echohl Identifier | echon "compiling tests ..." | echohl None
+      call go#util#EchoProgress("compiling tests ...")
     else
-      echon "vim-go: " | echohl Identifier | echon "testing ..." | echohl None
+      call go#util#EchoProgress("testing...")
     endif
   endif
 
@@ -87,15 +87,15 @@ function! go#test#Test(bang, compile, ...) abort
       " failed to parse errors, output the original content
       call go#util#EchoError(out)
     endif
-    echon "vim-go: " | echohl ErrorMsg | echon "[test] FAIL" | echohl None
+    call go#util#EchoError("[test] FAIL")
   else
     call go#list#Clean(l:listtype)
     call go#list#Window(l:listtype)
 
     if a:compile
-      echon "vim-go: " | echohl Function | echon "[test] SUCCESS" | echohl None
+      call go#util#EchoSuccess("[test] SUCCESS")
     else
-      echon "vim-go: " | echohl Function | echon "[test] PASS" | echohl None
+      call go#util#EchoSuccess("[test] PASS")
     endif
   endif
   execute cd . fnameescape(dir)
@@ -172,12 +172,12 @@ function s:test_job(args) abort
     if get(g:, 'go_echo_command_info', 1)
       if a:exitval == 0
         if a:args.compile_test
-          call go#util#EchoSuccess("SUCCESS")
+          call go#util#EchoSuccess("[test] SUCCESS")
         else
-          call go#util#EchoSuccess("PASS")
+          call go#util#EchoSuccess("[test] PASS")
         endif
       else
-        call go#util#EchoError("FAILED")
+        call go#util#EchoError("[test] FAIL")
       endif
     endif
 


### PR DESCRIPTION
Normalize message output from autoload/go/test.vim to use the
go#util#Echo* functions instead of replicating their functionality.

Use the same messages for Vim 7.4 and 8.0.