### PR TITLE
Fixes issue where GoRename is passed a resolved path

### DIFF
--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -38,7 +38,7 @@ function! go#rename#Rename(bang, ...) abort
     return
   endif
 
-  let fname = expand('%:p')
+  let fname = expand('%:t')
   let pos = go#util#OffsetCursor()
   let offset = printf('%s:#%d', fname, pos)
 


### PR DESCRIPTION
VIM resolves paths that include links, if a file resides
outside $GOPATH/src then gorename has trouble, even if
the file is linked into $GOPATH/src

For instance:
~/local/src/github.com/abates/mypkg
ln -s ~/local/src/github.com/abates/mypkg
$GOPATH/src/github.com/abates/mypkg

Even if the file is opened from the gopath, gorename fails with
vim-go: gorename: can't find package containing /Users/user/local/src/github.com/abates/mypkg

This commit fixes the issue by passing only the filename (as
opposed to the full path) to gorename, which seems to fix
the issue