### PR TITLE
handle testify output

### DIFF
--- a/autoload/go/test-fixtures/test/src/testify/testify_test.go
+++ b/autoload/go/test-fixtures/test/src/testify/testify_test.go
@@ -1,0 +1,27 @@
+package testify
+
+import (
+	"testing"
+)
+
+func Nop() {}
+
+func TestTestify(t *testing.T) {
+	// write consistent with github.com/stretchr/testify output that indicates
+	// the file location is line 7, the line that has the Nop function.
+	t.Errorf("%s", "\r             \r\tError Trace:\ttestify_test.go:7\n\r\tError:      \ttestify is not go test")
+}
+
+/*
+func TestMain(t *testing.T) {
+	t.Run("trying to hide", func(t *testing.T) {
+		t.Errorf("%s", "\rwhere is the indentation and filename?")
+	})
+	t.Run("fail", func(t *testing.T) {
+		t.Error("fail")
+	})
+	t.Run("is false", func(t *testing.T) {
+		assert.False(t, true)
+	})
+}
+*/

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -295,6 +295,13 @@ function! s:errorformat() abort
     let format .= ",%-G" . indent . "--- FAIL: %.%#"
   endif
 
+  " Match github.com/stretchr/testify output. We won't make a great effort
+  " (e.g. we won't try to match messages that contain embedded newlines), but
+  " we can hit the 80% case pretty easily. This has to be done before the
+  " entries for normal go test output.
+  let format .= ",%A" . indent . "%\\t%\\+%\\f%\\+:%\\d%\\+: %\\r %\\+%\\r%\\tError Trace:%\\t%f:%l"
+  let format .= ",%C" . indent . "%\\t%\\{2}%\\r%\\tError:      %\\t%m"
+
   " Matches test output lines.
   "
   " All test output lines start with the test indentation and a tab, followed

--- a/autoload/go/test_test.vim
+++ b/autoload/go/test_test.vim
@@ -57,6 +57,14 @@ func! Test_GoTestTimeout() abort
   unlet g:go_test_timeout
 endfunc
 
+func! Test_GoTestTestify() abort
+  let expected = [
+        \ {'lnum': 7, 'bufnr': 9, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': "\ntestify is not go test"},
+      \ ]
+
+  call s:test('testify/testify_test.go', expected)
+endfunc
+
 func! s:test(file, expected, ...) abort
   if has('nvim')
     " nvim mostly shows test errors correctly, but the the expected errors are


### PR DESCRIPTION
I'm not sure if we want to do this or not, but the fix was relatively simple... testify is its own beast, though, and I'm reluctant to add official support for it.

Fixes #1636