### PR TITLE
improve neovim support

### DIFF
--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -56,10 +56,11 @@ function! go#term#newmode(bang, cmd, mode) abort
 
   " we are careful how to resize. for example it's vsplit we don't change
   " the height. The below command resizes the buffer
-  if mode =~ "split"
-    exe 'resize ' . height
-  elseif mode =~ "vsplit" || mode =~ "vertical"
+
+  if mode =~ "vertical" || mode =~ "vsplit" || mode =~ "vnew"
     exe 'vertical resize ' . width
+  elseif mode =~ "split" || mode =~ "new"
+    exe 'resize ' . height
   endif
 
   " we also need to resize the pty, so there you go...

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -44,10 +44,6 @@ function! go#term#newmode(bang, cmd, mode) abort
 
   let id = termopen(a:cmd, job)
 
-  if l:winnr !=# winnr()
-    exe l:winnr . "wincmd w"
-  endif
-
   execute cd . fnameescape(dir)
 
   let job.id = id
@@ -60,9 +56,9 @@ function! go#term#newmode(bang, cmd, mode) abort
 
   " we are careful how to resize. for example it's vertical we don't change
   " the height. The below command resizes the buffer
-  if a:mode == "split"
+  if mode =~ "split"
     exe 'resize ' . height
-  elseif a:mode == "vertical"
+  elseif mode =~ "vertical"
     exe 'vertical resize ' . width
   endif
 
@@ -71,6 +67,11 @@ function! go#term#newmode(bang, cmd, mode) abort
 
   let s:jobs[id] = job
   stopinsert
+
+  if l:winnr !=# winnr()
+    exe l:winnr . "wincmd w"
+  endif
+
   return id
 endfunction
 

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -54,11 +54,11 @@ function! go#term#newmode(bang, cmd, mode) abort
   let height = get(g:, 'go_term_height', winheight(0))
   let width = get(g:, 'go_term_width', winwidth(0))
 
-  " we are careful how to resize. for example it's vertical we don't change
+  " we are careful how to resize. for example it's vsplit we don't change
   " the height. The below command resizes the buffer
   if mode =~ "split"
     exe 'resize ' . height
-  elseif mode =~ "vertical"
+  elseif mode =~ "vsplit"
     exe 'vertical resize ' . width
   endif
 

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -58,7 +58,7 @@ function! go#term#newmode(bang, cmd, mode) abort
   " the height. The below command resizes the buffer
   if mode =~ "split"
     exe 'resize ' . height
-  elseif mode =~ "vsplit"
+  elseif mode =~ "vsplit" || mode =~ "vertical"
     exe 'vertical resize ' . width
   endif
 


### PR DESCRIPTION
1. Since `a:mode` will always be "", it's better to use `mode`. When user set `let g:go_term_mode = "split"`, it could be supported.
2. Use `=~` instead `==` to cover case like `botright split`.
3. Window switch should be done after all terminal buffer command finished.