### PR TITLE
Pass --tests flag to gometalinter so that we lint test files

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -48,19 +48,19 @@ function! go#lint#Gometa(autosave, ...) abort
       let cmd += ["--exclude=".exclude]
     endfor
 
+    " gometalinter has a --tests flag to tell its linters whether to run
+    " against tests. While not all of its linters respect this flag, for those
+    " that do, it means if we don't pass --tests, the linter won't run against
+    " test files. One example of a linter that will not run against tests if
+    " we do not specify this flag is errcheck.
+    let cmd += ["--tests"]
+
     " path
     let cmd += [expand('%:p:h')]
   else
     " the user wants something else, let us use it.
     let cmd += split(g:go_metalinter_command, " ")
   endif
-
-  " gometalinter has a --tests flag to tell its linters whether to run against
-  " tests. While not all of its linters respect this flag, for those that do,
-  " it means if we don't pass --tests, the linter won't run against test
-  " files. One example of a linter that will not run against tests if we do
-  " not specify this flag is errcheck.
-  let cmd += ["--tests"]
 
   " gometalinter has a default deadline of 5 seconds.
   "

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -55,6 +55,13 @@ function! go#lint#Gometa(autosave, ...) abort
     let cmd += split(g:go_metalinter_command, " ")
   endif
 
+  " gometalinter has a --tests flag to tell its linters whether to run against
+  " tests. While not all of its linters respect this flag, for those that do,
+  " it means if we don't pass --tests, the linter won't run against test
+  " files. One example of a linter that will not run against tests if we do
+  " not specify this flag is errcheck.
+  let cmd += ["--tests"]
+
   " gometalinter has a default deadline of 5 seconds.
   "
   " For async mode (s:lint_job), we want to override the default deadline only


### PR DESCRIPTION
Previously we'd lint test files. In the recent PR
alecthomas/gometalinter#377, gometalinter stopped asking errcheck to
lint tests. This change makes us again lint test files which I think is
sensible.