### PR TITLE
Fix ftdetect

### DIFF
--- a/ftdetect/gofiletype.vim
+++ b/ftdetect/gofiletype.vim
@@ -1,3 +1,5 @@
+" vint: -ProhibitAutocmdWithNoGroup
+
 " We take care to preserve the user's fileencodings and fileformats,
 " because those settings are global (not buffer local), yet we want
 " to override them for loading Go files, which are defined to be UTF-8.
@@ -18,17 +20,15 @@ function! s:gofiletype_post()
   let &g:fileencodings = s:current_fileencodings
 endfunction
 
-augroup vim-go-filetype
-  autocmd!
-  au BufNewFile *.go setfiletype go | setlocal fileencoding=utf-8 fileformat=unix
-  au BufRead *.go call s:gofiletype_pre("go")
-  au BufReadPost *.go call s:gofiletype_post()
+" Note: should not use augroup in ftdetect (see :help ftdetect)
+au BufNewFile *.go setfiletype go | setlocal fileencoding=utf-8 fileformat=unix
+au BufRead *.go call s:gofiletype_pre("go")
+au BufReadPost *.go call s:gofiletype_post()
 
-  au BufNewFile *.s setfiletype asm | setlocal fileencoding=utf-8 fileformat=unix
-  au BufRead *.s call s:gofiletype_pre("asm")
-  au BufReadPost *.s call s:gofiletype_post()
+au BufNewFile *.s setfiletype asm | setlocal fileencoding=utf-8 fileformat=unix
+au BufRead *.s call s:gofiletype_pre("asm")
+au BufReadPost *.s call s:gofiletype_post()
 
-  au BufRead,BufNewFile *.tmpl set filetype=gohtmltmpl
-augroup end
+au BufRead,BufNewFile *.tmpl set filetype=gohtmltmpl
 
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
When sourcing `ftdetect/*.vim` (in `$VIMRUNTIME/filetype.vim`), `augroup filetypedetect` is already set.

Thus using `augroup` in ftdetect script, autocmds in gofiletype.vim and in other ftdetect scripts sourced after gofiletype.vim do not belong to `augroup filetypedetect`.
This makes some behaviors about filetype (e.g. `:filetype off`) broken.