### PR TITLE
[snippets] make "error multiple return" distinct

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -167,7 +167,7 @@ ${0}
 endsnippet
 
 # error multiple return
-snippet errn, "Error return with two return values" !b
+snippet errnn, "Error return with two return values" !b
 if err != nil {
 	return ${1:nil}, err
 }


### PR DESCRIPTION
errn was defined twice. Once for 
return nil
and another for 
return ${1:nil}, err

I propose naming the second snippet errnn, as it would commonly be used to return nil, err.