### PR TITLE
Ensure that goPackageComment region ends after comment.

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -453,7 +453,7 @@ if g:go_highlight_build_constraints != 0 || s:fold_package_comment
         \ . ' contains=@goCommentGroup,@Spell'
         \ . (s:fold_package_comment ? ' fold' : '')
   exe 'syn region  goPackageComment    start=/\v\/\*.*\n(.*\n)*\s*\*\/\npackage/'
-        \ . ' end=/\v\n\s*package/he=e-7,me=e-7,re=e-7'
+        \ . ' end=/\v\*\/\n\s*package/he=e-7,me=e-7,re=e-7'
         \ . ' contains=@goCommentGroup,@Spell'
         \ . (s:fold_package_comment ? ' fold' : '')
   hi def link goPackageComment    Comment


### PR DESCRIPTION
If a package comment contained a line starting with "package", then it terminated the package comment. Ensure that "package" is preceded with a comment block terminator to fix the highlighting.

Before and after:
![before](https://user-images.githubusercontent.com/1042524/35974087-6239196a-0ce0-11e8-9725-15d7c2d42432.png) ![after](https://user-images.githubusercontent.com/1042524/35974106-6f753f96-0ce0-11e8-963e-1a4030475e72.png)
