### PR TITLE
Fix go#template#create() for directories that don't exist yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ BUG FIXES:
   [[GH-1587]](https://github.com/fatih/vim-go/pull/1587).
 * Fix installation of `gocode` on MS-Windows.
   [[GH-1606]](https://github.com/fatih/vim-go/pull/1606).
+* Fix template creation for files in directories that don't exist yet.
+  [[GH-1618]](https://github.com/fatih/vim-go/pull/1618).
 
 BACKWARDS INCOMPATIBILITIES:
 

--- a/autoload/go/template.vim
+++ b/autoload/go/template.vim
@@ -6,9 +6,12 @@ function! go#template#create() abort
 
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
   let dir = getcwd()
-  execute cd . fnameescape(expand("%:p:h"))
+  let l:package_name = -1
 
-  let l:package_name = go#tool#PackageName()
+  if isdirectory(expand('%:p:h'))
+    execute cd . fnameescape(expand('%:p:h'))
+    let l:package_name = go#tool#PackageName()
+  endif
 
   " if we can't figure out any package name(no Go files or non Go package
   " files) from the directory create the template or use the cwd


### PR DESCRIPTION
Previously `vim ~/go/src/newdir/main.go` would result in:

	"~/go/src/newdir/main.go" [New DIRECTORY]
	Error detected while processing function <SNR>56_template_autocreate[3]..go#template#create:
	line    6:
	E344: Can't find directory "/home/martin/go/src/newdir" in cdpath
	E472: Command failed

With this change this gets treated like a directory which isn't a Go
package yet.