### PR TITLE
do not try to run tests for :GoTestCompile

### DIFF
--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -6,9 +6,8 @@ function! go#test#Test(bang, compile, ...) abort
 
   " don't run the test, only compile it. Useful to capture and fix errors.
   if a:compile
-    " we're going to tell to run a test function that doesn't exist. This
-    " triggers a build of the test file itself but no tests will run.
-    call extend(args, ["-run", "499EE4A2-5C85-4D35-98FC-7377CD87F263"])
+    let testfile = tempname() . ".vim-go.test"
+    call extend(args, ["-c", "-o", testfile])
   endif
 
   if a:0


### PR DESCRIPTION
Do not try to run a non-existent test for :GoTestCompile. Instead,
compile tests to a temporary file with `go test -c` in order to avoid
problems that may be caused by runtime errors in an init function when
trying to run a non-existent test.

To avoid the problems that 21376e689d6b701b4367cf121da4cfcf17e5fa19
resolved, this change relies on Vim's managing of the temporary
directory instead.

Fixes #1515