### PR TITLE
handle autowriteall the same as autowrite

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -1,5 +1,5 @@
 function! go#cmd#autowrite() abort
-  if &autowrite == 1
+  if &autowrite == 1 || &autowriteall == 1
     silent! wall
   endif
 endfunction


### PR DESCRIPTION
Vim docs say that autowriteall implies autowrite, so make sure that
go#cmd#autowrite() has the same behavior when only one of either
autowrite or autowriteall is set.