### PR TITLE
Use :sbuffer in :GoAlternate

### DIFF
--- a/autoload/go/alternate.vim
+++ b/autoload/go/alternate.vim
@@ -1,32 +1,36 @@
-" By default use edit (current buffer view) to switch
-if !exists("g:go_alternate_mode")
-  let g:go_alternate_mode = "edit"
-endif
-
-" Test alternates between the implementation of code and the test code.
-function! go#alternate#Switch(bang, cmd) abort
-  let file = expand('%')
-  if empty(file)
-    call go#util#EchoError("no buffer name")
+" Alternate between the implementation of code and the test code.
+"
+" if a:bang is true then we will switch to the new file even if it doesn't
+" exist.
+" a:cmd is the edit command, such as :edit, :tabedit, :vsplit, etc.
+function! go#alternate#Switch(bang, cmd)
+  let l:file = expand('%')
+  if empty(l:file)
+    call go#util#EchoError('no buffer name')
     return
-  elseif file =~# '^\f\+_test\.go$'
-    let l:root = split(file, '_test.go$')[0]
-    let l:alt_file = l:root . ".go"
-  elseif file =~# '^\f\+\.go$'
-    let l:root = split(file, ".go$")[0]
+  elseif l:file[-8:] is# '_test.go'
+    let l:root = split(l:file, '_test.go$')[0]
+    let l:alt_file = l:root . '.go'
+  elseif l:file[-3:] is# '.go'
+    let l:root = split(l:file, '.go$')[0]
     let l:alt_file = l:root . '_test.go'
   else
-    call go#util#EchoError("not a go file")
+    call go#util#EchoError(printf('%s is not a go file', l:file))
     return
   endif
-  if !filereadable(alt_file) && !bufexists(alt_file) && !a:bang
-    call go#util#EchoError("couldn't find ".alt_file)
+
+  if !filereadable(l:alt_file) && !bufexists(l:alt_file) && !a:bang
+    call go#util#EchoError("couldn't find " . l:alt_file)
     return
-  elseif empty(a:cmd)
-    execute ":" . g:go_alternate_mode . " " . alt_file
+  endif
+
+  if bufloaded(l:alt_file)
+    let l:cmd = 'sbuffer'
   else
-    execute ":" . a:cmd . " " . alt_file
+    let l:cmd = empty(a:cmd) ? get(g:, 'go_alternate_mode', 'edit') : a:cmd
   endif
+
+  exe printf(':%s %s', l:cmd, fnameescape(l:alt_file))
 endfunction
 
 " vim: sw=2 ts=2 et

