### PR TITLE
fix vim-vint installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM golang:1.9.1
+FROM golang:1.9.2
 
 RUN apt-get update -y && \
   apt-get install -y build-essential curl git libncurses5-dev python3-pip && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN pip3 install vim-vint
 
 RUN useradd -ms /bin/bash -d /vim-go vim-go
 USER vim-go
@@ -14,6 +16,5 @@ WORKDIR /vim-go
 RUN scripts/install-vim vim-7.4
 RUN scripts/install-vim vim-8.0
 RUN scripts/install-vim nvim
-RUN pip3 install vim-vint
 
 ENTRYPOINT ["make"]


### PR DESCRIPTION
Move RUN instruction to install vim-vint so that it will be in $PATH.
By moving the instruction to before the USER instruction, vim-vint will
be installed to /usr/local/bin instead of /vim-go/.local/bin;
$HOME/.local/bin is not in $PATH...

Also upgrade to Go 1.9.2.