### PR TITLE
Display warning when people use an older Vim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## unplanned
 
+BACKWARDS INCOMPATIBILITIES:
+
+* Display a warning for Vim versions older than 7.4.1689. Older versions may
+  still work, but are not supported. You can use `let g:go_version_warning = 0`
+  to disable the warning.
+  [[GH-1524]](https://github.com/fatih/vim-go/pull/1524).
+
 BUG FIXES:
 
 * Fix compatibility with Vim version before 7.4.1546

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -11,7 +11,7 @@ let g:go_loaded_install = 1
 " Version 7.4.1689 was chosen because that's what the most recent Ubuntu LTS
 " release (16.04) uses.
 if
-      \ !exists('g:go_no_version_warning') &&
+      \ get(g:, 'go_no_version_warning', 0) != 1 &&
       \ (v:version < 704 || (v:version == 704 && !has('patch1689')))
       \ && !has('nvim')
   echohl Error
@@ -19,7 +19,7 @@ if
   echom "Please update your Vim for the best vim-go experience."
   echom "If you really want to continue you can set this to make the error go away:"
   echom "    let g:go_no_version_warning = 1"
-  echom "Note that some features may error out or behave incorrect."
+  echom "Note that some features may error out or behave incorrectly."
   echom "Please do not report bugs unless you're using Vim 7.4.1689 or newer."
   echohl None
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -11,14 +11,14 @@ let g:go_loaded_install = 1
 " Version 7.4.1689 was chosen because that's what the most recent Ubuntu LTS
 " release (16.04) uses.
 if
-      \ get(g:, 'go_no_version_warning', 0) != 1 &&
+      \ get(g:, 'go_version_warning', 1) != 0 &&
       \ (v:version < 704 || (v:version == 704 && !has('patch1689')))
       \ && !has('nvim')
   echohl Error
   echom "vim-go requires Vim 7.4.1689 or Neovim, but you're using an older version."
   echom "Please update your Vim for the best vim-go experience."
   echom "If you really want to continue you can set this to make the error go away:"
-  echom "    let g:go_no_version_warning = 1"
+  echom "    let g:go_version_warning = 0"
   echom "Note that some features may error out or behave incorrectly."
   echom "Please do not report bugs unless you're using Vim 7.4.1689 or newer."
   echohl None

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -4,6 +4,29 @@ if exists("g:go_loaded_install")
 endif
 let g:go_loaded_install = 1
 
+" Not using the has('patch-7.4.1689') syntax because that wasn't added until
+" 7.4.237, and we want to be sure this works for everyone (this is also why
+" we're not using utils#EchoError()).
+"
+" Version 7.4.1689 was chosen because that's what the most recent Ubuntu LTS
+" release (16.04) uses.
+if
+      \ !exists('g:go_no_version_warning') &&
+      \ (v:version < 704 || (v:version == 704 && !has('patch1689')))
+      \ && !has('nvim')
+  echohl Error
+  echom "vim-go requires Vim 7.4.1689 or Neovim, but you're using an older version."
+  echom "Please update your Vim for the best vim-go experience."
+  echom "If you really want to continue you can set this to make the error go away:"
+  echom "    let g:go_no_version_warning = 1"
+  echom "Note that some features may error out or behave incorrect."
+  echom "Please do not report bugs unless you're using Vim 7.4.1689 or newer."
+  echohl None
+
+  " Make sure people see this.
+  sleep 2
+endif
+
 " these packages are used by vim-go and can be automatically installed if
 " needed by the user with GoInstallBinaries
 let s:packages = {


### PR DESCRIPTION
This shows a warning when people use an older Vim version. You can still set
`g:go_no_version_warning` to override this, if people really want to continue. I
don't think we need to bother documenting that setting in the help page.

The version 7.4.1689 was chosen because that's what the latest Ubuntu LTS
(16.04) uses, which seems like a reasonable choice. I don't mind using an older
version though.