### PR TITLE
add additional godoc url configuration

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -29,18 +29,7 @@ function! go#doc#OpenBrowser(...) abort
     let name = out["name"]
     let decl = out["decl"]
 
-    let godoc_url = get(g:, 'go_doc_url', 'https://godoc.org')
-    if godoc_url isnot 'https://godoc.org'
-      " strip last '/' character if available
-      let last_char = strlen(godoc_url) - 1
-      if godoc_url[last_char] == '/'
-        let godoc_url = strpart(godoc_url, 0, last_char)
-      endif
-
-      " custom godoc installations expects it
-      let godoc_url .= "/pkg"
-    endif
-
+    let godoc_url = s:customGodocUrl()
     let godoc_url .= "/" . import
     if decl !~ "^package"
       let godoc_url .= "#" . name
@@ -61,7 +50,7 @@ function! go#doc#OpenBrowser(...) abort
   let exported_name = pkgs[1]
 
   " example url: https://godoc.org/github.com/fatih/set#Set
-  let godoc_url = "https://godoc.org/" . pkg . "#" . exported_name
+  let godoc_url = s:customGodocUrl() . "/" . pkg . "#" . exported_name
   call go#tool#OpenBrowser(godoc_url)
 endfunction
 
@@ -225,5 +214,18 @@ function! s:godocNotFound(content) abort
   return a:content =~# '^.*: no such file or directory\n$'
 endfunction
 
+function! s:customGodocUrl() abort
+  let godoc_url = get(g:, 'go_doc_url', 'https://godoc.org')
+  if godoc_url isnot 'https://godoc.org'
+    " strip last '/' character if available
+    let last_char = strlen(godoc_url) - 1
+    if godoc_url[last_char] == '/'
+      let godoc_url = strpart(godoc_url, 0, last_char)
+    endif
+    " custom godoc installations expect /pkg before package names
+    let godoc_url .= "/pkg"
+  endif
+  return godoc_url
+endfunction
 
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
The user's configured "go_doc_url" variable should still work correctly in the case when the "gogetdoc" command isn't installed.