### PR TITLE
Add support for denite.nvim about :GoDecls / :GoDeclsDir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /doc/tags
 /.coverage.covimerage
 /coverage.xml
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ FEATURES:
 * New setting `g:go_test_prepend_name` (off by default) to add the failing test
   name to the output of `:GoTest`
   [[GH-1578]](https://github.com/fatih/vim-go/pull/1578).
+* Support [denite.vim](https://github.com/Shougo/denite.nvim) for `:GoDecls[Dir]`
+  [[GH-1604]](https://github.com/fatih/vim-go/pull/1604).
 
 IMPROVEMENTS:
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -149,7 +149,8 @@ The following plugins are supported for use with vim-go:
 * Interactive |:GoDecls| and |:GoDeclsDir|:
   https://github.com/ctrlpvim/ctrlp.vim or
   https://github.com/junegunn/fzf.vim or
-  https://github.com/Shougo/unite.vim
+  https://github.com/Shougo/unite.vim or
+  https://github.com/Shougo/denite.nvim
 
 ==============================================================================
 COMMANDS                                                         *go-commands*
@@ -687,7 +688,7 @@ CTRL-t
     Requires `ctrlp.vim` or `fzf`; it will autodetect the plugin if installed,
     but you can use |'g:go_decls_mode'| to force using one or the other.
     By default `type` and `func` declarations are shown. This can be changed
-    via |'g:go_decls_includes'|. Also see |unite-decls|.
+    via |'g:go_decls_includes'|. Also see |unite-decls|, |denite-decls|.
 
                                                                  *:GoDeclsDir*
 :GoDeclsDir [dir]
@@ -696,20 +697,25 @@ CTRL-t
     [dir] is given it parses the given directory.
 
                                                                  *unite-decls*
+                                                                *denite-decls*
 :Unite decls[:file or dir]
+:Denite decls[:file or dir]
 
-    Only enabled if `unite.vim` is installed. Show declarations for all
-    functions and types on the current file or directory.  If [:file or dir]
-    is non empty, it parses the given one.
+    Only enabled if `unite.vim` or `denite.nvim` is installed. Show
+    declarations for all functions and types on the current file or directory.
+    If [:file or dir] is non empty, it parses the given one.
 >
     " show declarations on the parent directory of the current file
     :Unite decls
+    :Denite decls
 
     " show declarations on the file
     :Unite decls:foo/bar.go
+    :Denite decls:foo/bar.go
 
     " show declarations on the directory
     :Unite decls:foo
+    :Denite decls:foo
 <
                                                                      *:GoImpl*
 :GoImpl [receiver] [interface]
@@ -1581,10 +1587,10 @@ By default the template file specified by |'g:go_template_file'| is used.
 <
                                                        *'g:go_decls_includes'*
 
-Only useful if `ctrlp.vim`, `unite.vim` or `fzf` are installed. This sets
-which declarations to show for |:GoDecls| (`ctrp.vim`) and |unite-decls|
-(`unite.vim`).  It is a Comma delimited list Possible options are:
-{func,type}.  The default is: >
+Only useful if `ctrlp.vim`, `unite.vim`, `denite.nvim` or `fzf` are installed.
+This sets which declarations to show for |:GoDecls| (`ctrp.vim`),
+|unite-decls| (`unite.vim`) and |denite-decls| (`denite.nvim`).  It is a Comma
+delimited list Possible options are: {func,type}.  The default is: >
 
       let g:go_decls_includes = 'func,type'
 <

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1590,7 +1590,7 @@ By default the template file specified by |'g:go_template_file'| is used.
 Only useful if `ctrlp.vim`, `unite.vim`, `denite.nvim` or `fzf` are installed.
 This sets which declarations to show for |:GoDecls| (`ctrp.vim`),
 |unite-decls| (`unite.vim`) and |denite-decls| (`denite.nvim`).  It is a Comma
-delimited list Possible options are: {func,type}.  The default is: >
+delimited list.  Possible options are: {func,type}.  The default is: >
 
       let g:go_decls_includes = 'func,type'
 <

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -704,6 +704,8 @@ CTRL-t
     Only enabled if `unite.vim` or `denite.nvim` is installed. Show
     declarations for all functions and types on the current file or directory.
     If [:file or dir] is non empty, it parses the given one.
+
+    Note: `denite.nvim` requires NeoVim or Vim 8 with |:python3| enabled.
 >
     " show declarations on the parent directory of the current file
     :Unite decls

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -698,12 +698,12 @@ CTRL-t
 
                                                                  *unite-decls*
                                                                 *denite-decls*
-:Unite decls[:file or dir]
-:Denite decls[:file or dir]
+:Unite decls[:path]
+:Denite decls[:path]
 
     Only enabled if `unite.vim` or `denite.nvim` is installed. Show
-    declarations for all functions and types on the current file or directory.
-    If [:file or dir] is non empty, it parses the given one.
+    declarations for all functions and types on the current file or directory
+    or for [path] if given.
 
     Note: `denite.nvim` requires NeoVim or Vim 8 with |:python3| enabled.
 >
@@ -711,11 +711,11 @@ CTRL-t
     :Unite decls
     :Denite decls
 
-    " show declarations on the file
+    " show declarations in the file.
     :Unite decls:foo/bar.go
     :Denite decls:foo/bar.go
 
-    " show declarations on the directory
+    " show declarations in the directory "foo".
     :Unite decls:foo
     :Denite decls:foo
 <

--- a/rplugin/python3/denite/source/decls.py
+++ b/rplugin/python3/denite/source/decls.py
@@ -40,7 +40,7 @@ class Source(Base):
             return []
 
         expand = context['args'][0] if context['args'] else '%:p:h'
-        target = self.vim.call('expand', expand)
+        target = self.vim.funcs.expand(expand)
 
         if os.path.isdir(target):
             mode = 'dir'
@@ -49,7 +49,7 @@ class Source(Base):
         else:
             return []
 
-        if self.vim.call('exists', 'g:go_decls_includes'):
+        if self.vim.funcs.exists('g:go_decls_includes'):
             include = self.vim.eval('g:go_decls_includes')
         else:
             include = 'func,type'
@@ -68,7 +68,7 @@ class Source(Base):
         output = json.loads(txt, encoding='utf-8')
 
         def make_candidates(row):
-            name = self.vim.call('fnamemodify', row['filename'], ':~:.')
+            name = self.vim.funcs.fnamemodify(row['filename'], ':~:.')
             return {
                 'word': '{0} :{1} :{2}'.format(name, row['line'], row['full']),
                 'action__path': row['filename'],

--- a/rplugin/python3/denite/source/decls.py
+++ b/rplugin/python3/denite/source/decls.py
@@ -1,0 +1,93 @@
+# ============================================================================
+# FILE: decls.py
+# AUTHOR: delphinus <delphinus@remora.cx>
+# License: MIT license
+# ============================================================================
+
+import os
+import subprocess
+import json
+import denite.util
+from .base import Base
+
+DECLS_SYNTAX_HIGHLIGHT = [
+    {'name': 'FilePath', 're': r'[^:]*\ze:', 'link': 'Comment'},
+    {'name': 'Line', 're': r'\d\+\ze :', 'link': 'LineNr'},
+    {'name': 'WholeFunction', 're': r'\vfunc %(\([^)]+\) )?[^(]+'},
+    {'name': 'Function', 'parent': 'WholeFunction',
+     're': r'\S\+\ze(', 'link': 'Function'},
+    {'name': 'WholeType', 're': r'type \S\+'},
+    {'name': 'Type', 'parent': 'WholeType',
+     're': r'\v( )@<=\S+', 'link': 'Type'},
+    {'name': 'Separator', 're': r':', 'conceal': True},
+    {'name': 'SeparatorFunction', 'parent': 'WholeFunction',
+     're': r'func ', 'conceal': True},
+    {'name': 'SeparatorType', 'parent': 'WholeType',
+     're': r'type ', 'conceal': True},
+    ]
+
+class Source(Base):
+
+    def __init__(self, vim):
+        super().__init__(vim)
+
+        self.name = 'decls'
+        self.kind = 'file'
+
+    def gather_candidates(self, context):
+        bin_path = self.vim.call('go#path#CheckBinPath', 'motion')
+        if bin_path == '':
+            return []
+
+        expand = context['args'][0] if context['args'] else '%:p:h'
+        target = self.vim.call('expand', expand)
+
+        if os.path.isdir(target):
+            mode = 'dir'
+        elif os.path.isfile(target):
+            mode = 'file'
+        else:
+            return []
+
+        if self.vim.call('exists', 'g:go_decls_includes'):
+            include = self.vim.eval('g:go_decls_includes')
+        else:
+            include = 'func,type'
+
+        command = [bin_path, '-mode', 'decls', '-include', include,
+                   '-' + mode, target]
+
+        try:
+            cmd = subprocess.run(command, stdout=subprocess.PIPE, check=True)
+        except subprocess.CalledProcessError as err:
+            denite.util.error(self.vim,
+                              'command returned invalid response: ' + str(err))
+            return []
+
+        txt = cmd.stdout.decode('utf-8')
+        output = json.loads(txt, encoding='utf-8')
+
+        def make_candidates(row):
+            name = self.vim.call('fnamemodify', row['filename'], ':~:.')
+            return {
+                'word': '{0} :{1} :{2}'.format(name, row['line'], row['full']),
+                'action__path': row['filename'],
+                'action__line': row['line'],
+                'action__col': row['col'],
+                }
+        return list(map(make_candidates, output['decls']))
+
+    def highlight(self):
+        for syn in DECLS_SYNTAX_HIGHLIGHT:
+            containedin = self.syntax_name
+            containedin += '_' + syn['parent'] if 'parent' in syn else ''
+            conceal = ' conceal' if 'conceal' in syn else ''
+
+            self.vim.command(
+                'syntax match {0}_{1} /{2}/ contained containedin={3}{4}'
+                .format(self.syntax_name, syn['name'], syn['re'],
+                        containedin, conceal))
+
+            if 'link' in syn:
+                self.vim.command('highlight default link {0}_{1} {2}'.format(
+                    self.syntax_name, syn['name'], syn['link']))


### PR DESCRIPTION
[denite.nvim][] is the successor of [unite.vim][].  This PR enables `:GoDecls` & `:GoDeclsDir` features by denite as same as unite in #1391.

[denite.nvim]: https://github.com/Shougo/denite.nvim
[unite.vim]: https://github.com/Shougo/unite.vim

```vim
" available below as same as :Unite decls
:Denite decls
:Denite decls:foo.go
:Denite decls:foo/bar
```

denite is written for NeoVim / Vim 8 and it uses more progressive features than unite.  The expansions of denite must be written in Python3.

| `:Denite decls` |
|---|
| <img width="766" alt="2017-12-07 23 33 25" src="https://user-images.githubusercontent.com/1239245/33720448-4fd36984-dba7-11e7-8074-e40c9495ee57.png"> |

