### PR TITLE
Some small test running improvements

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -7,6 +7,32 @@ set -euC
 vimgodir=$(cd -P "$(dirname "$0")/.." > /dev/null && pwd)
 cd "$vimgodir"
 
+usage() {
+  echo "Usage: ${0##*/} [-v] [-r file] vim_version"
+  echo
+  echo "Options:"
+  echo "  -h     Show this help"
+  echo "  -v     Enable verbose output"
+  echo "  -r     Run only the tests from this file"
+  echo
+}
+
+verbose=0
+run=""
+while getopts "hvr:" option; do
+  case "$option" in
+      h) _usage; exit 0 ;;
+      v) verbose=1; ;;
+      r) run=$OPTARG ;;
+      *)
+        echo "error: unknown option '$option'"
+        _usage
+        exit 1
+        ;;
+  esac
+done
+shift $((OPTIND - 1))
+
 ### Setup Vim and other dependencies.
 #####################################
 if [ -z "${1:-}" ]; then
@@ -21,8 +47,8 @@ export GOPATH=$vimdir
 export PATH=${GOPATH}/bin:$PATH
 
 if [ ! -f "$vimdir/bin/vim" ]; then
-	echo "$vimdir/bin/vim doesn't exist; did you install it with the install-vim script?"
-	exit 1
+  echo "$vimdir/bin/vim doesn't exist; did you install it with the install-vim script?"
+  exit 1
 fi
 
 ### Run tests.
@@ -32,9 +58,20 @@ fi
 [ -f '/tmp/vim-go-test/FAILED' ] && rm '/tmp/vim-go-test/FAILED'
 
 # Run the actual tests.
-fail=0
-for test_file in "$vimgodir"/autoload/go/*_test.vim; do
-  "$vimgodir/scripts/run-vim" $vim -e +"silent e $test_file" -S ./scripts/runtest.vim
+find "$vimgodir" -name '*_test.vim' | while read test_file; do
+  [ -n "$run" -a "$(basename "$test_file")" != "$run" ] && continue
+
+  "$vimgodir/scripts/run-vim" $vim -e \
+    +"silent e $test_file" \
+    +"let g:test_verbose=$verbose" \
+    -S ./scripts/runtest.vim || (
+      # If Vim exits with non-0 it's almost certainly a bug in the test runner;
+      # should very rarely happen in normal usage.
+      echo 'test runner failure'
+      cat '/tmp/vim-go-test/test.tmp'
+      rm '/tmp/vim-go-test/test.tmp'
+      exit 5
+    )
 
   # Append logs
   cat '/tmp/vim-go-test/test.tmp' | tee '/tmp/vim-go-test/test.log'


### PR DESCRIPTION
Deals better with some errors, add some commandline flags, and improve
output.

It will now also run tests from all directories, instead of the autoload
directory. I wanted to add a test for #1525, and putting it in
`autoload/go/` seemed wrong to me.

Would also be nice to be able to run just one test with e.g.
`-r tags_test.vim:Test_Foo`. I'll add that when I need it I guess.

Regular:

	[~/.vim/pack/plugins/start/vim-go](master)% ./scripts/test vim-8.0
	ok   tags_test.vim              0.146627s / 2 tests
	ok   fillstruct_test.vim        0.685770s / 1 tests
	ok   tool_test.vim              0.083538s / 2 tests
	ok   def_test.vim               0.018329s / 2 tests
	ok   fmt_test.vim               0.023622s / 3 tests

	All tests PASSED

Test failure:

	[~/.vim/pack/plugins/start/vim-go](master)% ./scripts/test vim-8.0
	ok   tags_test.vim              0.117528s / 2 tests
	ok   fillstruct_test.vim        0.772903s / 1 tests
	ok   tool_test.vim              0.043084s / 2 tests
	--- FAIL Test_jump_to_declaration_guru (0.000698s)
			function Test_jump_to_declaration_guru line 13: Expected 'oh' but got 'noes'
	FAIL def_test.vim               0.007922s / 2 tests
	ok   fmt_test.vim               0.021428s / 3 tests

	Some tests FAILED

Syntax error (would prevously keep Vim open!):

	[~/.vim/pack/plugins/start/vim-go](test)% ./scripts/test vim-8.0
	ok   tags_test.vim              0.169554s / 2 tests
	--- FAIL Test_fillstruct (0.845644s)
			Vim:E492: Not an editor command:     asd
	FAIL fillstruct_test.vim        0.846325s / 1 tests
	ok   tool_test.vim              0.060288s / 2 tests
	ok   def_test.vim               0.023219s / 2 tests
	ok   fmt_test.vim               0.026293s / 3 tests

	Some tests FAILED

Verbose:

	[~/.vim/pack/plugins/start/vim-go](master)% ./scripts/test -v vim-8.0

	=== RUN  Test_add_tags
	--- PASS Test_add_tags (0.084296s)
	=== RUN  Test_remove_tags
	--- PASS Test_remove_tags (0.086975s)
	ok  tags_test.vim              0.172008s / 2 tests

	=== RUN  Test_fillstruct
	--- PASS Test_fillstruct (0.792921s)
	ok  fillstruct_test.vim        0.793609s / 1 tests

	=== RUN  Test_ExecuteInDir
	--- PASS Test_ExecuteInDir (0.044198s)
	=== RUN  Test_ExecuteInDir_nodir
	--- PASS Test_ExecuteInDir_nodir (0.003989s)
	ok  tool_test.vim              0.048599s / 2 tests

	=== RUN  Test_jump_to_declaration_godef
	--- PASS Test_jump_to_declaration_godef (0.006618s)
	=== RUN  Test_jump_to_declaration_guru
	--- FAIL Test_jump_to_declaration_guru (0.000832s)
			function Test_jump_to_declaration_guru line 13: Expected 'oh' but got 'noes'
	FAIL def_test.vim               0.007953s / 2 tests

	=== RUN  Test_goimports
	--- PASS Test_goimports (0.013912s)
	=== RUN  Test_run_fmt
	--- PASS Test_run_fmt (0.006824s)
	=== RUN  Test_update_file
	--- PASS Test_update_file (0.000501s)
	ok  fmt_test.vim               0.021532s / 3 tests

	Some tests FAILED

Running just one test file:

	[~/.vim/pack/plugins/start/vim-go](master)% ./scripts/test -r tags_test.vim vim-8.0
	ok   tags_test.vim              0.093540s / 2 tests

	All tests PASSED