### PR TITLE
Implement -line for fillstruct

### DIFF
--- a/autoload/go/fillstruct.vim
+++ b/autoload/go/fillstruct.vim
@@ -1,7 +1,8 @@
 function! go#fillstruct#FillStruct() abort
   let l:cmd = ['fillstruct',
       \ '-file', bufname(''),
-      \ '-offset', go#util#OffsetCursor()]
+      \ '-offset', go#util#OffsetCursor(),
+      \ '-line', line('.')]
 
   " Read from stdin if modified.
   if &modified
@@ -23,27 +24,36 @@ function! go#fillstruct#FillStruct() abort
     return
   endtry
 
-  let l:code = split(l:json['code'], "\n")
+  " Output is array:
+  "[
+  "   {"start": 92, "end": 106, "code": "mail.Address{\n\tName:    \"\",\n\tAddress: \"\",\n}"},
+  "   {...second struct...}
+  " ]
+
   let l:pos = getpos('.')
 
   try
-    " Add any code before/after the struct.
-    exe l:json['start'] . 'go'
-    let l:code[0] = getline('.')[:col('.')-1] . l:code[0]
-    exe l:json['end'] . 'go'
-    let l:code[len(l:code)-1] .= getline('.')[col('.'):]
+    for l:struct in l:json
+      let l:code = split(l:struct['code'], "\n")
 
-    " Indent every line except the first one; makes it look nice.
-    let l:indent = repeat("\t", indent('.') / &ts)
-    for i in range(1, len(l:code)-1)
-      let l:code[l:i] = l:indent . l:code[i]
+      " Add any code before/after the struct.
+      exe l:struct['start'] . 'go'
+      let l:code[0] = getline('.')[:col('.')-1] . l:code[0]
+      exe l:struct['end'] . 'go'
+      let l:code[len(l:code)-1] .= getline('.')[col('.'):]
+
+      " Indent every line except the first one; makes it look nice.
+      let l:indent = repeat("\t", indent('.') / &tabstop)
+      for l:i in range(1, len(l:code)-1)
+        let l:code[l:i] = l:indent . l:code[l:i]
+      endfor
+
+      " Out with the old ...
+      exe 'normal! ' . l:struct['start'] . 'gov' . l:struct['end'] . 'gox'
+      " ... in with the new.
+      call setline('.', l:code[0])
+      call append('.', l:code[1:])
     endfor
-
-    " Out with the old ...
-    exe 'normal! ' . l:json['start'] . 'gov' . l:json['end'] . 'gox'
-    " ... in with the new.
-    call setline('.', l:code[0])
-    call append('.', l:code[1:])
   finally
     call setpos('.', l:pos)
   endtry

--- a/autoload/go/fillstruct_test.vim
+++ b/autoload/go/fillstruct_test.vim
@@ -3,7 +3,7 @@ func! Test_fillstruct() abort
     let l:tmp = gotest#write_file('a/a.go', [
           \ 'package a',
           \ 'import "net/mail"',
-          \ 'var addr = mail.Address{}'])
+          \ "var addr = mail.\x1fAddress{}"])
 
     call go#fillstruct#FillStruct()
     call gotest#assert_buffer(1, [
@@ -11,6 +11,77 @@ func! Test_fillstruct() abort
           \ '\tName:    "",',
           \ '\tAddress: "",',
           \ '}'])
+  finally
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
+func! Test_fillstruct_line() abort
+  try
+    let l:tmp = gotest#write_file('a/a.go', [
+          \ 'package a',
+          \ 'import "net/mail"',
+          \ "\x1f" . 'var addr = mail.Address{}'])
+
+    call go#fillstruct#FillStruct()
+    call gotest#assert_buffer(1, [
+          \ 'var addr = mail.Address{',
+          \ '\tName:    "",',
+          \ '\tAddress: "",',
+          \ '}'])
+  finally
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
+func! Test_fillstruct_two_line() abort
+  try
+    let l:tmp = gotest#write_file('a/a.go', [
+          \ 'package a',
+          \ 'import (',
+          \ '"fmt"',
+          \ '"net/mail"',
+          \ ')',
+          \ "\x1f" . 'func x() { fmt.Println(mail.Address{}, mail.Address{}) }'])
+
+    call go#fillstruct#FillStruct()
+    call gotest#assert_buffer(1, [
+          \ 'import (',
+          \ '"fmt"',
+          \ '"net/mail"',
+          \ ')',
+          \ 'func x() { fmt.Println(mail.Address{',
+          \ '\tName:    "",',
+          \ '\tAddress: "",',
+          \ '}, mail.Address{',
+          \ '\tName:    "",',
+          \ '\tAddress: "",',
+          \ '}) }'])
+  finally
+    "call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
+func! Test_fillstruct_two_cursor() abort
+  try
+    let l:tmp = gotest#write_file('a/a.go', [
+          \ 'package a',
+          \ 'import (',
+          \ '"fmt"',
+          \ '"net/mail"',
+          \ ')',
+          \ "func x() { fmt.Println(mail.Address{}, mail.Ad\x1fdress{}) }"])
+
+    call go#fillstruct#FillStruct()
+    call gotest#assert_buffer(1, [
+          \ 'import (',
+          \ '"fmt"',
+          \ '"net/mail"',
+          \ ')',
+          \ 'func x() { fmt.Println(mail.Address{}, mail.Address{',
+          \ '\tName:    "",',
+          \ '\tAddress: "",',
+          \ '}) }'])
   finally
     call delete(l:tmp, 'rf')
   endtry

--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -20,10 +20,10 @@ fun! gotest#write_file(path, contents) abort
   " Set cursor.
   let l:lnum = 1
   for l:line in a:contents
-    let l:m = match(l:line, '')
+    let l:m = match(l:line, "\x1f")
     if l:m > -1
       call setpos('.', [0, l:lnum, l:m, 0])
-      call setline('.', substitute(getline('.'), '', '', ''))
+      call setline('.', substitute(getline('.'), "\x1f", '', ''))
       break
     endif
 


### PR DESCRIPTION
This way the cursor doesn't need to be exactly on the struct.

If multiple structs are found it will still prefer the one under the
cursor. Otherwise it will expand both.

Needs https://github.com/davidrjenni/reftools/pull/8 (tests will fail before that's merged)