### PR TITLE
Fix installing `gocode` on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ BUG FIXES:
   [[GH-1581]](https://github.com/fatih/vim-go/pull/1581).
 * Add `g:go_highlight_function_arguments` to highlight function arguments.
   [[GH-1587]](https://github.com/fatih/vim-go/pull/1587).
+* Fix installation of `gocode` on MS-Windows.
+  [[GH-1606]](https://github.com/fatih/vim-go/pull/1606).
 
 BACKWARDS INCOMPATIBILITIES:
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -146,7 +146,7 @@ function! s:GoInstallBinaries(updateBinaries, ...)
         echo "vim-go: ". binary ." not found. Installing ". importPath . " to folder " . go_bin_path
       endif
 
-      let out = go#util#System(cmd . l:goGetFlags . shellescape(importPath))
+      let out = go#util#System(printf('%s %s %s', cmd, l:goGetFlags, shellescape(importPath)))
       if go#util#ShellError() != 0
         echom "Error installing " . importPath . ": " . out
       endif


### PR DESCRIPTION
Was missing a space in composing the command, so this would get run:

    go get -v -u -ldflags -H=windowsgui"github.com/nsf/gocode"