--- a/autoload/go/alternate_test.vim
+++ b/autoload/go/alternate_test.vim
@@ -1,0 +1,49 @@
+fun! Test_Alternate() abort
+  let l:cases = [
+    \ {
+        \ 'start':   'notest.go',
+        \ 'want':    'notest.go',
+        \ 'wantErr': "couldn't find notest_test.go",
+    \ },
+    \ {
+        \ 'start':   'nomain_test.go',
+        \ 'want':    'nomain_test.go',
+        \ 'wantErr': "couldn't find nomain.go",
+    \ },
+    \ {
+        \ 'start':   'bang.go',
+        \ 'want':    'bang_test.go',
+        \ 'wantErr': 0,
+        \ 'bang':    1,
+    \ },
+    \ {
+        \ 'start':   'f.go',
+        \ 'want':    'f_test.go',
+        \ 'wantErr': 0,
+        \ 'run':     'e f_test.go | silent noau w'
+    \ },
+    \ {
+        \ 'start':   'space path/a_test.go',
+        \ 'want':    'space path/a.go',
+        \ 'wantErr': 0,
+        \ 'run':     'call mkdir("space path") | e space\ path/a.go | silent noau w'
+    \ },
+  \ ]
+
+  for l:tc in l:cases
+    exe 'lcd ' . gotest#dir('', 1)
+
+    try
+      if get(l:tc, 'run', '') isnot# ''
+        exe l:tc.run
+      endif
+
+      exe 'e ' . gotest#dir(l:tc.start, 1)
+      silent call go#alternate#Switch(get(l:tc, 'bang', 0), '')
+      call assert_equal(l:tc.want, bufname('%'))
+      call assert_equal(l:tc.wantErr, gotest#lastmsg())
+    finally
+      let g:go_messages = []
+    endtry
+  endfor
+endfun

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -313,6 +313,11 @@ function! s:echo(msg, hi)
   " Tabs display as ^I or <09>, so manually expand them.
   let l:msg = map(l:msg, 'substitute(v:val, "\t", "        ", "")')
 
+  " Record messages for tests.
+  if get(g:, 'go_running_tests', 0)
+    let g:go_messages += [[a:hi, l:msg]]
+  endif
+
   exe 'echohl ' . a:hi
   for line in l:msg
     echom "vim-go: " . line

--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -1,3 +1,21 @@
+" Return a path relative to the test run directory. If the second parameter is 1
+" then it is fnameescaped()'d.
+fun! gotest#dir(path, ...) abort
+  if len(a:000) > 0 && a:1 is 1
+    return fnameescape(g:go_testdir . '/' . a:path)
+  else
+    return g:go_testdir . '/' . a:path
+  endif
+endfun
+
+" Return the last message as a string, or 0 (int) if there are no messages.
+fun! gotest#lastmsg() abort
+  if len(g:go_messages) is 0
+    return 0
+  endif
+  return join(g:go_messages[len(g:go_messages) - 1][1], '\n')
+endfun
+
 " Write a Go file to a temporary directory and append this directory to $GOPATH.
 "
 " The file will written to a:path, which is relative to the temporary directory,

--- a/scripts/runtest.vim
+++ b/scripts/runtest.vim
@@ -11,8 +11,11 @@ let s:fail = 0
 let s:done = 0
 let s:logs = []
 let s:gopath = $GOPATH
-if !exists('g:test_verbose')
-  let g:test_verbose = 0
+let g:go_testdir = '/tmp/vim-go-test/testrun'
+let g:go_running_tests = 1
+let g:go_messages = []
+if !exists('g:go_test_verbose')
+  let g:go_test_verbose = 0
 endif
 
 " Source the passed test file.
@@ -41,7 +44,7 @@ for s:test in sort(s:tests)
   endif
 
   let s:started = reltime()
-  if g:test_verbose is 1
+  if g:go_test_verbose is 1
     call add(s:logs, printf("=== RUN  %s", s:test[:-3]))
   endif
   try
@@ -50,8 +53,9 @@ for s:test in sort(s:tests)
     let v:errors += [v:exception]
   endtry
 
-  " Restore GOPATH after each test.
+  " Restore GOPATH and g:go_messages after each test.
   let $GOPATH = s:gopath
+  let g:go_messages = []
 
   let s:elapsed_time = substitute(reltimestr(reltime(s:started)), '^\s*\(.\{-}\)\s*$', '\1', '')
   let s:done += 1
@@ -64,7 +68,7 @@ for s:test in sort(s:tests)
     " Reset so we can capture failures of the next test.
     let v:errors = []
   else
-    if g:test_verbose is 1
+    if g:go_test_verbose is 1
       call add(s:logs, printf("--- PASS %s (%ss)", s:test[:-3], s:elapsed_time))
     endif
   endif
@@ -92,7 +96,7 @@ call append(line('$'), printf("%s %s %s %ss / %s tests",
       \ s:testfile,
       \ repeat(' ', 25 - len(s:testfile)),
       \ s:total_elapsed_time, s:done))
-if g:test_verbose is 0
+if g:go_test_verbose is 0
   silent :g/^$/d
 endif
 silent! write

--- a/scripts/test
+++ b/scripts/test
@@ -57,13 +57,16 @@ fi
 [ -f '/tmp/vim-go-test/test.log' ] && rm '/tmp/vim-go-test/test.log'
 [ -f '/tmp/vim-go-test/FAILED' ] && rm '/tmp/vim-go-test/FAILED'
 
+# Make sure we start with an empty testrun directory.
+rm -fr '/tmp/vim-go-test/testrun/'*
+
 # Run the actual tests.
 find "$vimgodir" -name '*_test.vim' | while read test_file; do
   [ -n "$run" -a "$(basename "$test_file")" != "$run" ] && continue
 
   "$vimgodir/scripts/run-vim" $vim -e \
     +"silent e $test_file" \
-    +"let g:test_verbose=$verbose" \
+    +"let g:go_test_verbose=$verbose" \
     -S ./scripts/runtest.vim || (
       # If Vim exits with non-0 it's almost certainly a bug in the test runner;
       # should very rarely happen in normal usage.


### PR DESCRIPTION
Use the `:sbuffer` command when it's already loaded. This is especially
useful if switchbuf is set to useopen or usetab.
Otherwise setting g:go_alternate_mode to `split` or `tabe` will just
keep on creating new windows or tabs.

This also fixes a bug where paths with e.g. a space didn't work
correctly.

Also add a test for go#alternate#Switch() and a few help for tests. If
`g:go_running_tests` is set, `go#util#Echo*` will record messages in
`g:go_messages` so we can easily access it from tests.