### PR TITLE
Make :GoTestCompile respect build tags

### DIFF
--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -10,6 +10,11 @@ function! go#test#Test(bang, compile, ...) abort
     call extend(args, ["-c", "-o", testfile])
   endif
 
+  if exists('g:go_build_tags')
+    let tags = get(g:, 'go_build_tags')
+    call extend(args, ["-tags", tags])
+  endif
+
   if a:0
     let goargs = a:000
 


### PR DESCRIPTION
I have a test that uses build tags: `// +build integration`.

I found I wasn't able to build it in vim, so I added this. Seems correct to me.