### PR TITLE
Active buffer relative to workdir for gometalint

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -88,7 +88,7 @@ function! go#lint#Gometa(autosave, ...) abort
 
   if a:autosave
     " include only messages for the active buffer
-    let cmd += ["--include='^" . expand('%:p') . ".*$'"]
+    let cmd += ["--include='" . @% . ".*$'"]
   endif
 
 


### PR DESCRIPTION
When `go#lint#Gometa` is triggered by autosave, we attempt to only show
lint warnings and errors that are applicable for the active buffer. This
is done by passing the path to the file represented by the active buffer
to gometalinter's `--include` option.

The existing behaviour expands the absolute path, whereas gometalinter
outputs paths that are relative to the current working directory.

This change modifies the variable used for matching so that we also use
the current working directory for matching against lint errors/warnings.

Signed-off-by: Tom Barlow <tomwbarlow@gmail.com>