### PR TITLE
separate gometalinter error list use cases

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -82,7 +82,7 @@ function! go#lint#Gometa(autosave, ...) abort
 
     let cmd += goargs
 
-    call s:lint_job({'cmd': cmd})
+    call s:lint_job({'cmd': cmd}, a:autosave)
     return
   endif
 
@@ -93,7 +93,12 @@ function! go#lint#Gometa(autosave, ...) abort
 
   let [l:out, l:err] = go#util#Exec(cmd)
 
-  let l:listtype = go#list#Type("GoMetaLinter")
+  if a:autosave
+    let l:listtype = go#list#Type("GoMetaLinterAutoSave")
+  else
+    let l:listtype = go#list#Type("GoMetaLinter")
+  endif
+
   if l:err == 0
     redraw | echo
     call go#list#Clean(l:listtype)
@@ -237,7 +242,7 @@ function! go#lint#ToggleMetaLinterAutoSave() abort
   call go#util#EchoProgress("auto metalinter enabled")
 endfunction
 
-function s:lint_job(args)
+function! s:lint_job(args, autosave)
   let status_dir = expand('%:p:h')
   let started_at = reltime()
 
@@ -250,7 +255,12 @@ function s:lint_job(args)
   " autowrite is not enabled for jobs
   call go#cmd#autowrite()
 
-  let l:listtype = go#list#Type("GoMetaLinter")
+  if a:autosave
+    let l:listtype = go#list#Type("GoMetaLinterAutoSave")
+  else
+    let l:listtype = go#list#Type("GoMetaLinter")
+  endif
+
   let l:errformat = '%f:%l:%c:%t%*[^:]:\ %m,%f:%l::%t%*[^:]:\ %m'
 
   function! s:callback(chan, msg) closure

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -74,8 +74,10 @@ func! Test_GometaAutoSave() abort
         \ {'lnum': 5, 'bufnr': 2, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported (golint)'}
       \ ]
 
-  " clear the quickfix lists
-  call setqflist([], 'r')
+  let winnr = winnr()
+
+  " clear the location lists
+  call setloclist(l:winnr, [], 'r')
 
   " call go#lint#ToggleMetaLinterAutoSave from lint.vim so that the file will
   " be autoloaded and the default for g:go_metalinter_autosave_enabled will be
@@ -89,11 +91,11 @@ func! Test_GometaAutoSave() abort
 
   call go#lint#Gometa(1)
 
-  let actual = getqflist()
+  let actual = getloclist(l:winnr)
   let start = reltime()
   while len(actual) == 0 && reltimefloat(reltime(start)) < 10
     sleep 100m
-    let actual = getqflist()
+    let actual = getloclist(l:winnr)
   endwhile
 
   call gotest#assert_quickfix(actual, expected)

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -137,21 +137,22 @@ endfunction
 " single file or buffer. Keys that begin with an underscore are not supported
 " in g:go_list_type_commands.
 let s:default_list_type_commands = {
-      \ "GoBuild":      "quickfix",
-      \ "GoErrCheck":   "quickfix",
-      \ "GoFmt":        "locationlist",
-      \ "GoGenerate":   "quickfix",
-      \ "GoInstall":    "quickfix",
-      \ "GoLint":       "quickfix",
-      \ "GoMetaLinter": "quickfix",
-      \ "GoModifyTags": "locationlist",
-      \ "GoRename":     "quickfix",
-      \ "GoRun":        "quickfix",
-      \ "GoTest":       "quickfix",
-      \ "GoVet":        "quickfix",
-      \ "_guru":        "locationlist",
-      \ "_term":        "locationlist",
-      \ "_job":         "locationlist",
+      \ "GoBuild":              "quickfix",
+      \ "GoErrCheck":           "quickfix",
+      \ "GoFmt":                "locationlist",
+      \ "GoGenerate":           "quickfix",
+      \ "GoInstall":            "quickfix",
+      \ "GoLint":               "quickfix",
+      \ "GoMetaLinter":         "quickfix",
+      \ "GoMetaLinterAutoSave": "locationlist",
+      \ "GoModifyTags":         "locationlist",
+      \ "GoRename":             "quickfix",
+      \ "GoRun":                "quickfix",
+      \ "GoTest":               "quickfix",
+      \ "GoVet":                "quickfix",
+      \ "_guru":                "locationlist",
+      \ "_term":                "locationlist",
+      \ "_job":                 "locationlist",
   \ }
 
 function! go#list#Type(for) abort

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -797,6 +797,9 @@ CTRL-t
 
     Toggles |'g:go_metalinter_autosave'|.
 
+    By default, `gometalinter` messages will be shown in the |location-list|
+    window. The list to use can be set using |'g:go_list_type_commands'|.
+
                                                  *:GoTemplateAutoCreateToggle*
 :GoTemplateAutoCreateToggle
 
@@ -1371,8 +1374,12 @@ function when using the `af` text object. By default it's enabled. >
                                                   *'g:go_metalinter_autosave'*
 
 Use this option to auto |:GoMetaLinter| on save. Only linter messages for
-the active buffer will be shown. By default it's disabled >
+the active buffer will be shown.
 
+By default, `gometalinter` messages will be shown in the |location-list|
+window. The list to use can be set using |'g:go_list_type_commands'|.
+
+ By default it's disabled >
   let g:go_metalinter_autosave = 0
 <
                                           *'g:go_metalinter_autosave_enabled'*

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1437,9 +1437,9 @@ Specifies the type of list to use for command outputs (such as errors from
 builds, results from static analysis commands, etc...). When an expected key
 is not present in the dictionary, |'g:go_list_type'| will be used instead.
 Supported keys are "GoBuild", "GoErrCheck", "GoFmt", "GoInstall", "GoLint",
-"GoMetaLinter", "GoModifyTags" (used for both :GoAddTags and :GoRemoveTags),
-"GoRename", "GoRun", and "GoTest".  Supported values for each command are
-"quickfix" and "locationlist".
+"GoMetaLinter", "GoMetaLinterAutoSave", "GoModifyTags" (used for both
+:GoAddTags and :GoRemoveTags), "GoRename", "GoRun", and "GoTest".  Supported
+values for each command are "quickfix" and "locationlist".
 >
   let g:go_list_type_commands = {}
 <


### PR DESCRIPTION
gometalinter is used in two distinct cases. When run using
:GoMetaLinter, all of its output is used. When run automatically on save
(e.g. g:go_metalinter_autosave=1), only its output that applies to the
current buffer is used. In that case, it makes sense to show its
messages in the location list without forcing the user to also use the
location list when the user executes :GoMetaLinter.

Therefore, add a new key to g:go_list_type_commands,
GoMetaLinterAutoSave, with a default value of locationlist and modify
go#lint#Gometa to distinguish between the two cases.

Fixes #1644