### PR TITLE
Fix handling and change name of g:go_metalinter_excludes

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -10,8 +10,8 @@ if !exists("g:go_metalinter_enabled")
   let g:go_metalinter_enabled = ['vet', 'golint', 'errcheck']
 endif
 
-if !exists("g:go_metalinter_excludes")
-  let g:go_metalinter_excludes = []
+if !exists("g:go_metalinter_disabled")
+  let g:go_metalinter_disabled = []
 endif
 
 if !exists("g:go_golint_bin")
@@ -44,8 +44,8 @@ function! go#lint#Gometa(autosave, ...) abort
       let cmd += ["--enable=".linter]
     endfor
 
-    for exclude in g:go_metalinter_excludes
-      let cmd += ["--exclude=".exclude]
+    for linter in g:go_metalinter_disabled
+      let cmd += ["--disable=".linter]
     endfor
 
     " gometalinter has a --tests flag to tell its linters whether to run

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -32,6 +32,40 @@ func! Test_Gometa() abort
   let g:go_metalinter_enabled = orig_go_metalinter_enabled
 endfunc
 
+func! Test_GometaWithDisabled() abort
+  let $GOPATH = fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint'
+  silent exe 'e ' . $GOPATH . '/src/lint/lint.go'
+
+  let expected = [
+        \ {'lnum': 5, 'bufnr': 3, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingFooDoc should have comment or be unexported (golint)'}
+      \ ]
+
+  " clear the quickfix lists
+  call setqflist([], 'r')
+
+  " call go#lint#ToggleMetaLinterAutoSave from lint.vim so that the file will
+  " be autoloaded and the default for g:go_metalinter_disabled will be set so
+  " we can capture it to restore it after the test is run.
+  call go#lint#ToggleMetaLinterAutoSave()
+  " And restore it back to its previous value
+  call go#lint#ToggleMetaLinterAutoSave()
+
+  let orig_go_metalinter_disabled = g:go_metalinter_disabled
+  let g:go_metalinter_disabled = ['vet']
+
+  call go#lint#Gometa(0, $GOPATH . '/src/foo')
+
+  let actual = getqflist()
+  let start = reltime()
+  while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+    sleep 100m
+    let actual = getqflist()
+  endwhile
+
+  call gotest#assert_quickfix(actual, expected)
+  let g:go_metalinter_disabled = orig_go_metalinter_disabled
+endfunc
+
 func! Test_GometaAutoSave() abort
   let $GOPATH = fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint'
   silent exe 'e ' . $GOPATH . '/src/lint/lint.go'

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1384,17 +1384,17 @@ default it's using `vet` and `golint`.
 <
                                                    *'g:go_metalinter_enabled'*
 
-Specifies the currently enabled linters for the |:GoMetaLinter| command. By
-default it's using `vet`, `golint` and `errcheck`.
+Specifies the linters to enable for the |:GoMetaLinter| command. By default
+it's using `vet`, `golint` and `errcheck`.
 >
   let g:go_metalinter_enabled = ['vet', 'golint', 'errcheck']
 <
-                                                  *'g:go_metalinter_excludes'*
+                                                  *'g:go_metalinter_disabled'*
 
-Specifies the linters to be excluded from the |:GoMetaLinter| command. By
-default it's empty
+Specifies the linters to disable for the |:GoMetaLinter| command. By default
+it's empty
 >
-  let g:go_metalinter_excludes = []
+  let g:go_metalinter_disabled = []
 <
                                                    *'g:go_metalinter_command'*
 


### PR DESCRIPTION
Use gometalinter's `--disable` option instead of its `--exclude` to
disable linters specified in `g:go_metalinter_excludes`; `--exclude` is
to exclude files, `--disable` is for disabling linters.

Rename `g:go_metalinter_excludes` to `g:go_metalinter_disabled` to more
accurately reflect its purpose in its name and so that it's symmetric
with `g:go_metalinter_enabled`.