### PR TITLE
improve testing story

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
+VIMS ?= vim-7.4 vim-8.0 nvim
+
 all: install test lint
 
 install:
 	@echo "==> Installing Vims"
-	@./scripts/install-vim vim-7.4
-	@./scripts/install-vim vim-8.0
-	@./scripts/install-vim nvim
+	@for vim in $(VIMS); do \
+		./scripts/install-vim $$vim; \
+	done
 
 test:
 	@echo "==> Running tests"
-	@./scripts/test vim-7.4
-	@./scripts/test vim-8.0
-	@./scripts/test nvim
+	@for vim in $(VIMS); do \
+		./scripts/test $$vim; \
+	done
 
 lint:
 	@echo "==> Running linting tools"
@@ -23,6 +25,5 @@ docker:
 clean:
 	@echo "==> Cleaning /tmp/vim-go-test"
 	@rm -rf /tmp/vim-go-test
-
 
 .PHONY: all test install clean lint docker

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ VIMS ?= vim-7.4 vim-8.0 nvim
 all: install test lint
 
 install:
-	@echo "==> Installing Vims"
+	@echo "==> Installing Vims: $(VIMS)"
 	@for vim in $(VIMS); do \
 		./scripts/install-vim $$vim; \
 	done
 
 test:
-	@echo "==> Running tests"
+	@echo "==> Running tests for $(VIMS)"
 	@for vim in $(VIMS); do \
 		./scripts/test $$vim; \
 	done

--- a/scripts/test
+++ b/scripts/test
@@ -80,9 +80,9 @@ done
 
 echo
 if [ -f "/tmp/vim-go-test/FAILED" ]; then
-  echo 2>&1 "Some tests FAILED"
+  echo 2>&1 "Some ($vim) tests FAILED"
   exit 1
 fi
-echo 2>&1 "All tests PASSED"
+echo 2>&1 "All ($vim) tests PASSED"
 
 # vim:ts=2:sts=2:sw=2:et


### PR DESCRIPTION
* Use a Make variable, VIMS, to specify which versions of Vim should be
  installed and tested.
* Include Vim version in test report to make correlation easier.

With these two changes, it's much easier to test only a single version
of Vim by running something like
  docker run -e VIMS=vim-8.0 -v $PWD:/vim-go vim-go-test

These changes are also included in #1583 , but it's taking me a little longer to get those done than I expected, and I've wanted the changes a couple of times while working on other things, too. Since it's separable, I figured I'd separate it :-)