### PR TITLE
Make sure all tests run in Neovim

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
+.local/
 .git/

--- a/scripts/test
+++ b/scripts/test
@@ -69,7 +69,7 @@ find "$vimgodir" -name '*_test.vim' | while read test_file; do
   "$vimgodir/scripts/run-vim" $coverage $vim -e \
     +"silent e $test_file" \
     +"let g:test_verbose=$verbose" \
-    -S ./scripts/runtest.vim || (
+    -S ./scripts/runtest.vim < /dev/null || (
       # If Vim exits with non-0 it's almost certainly a bug in the test runner;
       # should very rarely happen in normal usage.
       echo 'test runner failure'


### PR DESCRIPTION
Neovim closes stdin, so make sure to give it a stdin that is not
inherited from the parent process, because the parent process is reading
from its stdin...

Add .local/ to the list of ignored patterns for Docker so that Neovim
does not encounter errors trying to read the ShaDa file when trying to
build the Docker image after having run the Docker container with the
cwd mounted into the container at /vim-go.