### PR TITLE
fixing keyify repo path

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -44,7 +44,7 @@ let s:packages = {
       \ 'gotags':        ['github.com/jstemmer/gotags'],
       \ 'guru':          ['golang.org/x/tools/cmd/guru'],
       \ 'impl':          ['github.com/josharian/impl'],
-      \ 'keyify':        ['github.com/dominikh/go-tools/cmd/keyify'],
+      \ 'keyify':        ['github.com/go-tools/cmd/keyify'],
       \ 'motion':        ['github.com/fatih/motion'],
 \ }
 


### PR DESCRIPTION
The **keyify** link in plugin/go.vim is no longer valid:
```
$ go get github.com/dominikh/go-tools/cmd/keyify
package honnef.co/go/tools/version: unrecognized import path "honnef.co/go/tools/version" (https fetch: Get https://honnef.co/go/tools/version?go-get=1: http: server gave HTTP response to HTTPS client)
```
and this causes _:GoInstallBinaries_ fail. 
The following change fixes this issue:
```
$ ls $GOBIN/k*
/go-workspace/bin/keyify*
```