### PR TITLE
Fix :GoImpl completion

### DIFF
--- a/autoload/go/impl_test.vim
+++ b/autoload/go/impl_test.vim
@@ -1,0 +1,37 @@
+func! Test_impl() abort
+  try
+    let l:tmp = gotest#write_file('a/a.go', [
+          \ 'package a',
+          \ '',
+          \ ''])
+
+    call go#impl#Impl('r', 'reader', 'io.Reader')
+    call gotest#assert_buffer(1, [
+          \ 'func (r reader) Read(p []byte) (n int, err error) {',
+          \ '	panic("not implemented")',
+          \ '}'])
+  finally
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
+func! Test_impl_get() abort
+  try
+    let l:tmp = gotest#write_file('a/a.go', [
+          \ 'package a',
+          \ '',
+          \ 'type reader struct {}'])
+
+    call go#impl#Impl('io.Reader')
+    call gotest#assert_buffer(0, [
+          \ 'package a',
+          \ '',
+          \ 'type reader struct {}',
+          \ '',
+          \ 'func (r *reader) Read(p []byte) (n int, err error) {',
+          \ '	panic("not implemented")',
+          \ '}'])
+  finally
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc

--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -15,7 +15,7 @@ fun! gotest#write_file(path, contents) abort
   call mkdir(fnamemodify(l:full_path, ':h'), 'p')
   call writefile(a:contents, l:full_path)
   exe 'cd ' . l:dir . '/src'
-  silent exe 'e ' . a:path
+  silent exe 'e! ' . a:path
 
   " Set cursor.
   let l:lnum = 1

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -87,7 +87,7 @@ command! -nargs=? -complete=file GoDecls call go#decls#Decls(0, <q-args>)
 command! -nargs=? -complete=dir GoDeclsDir call go#decls#Decls(1, <q-args>)
 
 " -- impl
-command! -nargs=* -buffer -complete=customlist,go#impl#Complete GoImpl call go#impl#Impl(<f-args>)
+command! -nargs=* -complete=customlist,go#impl#Complete GoImpl call go#impl#Impl(<f-args>)
 
 " -- template
 command! -nargs=0 GoTemplateAutoCreateToggle call go#template#ToggleAutoCreate()


### PR DESCRIPTION
Fixes #1554

The problem is that `:GoImpl somethingInvalid` would set
`v:shell_error`, and on the next `:GoImpl <Tab>` the `go#util#env()`
call in `s:root_dirs()` would use the cache, so the `v:shell_error` is
"stuck".

Fix it by not checking this here; `go#util#env()` already shows an error
so that should be fine.

Long-term fix is to use `go#util#Exec()` everywhere which returns
`v:shell_error` instead of relying on a global value.

While I'm here also add a basic test and use `Exec()` in a few places.