### PR TITLE
check group in when toggling same ids

### DIFF
--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -548,11 +548,14 @@ function! go#guru#ClearSameIds() abort
 endfunction
 
 function! go#guru#ToggleSameIds() abort
-  if len(getmatches()) != 0
-    call go#guru#ClearSameIds()
-  else
-    call go#guru#SameIds()
-  endif
+  let m = getmatches()
+  for item in m
+    if item['group'] == 'goSameId'
+      call go#guru#ClearSameIds()
+      return
+    endif
+  endfor
+  call go#guru#SameIds()
 endfunction
 
 function! go#guru#AutoToogleSameIds() abort

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -534,10 +534,13 @@ function! s:same_ids_highlight(exit_val, output) abort
 endfunction
 
 function! go#guru#ClearSameIds() abort
+  let l:cleared = 0
+
   let m = getmatches()
   for item in m
     if item['group'] == 'goSameId'
       call matchdelete(item['id'])
+      let l:cleared = 1
     endif
   endfor
 
@@ -545,17 +548,14 @@ function! go#guru#ClearSameIds() abort
   if exists("#BufWinEnter#<buffer>")
     autocmd! BufWinEnter <buffer>
   endif
+
+  return cleared
 endfunction
 
 function! go#guru#ToggleSameIds() abort
-  let m = getmatches()
-  for item in m
-    if item['group'] == 'goSameId'
-      call go#guru#ClearSameIds()
-      return
-    endif
-  endfor
-  call go#guru#SameIds()
+  if !go#guru#ClearSameIds()
+    call go#guru#SameIds()
+  endif
 endfunction
 
 function! go#guru#AutoToogleSameIds() abort

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -534,26 +534,30 @@ function! s:same_ids_highlight(exit_val, output) abort
 endfunction
 
 function! go#guru#ClearSameIds() abort
-  let l:cleared = 0
+  let l:cleared = -1
 
   let m = getmatches()
   for item in m
     if item['group'] == 'goSameId'
       call matchdelete(item['id'])
-      let l:cleared = 1
+      let l:cleared = 0
     endif
   endfor
+
+  if l:cleared != 0
+    return -1
+  endif
 
   " remove the autocmds we defined
   if exists("#BufWinEnter#<buffer>")
     autocmd! BufWinEnter <buffer>
   endif
 
-  return cleared
+  return 0
 endfunction
 
 function! go#guru#ToggleSameIds() abort
-  if !go#guru#ClearSameIds()
+  if go#guru#ClearSameIds() != 0
     call go#guru#SameIds()
   endif
 endfunction


### PR DESCRIPTION
Currently, `ToggleSameIds` doesn't check the group of the match and, as I set up vim to highlight characters that go beyond column 80 (just find it a mostly helpful heuristic), when I open a file that contains longer lines, `ToggleSameIds` always try to clear highlighted ids, because `getmatches()` return all highlights and not just the `GoSameId` ones.

So, as already done in `ClearSameIds`, I think we should also test the group here.