### PR TITLE
support syntax highlighting for bracketed expression in fmt string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ BUG FIXES:
 * The user's configured `g:go_doc_url` variable wasn't working correctly in the
   case when the "gogetdoc" command isn't installed.
   [[GH-1629]](https://github.com/fatih/vim-go/pull/1629)
+* Highlight format specifiers with an index (e.g. `%[2]d`).
+  [[GH-1634]](https://github.com/fatih/vim-go/pull/1634)
 
 ## 1.16 - (December 29, 2017)
 

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -202,7 +202,7 @@ else
 endif
 
 if g:go_highlight_format_strings != 0
-  syn match       goFormatSpecifier   /\([^%]\(%%\)*\)\@<=%[-#0 +]*\%(\%(\%(\[\d\]\)\=\*\)\|\d\+\)\=\%(\.\%(\%(\%(\[\d\]\)\=\*\)\|\d\+\)\)\=\%(\[\d\]\)\=[vTtbcdoqxXUeEfgGsp]/ contained containedin=goString,goRawString
+  syn match       goFormatSpecifier   /\([^%]\(%%\)*\)\@<=%[-#0 +]*\%(\%(\%(\[\d\]\)\=\*\)\|\d\+\)\=\%(\.\%(\%(\%(\[\d\]\)\=\*\)\|\d\+\)\)\=\%(\[\d\]\)\=[vTtbcdoqxXUeEfFgGsp]/ contained containedin=goString,goRawString
   hi def link     goFormatSpecifier   goSpecialString
 endif
 

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -202,7 +202,7 @@ else
 endif
 
 if g:go_highlight_format_strings != 0
-  syn match       goFormatSpecifier   /\([^%]\(%%\)*\)\@<=%[-#0 +]*\%(\*\|\d\+\)\=\%(\.\%(\*\|\d\+\)\)*[vTtbcdoqxXUeEfgGsp]/ contained containedin=goString
+  syn match       goFormatSpecifier   /\([^%]\(%%\)*\)\@<=%[-#0 +]*\%(\%(\%(\[\d\]\)\=\*\)\|\d\+\)\=\%(\.\%(\%(\%(\[\d\]\)\=\*\)\|\d\+\)\)\=\%(\[\d\]\)\=[vTtbcdoqxXUeEfgGsp]/ contained containedin=goString,goRawString
   hi def link     goFormatSpecifier   goSpecialString
 endif
 

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -202,7 +202,19 @@ else
 endif
 
 if g:go_highlight_format_strings != 0
-  syn match       goFormatSpecifier   /\([^%]\(%%\)*\)\@<=%[-#0 +]*\%(\%(\%(\[\d\]\)\=\*\)\|\d\+\)\=\%(\.\%(\%(\%(\[\d\]\)\=\*\)\|\d\+\)\)\=\%(\[\d\]\)\=[vTtbcdoqxXUeEfFgGsp]/ contained containedin=goString,goRawString
+  " [n] notation is valid for specifying explicit argument indexes
+  " 1. Match a literal % not preceded by a %.
+  " 2. Match any number of -, #, 0, space, or +
+  " 3. Match * or [n]* or any number or nothing before a .
+  " 4. Match * or [n]* or any number or nothing after a .
+  " 5. Match [n] or nothing before a verb
+  " 6. Match a formatting verb
+  syn match       goFormatSpecifier   /\
+        \([^%]\(%%\)*\)\
+        \@<=%[-#0 +]*\
+        \%(\%(\%(\[\d\+\]\)\=\*\)\|\d\+\)\=\
+        \%(\.\%(\%(\%(\[\d\+\]\)\=\*\)\|\d\+\)\=\)\=\
+        \%(\[\d\+\]\)\=[vTtbcdoqxXUeEfFgGsp]/ contained containedin=goString,goRawString
   hi def link     goFormatSpecifier   goSpecialString
 endif
 


### PR DESCRIPTION
Per the go docs for the fmt package, there is a bracket expression that is supported in format strings. 

For example,
`
fmt.Sprintf("%[2]d %[1]d\n", 11, 22)
fmt.Sprintf("%[3]*.[2]*[1]f", 12.0, 2, 6)
fmt.Sprintf("%d %d %#[1]x %#x", 16, 17)
`

Should all be valid syntax highlighted format strings. 