### PR TITLE
Append Go file type when creating temporary file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ IMPROVEMENTS:
 * `g:go_snippet_engine` now defaults to `automatic` to use the first installed
   snippet engine it can find.
   [[GH-1589]](https://github.com/fatih/vim-go/pull/1589).
-
+* Make sure temporary files created for `:GoFmt` end with `.go` suffix as this
+  is required by some Go formatting tools
+  [[GH-1601]](https://github.com/fatih/vim-go/pull/1601).
 
 BUG FIXES:
 

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -58,7 +58,7 @@ function! go#fmt#Format(withGoimport) abort
   endif
 
   " Write current unsaved buffer to a temp file
-  let l:tmpname = tempname()
+  let l:tmpname = tempname() . '.go'
   call writefile(go#util#GetLines(), l:tmpname)
   if go#util#IsWin()
     let l:tmpname = tr(l:tmpname, '\', '/')


### PR DESCRIPTION
A lot of scripts filter files based on their name to make sure they
operate only on the appropriate content. By appending a Go file type to
a temporary file when running a formatter, we add support for a broader
range of Go formating tools.

Fixes #208