### PR TITLE
Rename go_highlight_methods to go_highlight_function_calls

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1250,7 +1250,7 @@ Maximum height for the GoDoc window created with |:GoDoc|. Default is 20. >
                                                               *'g:go_doc_url'*
 
 godoc server URL used when |:GoDocBrowser| is used. Change if you want to use
-a private internal service. Default is 'https://godoc.org'. 
+a private internal service. Default is 'https://godoc.org'.
 >
   let g:go_doc_url = 'https://godoc.org'
 <
@@ -1725,7 +1725,7 @@ Highlight operators such as `:=` , `==`, `-=`, etc.
 <
                                                   *'g:go_highlight_functions'*
 
-Highlight function names.
+Highlight function and method declarations.
 >
   let g:go_highlight_functions = 0
 <
@@ -1737,11 +1737,11 @@ declarations. Setting this implies the functionality from
 >
   let g:go_highlight_function_arguments = 0
 <
-                                                    *'g:go_highlight_methods'*
+                                             *'g:go_highlight_function_calls'*
 
-Highlight method names.
+Highlight function and method calls.
 >
-  let g:go_highlight_methods = 0
+  let g:go_highlight_function_calls = 0
 <
                                                       *'g:go_highlight_types'*
 

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -42,8 +42,8 @@ if !exists("g:go_highlight_function_arguments")
   let g:go_highlight_function_arguments = 0
 endif
 
-if !exists("g:go_highlight_methods")
-  let g:go_highlight_methods = 0
+if !exists("g:go_highlight_function_calls")
+  let g:go_highlight_function_calls = 0
 endif
 
 if !exists("g:go_highlight_fields")
@@ -348,7 +348,6 @@ hi def link     goOperator          Operator
 
 " Functions;
 if g:go_highlight_functions isnot 0 || g:go_highlight_function_arguments isnot 0
-  syn match goFunctionCall      /\w\+\ze(/ contains=goBuiltins,goDeclaration
   syn match goDeclaration       /\<func\>/ nextgroup=goReceiver,goFunction,goSimpleArguments skipwhite skipnl
   syn match goReceiverVar       /\w\+\ze\s\+\(\w\|\*\)/ nextgroup=goPointerOperator,goReceiverType skipwhite skipnl contained
   syn match goPointerOperator   /\*/ nextgroup=goReceiverType contained skipwhite skipnl
@@ -367,13 +366,12 @@ else
   syn keyword goDeclaration func
 endif
 hi def link     goFunction          Function
-hi def link     goFunctionCall      Type
 
-" Methods;
-if g:go_highlight_methods != 0
-  syn match goMethodCall            /\.\w\+\ze(/hs=s+1
+" Function calls;
+if g:go_highlight_function_calls != 0
+  syn match goFunctionCall      /\w\+\ze(/ contains=goBuiltins,goDeclaration
 endif
-hi def link     goMethodCall        Type
+hi def link     goFunctionCall      Type
 
 " Fields;
 if g:go_highlight_fields != 0


### PR DESCRIPTION
Separating method calls from calls on a package is not easy with the
current regexp based syntax highlighting. Is `fmt.Println` a method call
or function call?

This fixes #1500 by clarifying what the setting is supposed to do. I
think this makes sense, because people who want to highlight function
declarations probably want to do this for both functions and methods,
and people who want to highlight function calls want to do this for
functions and methods, too.