### PR TITLE
use greater contrasting colors for goCoverage highlight groups

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -444,8 +444,8 @@ function! s:hi()
   hi def link goSameId Search
 
   " :GoCoverage commands
-  hi def      goCoverageCovered    ctermfg=green guifg=#A6E22E
-  hi def      goCoverageUncover    ctermfg=red guifg=#F92672
+  hi def      goCoverageCovered    ctermfg=lightgreen guifg=#A6E22E
+  hi def      goCoverageUncover    ctermfg=darkred guifg=#F92672
 endfunction
 
 augroup vim-go-hi


### PR DESCRIPTION
I use `:GoCoverage` with molokai and solarized quite often, but cannot easily distinguish between the `goCoverageCovered` and `goCoverageNormalText` groups in the terminal. In molokai I can see _some_ difference, but it's subtle. In solarized I cannot distinguish any difference. I am color blind, though, so the lack of contrast on molokai may be more pronounced for me than for others.

Using colors that are further apart, though, renders nicely in the terminal for both color schemes. While I don't want to try to support all possible color schemes, solarized and molokai are two very prominent color schemes and can serve as a bellwether for vim-go highlight group coloring.

(Interestingly, I only see these contrast issues when using the solarized color profile on iTerm2, but I've also tested on Terminal to make sure these changes aren't too jarring there. Given that I'm color blind, though, it would be helpful if someone else could also verify that these colors are acceptable.)

molokai on master:
![image](https://user-images.githubusercontent.com/1958864/32145932-a1cef62e-bc8d-11e7-931d-21bc35f07674.png)

molakai now:
![image](https://user-images.githubusercontent.com/1958864/32145926-850edcc0-bc8d-11e7-92a4-f65ea388bb1f.png)

solarized on master:
![image](https://user-images.githubusercontent.com/1958864/32145928-911927b4-bc8d-11e7-80e3-2053edc41926.png)

solarized now:
![image](https://user-images.githubusercontent.com/1958864/32145924-6fae0504-bc8d-11e7-8a43-48e6db5a77b1.png)
