### PR TITLE
respect a changed g:go_test_show_name

### DIFF
--- a/autoload/go/test-fixtures/test/src/showname/showname_test.go
+++ b/autoload/go/test-fixtures/test/src/showname/showname_test.go
@@ -1,0 +1,11 @@
+package main
+
+import "testing"
+
+func TestHelloWorld(t *testing.T) {
+	t.Error("so long")
+
+	t.Run("sub", func(t *testing.T) {
+		t.Error("thanks for all the fish")
+	})
+}

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -257,6 +257,7 @@ endfunction
 
 
 let s:efm= ""
+let s:go_test_show_name=0
 
 function! s:errorformat() abort
   " NOTE(arslan): once we get JSON output everything will be easier :).
@@ -265,14 +266,16 @@ function! s:errorformat() abort
   "   https://github.com/golang/go/issues/2981.
   let goroot = go#util#goroot()
 
-  if s:efm != ""
+  let show_name=get(g:, 'go_test_show_name', 0)
+  if s:efm != "" && s:go_test_show_name == show_name
     return s:efm
   endif
+  let s:go_test_show_name = show_name
 
-  " each level of test indents the test output 4 spaces.
-  " TODO(bc): figure out how to use 0 or more groups of four spaces for the
-  " indentation. '%\\(    %\\)%#' should work, but doesn't.
-  let indent = " %#"
+  " each level of test indents the test output 4 spaces. Capturing groups
+  " (e.g. \(\)) cannot be used in an errorformat, but non-capturing groups can
+  " (e.g. \%(\)).
+  let indent = '%\\%(    %\\)%#'
 
   " match compiler errors
   let format = "%f:%l:%c: %m"
@@ -289,8 +292,8 @@ function! s:errorformat() abort
   "
   " e.g.:
   "   '--- FAIL: TestSomething (0.00s)'
-  if get(g:, 'go_test_show_name', 0)
-    let format .= ",%+G" . indent . "--- FAIL: %.%#"
+  if show_name
+    let format .= ",%G" . indent . "--- FAIL: %m (%.%#)"
   else
     let format .= ",%-G" . indent . "--- FAIL: %.%#"
   endif

--- a/autoload/go/test_test.vim
+++ b/autoload/go/test_test.vim
@@ -57,6 +57,19 @@ func! Test_GoTestTimeout() abort
   unlet g:go_test_timeout
 endfunc
 
+func! Test_GoTestShowName() abort
+  let expected = [
+        \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'TestHelloWorld'},
+        \ {'lnum': 6, 'bufnr': 9, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'so long'},
+        \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'TestHelloWorld/sub'},
+        \ {'lnum': 9, 'bufnr': 9, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'thanks for all the fish'},
+      \ ]
+
+  let g:go_test_show_name=1
+  call s:test('showname/showname_test.go', expected)
+  let g:go_test_show_name=0
+endfunc
+
 func! s:test(file, expected, ...) abort
   if has('nvim')
     " nvim mostly shows test errors correctly, but the the expected errors are
@@ -86,17 +99,6 @@ func! s:test(file, expected, ...) abort
   while len(actual) == 0 && reltimefloat(reltime(start)) < 10
     sleep 100m
     let actual = getqflist()
-  endwhile
-
-  " for some reason, when run headless, the quickfix lists includes a line
-  " that should have been filtered out; remove it manually. The line is not
-  " present when run manually.
-  let i = 0
-  while i < len(actual)
-    if actual[i].text =~# '^=== RUN   .*'
-      call remove(actual, i)
-    endif
-    let i += 1
   endwhile
 
   call assert_equal(len(a:expected), len(actual), "number of errors")


### PR DESCRIPTION
Respect the current value of g:go_test_show_name on :GoTest runs after
the first one by invalidating the cached errorformat value when the
g:go_test_show_name value is not the same as it was when the errorformat
value was last cached.

Only show the test name for failed tests instead of including the
'--- FAIL: ' prefix and the duration suffix when g:go_test_show_name=1.

Resolve a TODO item in the test errorformat so that the regular
expression used for test errorformat values is more precise.

Remove a bit of testing code that is no longer needed; it was probably
rendered obsolete with some recent changes to how the errorformat value
is created.