### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
We already add modelines for lots of files, but not 100% consistently,
and there's no modeline for new files.

I like editorconfig files :-) I use the
https://github.com/editorconfig/editorconfig-vim plugin for usin them in
Vim.