### PR TITLE
Fix: GoTestFunc dont respect go_test_timeout

### DIFF
--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -129,6 +129,10 @@ function! go#test#Func(bang, ...) abort
 
   if a:0
     call extend(args, a:000)
+  else
+    " only add this if no custom flags are passed
+    let timeout  = get(g:, 'go_test_timeout', '10s')
+    call add(args, printf("-timeout=%s", timeout))
   endif
 
   call call('go#test#Test', args)


### PR DESCRIPTION
Fixes #1619

Adds go_test_timeout support to GoTestFunc