### PR TITLE
Fix async race

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -269,7 +269,7 @@ function s:cmd_job(args) abort
   " autowrite is not enabled for jobs
   call go#cmd#autowrite()
 
-  function! s:error_info_cb(job, exit_status, data) closure abort
+  function! s:complete(job, exit_status, data) closure abort
     let status = {
           \ 'desc': 'last status',
           \ 'type': a:args.cmd[1],
@@ -288,12 +288,13 @@ function s:cmd_job(args) abort
     call go#statusline#Update(status_dir, status)
   endfunction
 
-  let a:args.error_info_cb = funcref('s:error_info_cb')
+  let a:args.complete = funcref('s:complete')
   let callbacks = go#job#Spawn(a:args)
 
   let start_options = {
         \ 'callback': callbacks.callback,
         \ 'exit_cb': callbacks.exit_cb,
+        \ 'close_cb': callbacks.close_cb,
         \ }
 
   " pre start

--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -51,7 +51,7 @@ function! go#coverage#Buffer(bang, ...) abort
   if go#util#has_job()
     call s:coverage_job({
           \ 'cmd': ['go', 'test', '-coverprofile', l:tmpname] + a:000,
-          \ 'custom_cb': function('s:coverage_callback', [l:tmpname]),
+          \ 'complete': function('s:coverage_callback', [l:tmpname]),
           \ 'bang': a:bang,
           \ 'for': 'GoTest',
           \ })
@@ -107,7 +107,7 @@ function! go#coverage#Browser(bang, ...) abort
   if go#util#has_job()
     call s:coverage_job({
           \ 'cmd': ['go', 'test', '-coverprofile', l:tmpname],
-          \ 'custom_cb': function('s:coverage_browser_callback', [l:tmpname]),
+          \ 'complete': function('s:coverage_browser_callback', [l:tmpname]),
           \ 'bang': a:bang,
           \ 'for': 'GoTest',
           \ })
@@ -278,7 +278,8 @@ function s:coverage_job(args)
   call go#cmd#autowrite()
 
   let status_dir =  expand('%:p:h')
-  function! s:error_info_cb(job, exit_status, data) closure
+  let Complete = a:args.complete
+  function! s:complete(job, exit_status, data) closure
     let status = {
           \ 'desc': 'last status',
           \ 'type': "coverage",
@@ -290,14 +291,16 @@ function s:coverage_job(args)
     endif
 
     call go#statusline#Update(status_dir, status)
+    return Complete(a:job, a:exit_status, a:data)
   endfunction
 
-  let a:args.error_info_cb = funcref('s:error_info_cb')
+  let a:args.complete = funcref('s:complete')
   let callbacks = go#job#Spawn(a:args)
 
   let start_options = {
         \ 'callback': callbacks.callback,
         \ 'exit_cb': callbacks.exit_cb,
+        \ 'close_cb': callbacks.close_cb,
         \ }
 
   " pre start

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -53,7 +53,7 @@ function! go#def#Jump(mode) abort
     if go#util#has_job()
       let l:spawn_args = {
             \ 'cmd': cmd,
-            \ 'custom_cb': function('s:jump_to_declaration_cb', [a:mode, bin_name]),
+            \ 'complete': function('s:jump_to_declaration_cb', [a:mode, bin_name]),
             \ }
 
       if &modified
@@ -292,16 +292,12 @@ function! go#def#Stack(...) abort
 endfunction
 
 function s:def_job(args) abort
-  function! s:error_info_cb(job, exit_status, data) closure
-    " do not print anything during async definition search&jump
-  endfunction
-
-  let a:args.error_info_cb = funcref('s:error_info_cb')
   let callbacks = go#job#Spawn(a:args)
 
   let start_options = {
         \ 'callback': callbacks.callback,
         \ 'exit_cb': callbacks.exit_cb,
+        \ 'close_cb': callbacks.close_cb,
         \ }
 
   if &modified

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -162,8 +162,12 @@ function! s:async_guru(args) abort
 
   let status = {}
   let exitval = 0
+  let closed = 0
+  let exited = 0
 
   function! s:exit_cb(job, exitval) closure
+    let exited = 1
+
     let status = {
           \ 'desc': 'last status',
           \ 'type': statusline_type,
@@ -176,9 +180,21 @@ function! s:async_guru(args) abort
     endif
 
     call go#statusline#Update(status_dir, status)
+
+    if closed
+      call s:complete()
+    endif
   endfunction
 
   function! s:close_cb(ch) closure
+    let closed = 1
+
+    if exited
+      call s:complete()
+    endif
+  endfunction
+
+  function! s:complete() closure
     let out = join(messages, "\n")
 
     if has_key(a:args, 'custom_parse')

--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -1,7 +1,56 @@
-" Spawn returns callbacks to be used with job_start.  It's abstracted to be
-" used with various go command, such as build, test, install, etc.. This avoid
-" us to write the same callback over and over for some commands. It's fully
-" customizable so each command can change it to it's own logic.
+" Spawn returns callbacks to be used with job_start. It is abstracted to be
+" used with various go commands, such as build, test, install, etc.. This
+" allows us to avoid writing the same callback over and over for some
+" commands. It's fully customizable so each command can change it to it's own
+" logic.
+"
+" args is a dictionary with the these keys:
+"   'cmd':
+"     The value to pass to job_start().
+"   'bang':
+"     Set to 0 to jump to the first error in the error list.
+"     Defaults to 0.
+"   'for':
+"     The g:go_list_type_command key to use to get the error list type to use.
+"     Defaults to '_job'
+"   'exit_cb':
+"     A function to call when the job exits. See job-exit_cb.
+"   'custom_cb':
+"     A function to call from the default exit_cb after the job exits. The
+"     function will be passed three arguments: the job, its exit code, and the
+"     list of messages received from the channel.
+"   'error_info_cb':
+"     A function to call from the default exit_cb after the job exits. The
+"     function will be passed three arguments: the job, its exit code, and the
+"     list of messages received from the channel.
+"   'callback':
+"     A function to call when there is a message to read from the job's
+"     channel. The function will be passed two arguments: the channel and a
+"     message. See job-callback.
+"
+" The return value is an object with these keys:
+"   'callback':
+"     A function suitable to be passed as a job callback handler. See
+"     job-callback.
+"   'exit_cb':
+"     A function suitable to be passed as a job exit_cb handler. See
+"     job-exit_cb.
+"   'winnr':
+"     The number of the current window.
+"   'dir':
+"     The current working directory.
+"   'jobdir':
+"     The directory of the current buffer.fnameescape(expand("%:p:h")),
+"   'messages':
+"     The list of messages received from the channel and filtered by args.
+"   'args':
+"     A dictionary with a single key, 'cmd', whose value is the a:args.cmd,
+"   'bang':
+"     Set to 0 when the first error will be jumped to after reading and
+"     processing all messages from the channel.
+"   'for':
+"     The g:go_list_type_command key to use to get the error list type to use.
+
 function go#job#Spawn(args)
   let cbs = {
         \ 'winnr': winnr(),

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -251,31 +251,21 @@ function s:lint_job(args)
   call go#cmd#autowrite()
 
   let l:listtype = go#list#Type("GoMetaLinter")
-  let l:errformat = '%f:%l:%c:%t%*[^:]:\ %m,%f:%l::%t%*[^:]:\ %m'
+
+  let l:messages = []
+  let l:exited = 0
+  let l:closed = 0
+  let l:exit_status = 0
+  let l:winnr = winnr()
 
   function! s:callback(chan, msg) closure
-    let old_errorformat = &errorformat
-    let &errorformat = l:errformat
-    try
-      if l:listtype == "locationlist"
-        lad a:msg
-      elseif l:listtype == "quickfix"
-        caddexpr a:msg
-      endif
-    finally
-      let &errorformat = old_errorformat
-    endtry
-
-    " TODO(jinleileiking): give a configure to jump or not
-    let l:winnr = winnr()
-
-    let errors = go#list#Get(l:listtype)
-    call go#list#Window(l:listtype, len(errors))
-
-    exe l:winnr . "wincmd w"
+    call add(messages, a:msg)
   endfunction
 
   function! s:exit_cb(job, exitval) closure
+    let exited = 1
+    let exit_status = a:exitval
+
     let status = {
           \ 'desc': 'last status',
           \ 'type': "gometaliner",
@@ -293,16 +283,33 @@ function s:lint_job(args)
 
     call go#statusline#Update(status_dir, status)
 
-    let errors = go#list#Get(l:listtype)
-    if empty(errors)
-      call go#list#Window(l:listtype, len(errors))
-    elseif has("patch-7.4.2200")
-      if l:listtype == 'quickfix'
-        call setqflist([], 'a', {'title': 'GoMetaLinter'})
-      else
-        call setloclist(0, [], 'a', {'title': 'GoMetaLinter'})
-      endif
+    if closed
+      call s:show_errors()
     endif
+  endfunction
+
+  function! s:close_cb(ch) closure
+    let closed = 1
+
+    if exited
+      call s:show_errors()
+    endif
+  endfunction
+
+
+  function! s:show_errors() closure
+    " make sure the current window is the window from which gometalinter was
+    " run when the listtype is locationlist so that the location list for the
+    " correct window will be populated.
+    if l:listtype == 'locationlist'
+      exe l:winnr . "wincmd w"
+    endif
+
+    let l:errorformat = '%f:%l:%c:%t%*[^:]:\ %m,%f:%l::%t%*[^:]:\ %m'
+    call go#list#ParseFormat(l:listtype, l:errorformat, messages, 'GoMetaLinter')
+
+    let errors = go#list#Get(l:listtype)
+    call go#list#Window(l:listtype, len(errors))
 
     if get(g:, 'go_echo_command_info', 1)
       call go#util#EchoSuccess("linting finished")
@@ -312,11 +319,10 @@ function s:lint_job(args)
   let start_options = {
         \ 'callback': funcref("s:callback"),
         \ 'exit_cb': funcref("s:exit_cb"),
+        \ 'close_cb': funcref("s:close_cb"),
         \ }
 
   call job_start(a:args.cmd, start_options)
-
-  call go#list#Clean(l:listtype)
 
   if get(g:, 'go_echo_command_info', 1)
     call go#util#EchoProgress("linting started ...")


### PR DESCRIPTION
Eliminate race conditions that were possible in vim8 job handling.

Most jobs were only handling the `exit_cb` handler for job options. To make sure that all messages are handled, `close_cb` has to be hooked up and coordinated with `exit_cb`, because there is no guarantee about which order they will be called in.

Refactor `autoload/go/job.vim` to call the caller-provided callbacks only after the job has exited _and_ channel has been closed so that the actual exit status and all messages can be provided. I also took this opportunity to clean up and simplify `go#job#Spawn` so that there's only one callback called when the job completes instead of two and so that the return value only exposes the callbacks that are needed by the caller.

Refactor `autoload/go/guru.vim` to account for the fact that it's possible that `exit_cb` may be called _after_ `close_cb`.

Refactor all other async jobs to coordinate calling functions that should be called only after the job's exit status is known and all the channel is closed.

Because this touched so much code, I tried to make each of the commits focused on a single area of improvement. You may find it much easier to review each commit rather than reviewing them all at once.

Closes #1440