### PR TITLE
Reduce path function scope

### DIFF
--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -45,9 +45,9 @@ function! go#path#Default() abort
   return $GOPATH
 endfunction
 
-" HasPath checks whether the given path exists in GOPATH environment variable
+" s:HasPath checks whether the given path exists in GOPATH environment variable
 " or not
-function! go#path#HasPath(path) abort
+function! s:HasPath(path) abort
   let go_paths = split(go#path#Default(), go#util#PathListSep())
   let last_char = strlen(a:path) - 1
 
@@ -94,11 +94,11 @@ function! go#path#Detect() abort
     " gb vendor plugin
     " (https://github.com/constabulary/gb/tree/master/cmd/gb-vendor)
     let gb_vendor_root = src_path . "vendor" . go#util#PathSep()
-    if isdirectory(gb_vendor_root) && !go#path#HasPath(gb_vendor_root)
+    if isdirectory(gb_vendor_root) && !s:HasPath(gb_vendor_root)
       let gopath = gb_vendor_root . go#util#PathListSep() . gopath
     endif
 
-    if !go#path#HasPath(src_path)
+    if !s:HasPath(src_path)
       let gopath =  src_path . go#util#PathListSep() . gopath
     endif
   endif
@@ -108,7 +108,7 @@ function! go#path#Detect() abort
   if !empty(godeps_root)
     let godeps_path = join([fnamemodify(godeps_root, ':p:h:h'), "Godeps", "_workspace" ], go#util#PathSep())
 
-    if !go#path#HasPath(godeps_path)
+    if !s:HasPath(godeps_path)
       let gopath =  godeps_path . go#util#PathListSep() . gopath
     endif
   endif

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -164,7 +164,7 @@ function! go#path#CheckBinPath(binpath) abort
     let $PATH = old_path
 
     if go#util#IsUsingCygwinShell() == 1
-      return go#path#CygwinPath(binpath)
+      return s:CygwinPath(binpath)
     endif
 
     return binpath
@@ -183,13 +183,13 @@ function! go#path#CheckBinPath(binpath) abort
   let $PATH = old_path
 
   if go#util#IsUsingCygwinShell() == 1
-    return go#path#CygwinPath(a:binpath)
+    return s:CygwinPath(a:binpath)
   endif
 
   return go_bin_path . go#util#PathSep() . basename
 endfunction
 
-function! go#path#CygwinPath(path)
+function! s:CygwinPath(path)
    return substitute(a:path, '\\', '/', "g")
 endfunction
 


### PR DESCRIPTION
Reduce the visibility of some functions that are never called outside of the script in which they are declared.