### PR TITLE
doc: make godoc instance configurable

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -29,7 +29,19 @@ function! go#doc#OpenBrowser(...) abort
     let name = out["name"]
     let decl = out["decl"]
 
-    let godoc_url = "https://godoc.org/" . import
+    let godoc_url = get(g:, 'go_doc_url', 'https://godoc.org')
+    if godoc_url != 'https://godoc.org'
+      " strip last '/' character if available
+      let last_char = strlen(godoc_url) - 1
+      if godoc_url[last_char] == '/'
+        let godoc_url = strpart(godoc_url, 0, last_char)
+      endif
+
+      " custom godoc installations expects it
+      let godoc_url .= "/pkg"
+    endif
+
+    let godoc_url .= "/" . import
     if decl !~ "^package"
       let godoc_url .= "#" . name
     endif

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -30,7 +30,7 @@ function! go#doc#OpenBrowser(...) abort
     let decl = out["decl"]
 
     let godoc_url = get(g:, 'go_doc_url', 'https://godoc.org')
-    if godoc_url != 'https://godoc.org'
+    if godoc_url isnot 'https://godoc.org'
       " strip last '/' character if available
       let last_char = strlen(godoc_url) - 1
       if godoc_url[last_char] == '/'

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -197,7 +197,8 @@ COMMANDS                                                         *go-commands*
 :GoDocBrowser [word]
 
     Open the relevant GoDoc in browser for either the word[s] passed to the
-    command or by default, the word under the cursor.
+    command or by default, the word under the cursor. By default it opens the
+    documentation in 'https://godoc.org'. To change it see |'g:go_doc_url'|.
 
                                                                       *:GoFmt*
 :GoFmt
@@ -1234,6 +1235,14 @@ is enabled. >
 Maximum height for the GoDoc window created with |:GoDoc|. Default is 20. >
 
   let g:go_doc_max_height = 20
+<
+
+                                                              *'g:go_doc_url'*
+
+godoc server URL used when |:GoDocBrowser| is used. Change if you want to use
+a private internal service. Default is 'https://godoc.org'. 
+>
+  let g:go_doc_url = 'https://godoc.org'
 <
 
                                                              *'g:go_def_mode'*


### PR DESCRIPTION
Useful to use internal, private installations.