### PR TITLE
Sync syntax from start after gofmt

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -101,6 +101,9 @@ function! go#fmt#Format(withGoimport) abort
 
   " be smart and jump to the line the new statement was added/removed
   call cursor(line('.') + diff_offset, current_col)
+
+  " Syntax highlighting breaks less often.
+  syntax sync fromstart
 endfunction
 
 " update_file updates the target file with the given formatted source


### PR DESCRIPTION
This should ensure that it breaks less often. The downside is that it's
a bit slower, but it still seems plenty fast enough on my system even
with large files.

Fixes #1447