### PR TITLE
Fix metalinter problems

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -64,7 +64,7 @@ function! go#lint#Gometa(autosave, ...) abort
 
   " Include only messages for the active buffer for autosave.
   if a:autosave
-    let cmd += [printf('--include=%s.*$', @%)]
+    let cmd += [printf('--include=^%s:.*$', fnamemodify(expand('%:p'), ":."))]
   endif
 
   " gometalinter has a default deadline of 5 seconds.

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -24,9 +24,9 @@ endif
 
 function! go#lint#Gometa(autosave, ...) abort
   if a:0 == 0
-    let goargs = shellescape(expand('%:p:h'))
+    let goargs = [expand('%:p:h')]
   else
-    let goargs = go#util#Shelljoin(a:000)
+    let goargs = a:000
   endif
 
   let bin_path = go#path#CheckBinPath("gometalinter")
@@ -54,9 +54,6 @@ function! go#lint#Gometa(autosave, ...) abort
     " test files. One example of a linter that will not run against tests if
     " we do not specify this flag is errcheck.
     let cmd += ["--tests"]
-
-    " path
-    let cmd += [expand('%:p:h')]
   else
     " the user wants something else, let us use it.
     let cmd += split(g:go_metalinter_command, " ")
@@ -83,12 +80,17 @@ function! go#lint#Gometa(autosave, ...) abort
       let cmd += ["--deadline=" . deadline]
     endif
 
+    let cmd += goargs
+
     call s:lint_job({'cmd': cmd})
     return
   endif
 
   " We're calling gometalinter synchronously.
   let cmd += ["--deadline=" . get(g:, 'go_metalinter_deadline', "5s")]
+
+  let cmd += goargs
+
   let [l:out, l:err] = go#util#Exec(cmd)
 
   let l:listtype = go#list#Type("GoMetaLinter")

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -88,7 +88,7 @@ function! go#lint#Gometa(autosave, ...) abort
 
   if a:autosave
     " include only messages for the active buffer
-    let cmd += ["--include='^" . expand('%:p') . ".*$'"]
+    let cmd += ["--include='" . @% . ".*$'"]
   endif
 
 

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -1,0 +1,69 @@
+func! Test_Gometa() abort
+  let $GOPATH = fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint'
+  silent exe 'e ' . $GOPATH . '/src/lint/lint.go'
+
+  let expected = [
+        \ {'lnum': 5, 'bufnr': 3, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingFooDoc should have comment or be unexported (golint)'}
+      \ ]
+
+  " clear the quickfix lists
+  call setqflist([], 'r')
+
+  " call go#lint#ToggleMetaLinterAutoSave from lint.vim so that the file will
+  " be autoloaded and the default for g:go_metalinter_enabled will be set so
+  " we can capture it to restore it after the test is run.
+  call go#lint#ToggleMetaLinterAutoSave()
+  " And restore it back to its previous value
+  call go#lint#ToggleMetaLinterAutoSave()
+
+  let orig_go_metalinter_enabled = g:go_metalinter_enabled
+  let g:go_metalinter_enabled = ['golint']
+
+  call go#lint#Gometa(0, $GOPATH . '/src/foo')
+
+  let actual = getqflist()
+  let start = reltime()
+  while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+    sleep 100m
+    let actual = getqflist()
+  endwhile
+
+  call gotest#assert_quickfix(actual, expected)
+  let g:go_metalinter_enabled = orig_go_metalinter_enabled
+endfunc
+
+func! Test_GometaAutoSave() abort
+  let $GOPATH = fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint'
+  silent exe 'e ' . $GOPATH . '/src/lint/lint.go'
+
+  let expected = [
+        \ {'lnum': 5, 'bufnr': 2, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported (golint)'}
+      \ ]
+
+  " clear the quickfix lists
+  call setqflist([], 'r')
+
+  " call go#lint#ToggleMetaLinterAutoSave from lint.vim so that the file will
+  " be autoloaded and the default for g:go_metalinter_autosave_enabled will be
+  " set so we can capture it to restore it after the test is run.
+  call go#lint#ToggleMetaLinterAutoSave()
+  " And restore it back to its previous value
+  call go#lint#ToggleMetaLinterAutoSave()
+
+  let orig_go_metalinter_autosave_enabled = g:go_metalinter_autosave_enabled
+  let g:go_metalinter_autosave_enabled = ['golint']
+
+  call go#lint#Gometa(1)
+
+  let actual = getqflist()
+  let start = reltime()
+  while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+    sleep 100m
+    let actual = getqflist()
+  endwhile
+
+  call gotest#assert_quickfix(actual, expected)
+  let g:go_metalinter_autosave_enabled = orig_go_metalinter_autosave_enabled
+endfunc
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/test-fixtures/lint/src/foo/foo.go
+++ b/autoload/go/test-fixtures/lint/src/foo/foo.go
@@ -1,0 +1,7 @@
+package foo
+
+import "fmt"
+
+func MissingFooDoc() {
+	fmt.Println("missing doc")
+}

--- a/autoload/go/test-fixtures/lint/src/lint/lint.go
+++ b/autoload/go/test-fixtures/lint/src/lint/lint.go
@@ -1,0 +1,7 @@
+package lint
+
+import "fmt"
+
+func MissingDoc() {
+	fmt.Println("missing doc")
+}

--- a/autoload/go/test-fixtures/lint/src/lint/quux.go
+++ b/autoload/go/test-fixtures/lint/src/lint/quux.go
@@ -1,0 +1,7 @@
+package lint
+
+import "fmt"
+
+func AlsoMissingDoc() {
+	fmt.Println("missing doc")
+}

--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -102,4 +102,29 @@ fun! gotest#assert_fixture(path) abort
   call gotest#assert_buffer(0, l:want)
 endfun
 
+func! gotest#assert_quickfix(got, want) abort
+  call assert_equal(len(a:want), len(a:got), "number of errors")
+  if len(a:want) != len(a:got)
+    call assert_equal(a:want, a:got)
+    return
+  endif
+
+  let i = 0
+  while i < len(a:want)
+    let want_item = a:want[i]
+    let got_item = a:got[i]
+    let i += 1
+
+    call assert_equal(want_item.bufnr, got_item.bufnr, "bufnr")
+    call assert_equal(want_item.lnum, got_item.lnum, "lnum")
+    call assert_equal(want_item.col, got_item.col, "col")
+    call assert_equal(want_item.vcol, got_item.vcol, "vcol")
+    call assert_equal(want_item.nr, got_item.nr, "nr")
+    call assert_equal(want_item.pattern, got_item.pattern, "pattern")
+    call assert_equal(want_item.text, got_item.text, "text")
+    call assert_equal(want_item.type, got_item.type, "type")
+    call assert_equal(want_item.valid, got_item.valid, "valid")
+  endwhile
+endfunc
+
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
Make sure linter errors for the file being saved are shown in vim74 and
nvim.

Make sure only linter errors for the file being saved are shown in vim8.
Previously, all linter errors for all files in the current file's
directory were being shown.

Make sure gometalinter is run on the given directories when arguments 
are given to `:GoMetaLinter`.

Fixes #1623