### PR TITLE
[WIP] def: implement lazy evaluation of definition call

### DIFF
--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -123,6 +123,11 @@ function go#job#Spawn(args)
     endtry
 
     if empty(errors)
+      " don't output this error as this is not useful at all
+      if messages[0] == "guru: no identifier here" 
+        return
+      endif
+
       " failed to parse errors, output the original content
       call go#util#EchoError(messages + [dir])
       return

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1266,6 +1266,21 @@ Use this option to define the command to be used for |:GoDef|. By default
 
   let g:go_def_mode = 'guru'
 <
+                                                         *'g:go_def_prefetch'*
+
+Use this option to enable continuous auto prefetching of |:GoDef| destination
+when the cursor is on rest. This is done in background and doesn't block the
+UI. If there is any prefetch candidate and the jump is executed via |:GoDef|
+or |gd|, the jump will happen instantaneously. This makes jumping *feel* even
+more faster as there is always couple of seconds hesitation before we jump to
+the destination.
+
+This is an experimental feature and is very power hungry due the continuous
+computation of the definitions. Only supported if |g:go_def_mode| is set to
+`guru` and Vim 8 is used. By default it's disabled.
+>
+  let g:go_def_prefetch = 0
+<
                                                   *'g:go_def_mapping_enabled'*
 
 Use this option to enable/disable the default mapping of CTRL-],

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -212,6 +212,22 @@ function! s:auto_sameids()
   endif
 endfunction
 
+function! s:auto_definition_prefetch()
+  if !get(g:, "go_def_prefetch", 0)
+    return
+  endif
+
+  if !go#util#has_job() || get(g:, 'go_def_mode', "") != 'guru'
+    " disable auto_definition so we don't spam the users statusline with the
+    " same message over and over again
+    let g:go_def_prefetch = 0
+    echohl Error | echomsg "g:go_def_prefetch requires at least Vim 8.0.0087 and g:go_def_mode set to 'guru'" | echohl None
+    return
+  endif
+
+  call go#def#Compute('', 0)
+endfunction
+
 function! s:fmt_autosave()
   " Go code formatting on save
   if get(g:, "go_fmt_autosave", 1)
@@ -245,6 +261,7 @@ augroup vim-go
 
   autocmd CursorHold *.go call s:auto_type_info()
   autocmd CursorHold *.go call s:auto_sameids()
+  autocmd CursorHold *.go call s:auto_definition_prefetch()
 
   " Echo the identifier information when completion is done. Useful to see
   " the signature of a function, etc...


### PR DESCRIPTION
This speeds up guru/godef jumping immensely by computing the destination
before the user decided to jump. This makes it feel like any jump is
instantaneous as the evaluating is done in background.

Because we don't want to block the UI during the computing it's only
supported for async mode.