### PR TITLE
Keep current alternate-file name while reading templates

### DIFF
--- a/autoload/go/template.vim
+++ b/autoload/go/template.vim
@@ -24,7 +24,7 @@ function! go#template#create() abort
       let l:template_file = get(g:, 'go_template_file', "hello_world.go")
     endif
     let l:template_path = go#util#Join(l:root_dir, "templates", l:template_file)
-    silent exe '0r ' . fnameescape(l:template_path)
+    silent exe 'keepalt 0r ' . fnameescape(l:template_path)
   elseif l:package_name == -1 && l:go_template_use_pkg == 1
     " cwd is now the dir of the package
     let l:path = fnamemodify(getcwd(), ':t')


### PR DESCRIPTION
vim-go doesn't keep the previous value of alternate-file register
while reading templates. As a result, you will not be able to go back
to the buffer you were editing.

Suppose you have a directory structure like:
```
.
├── cmd/
│   └── bar/
└── foo.go
```
And you are editing a file in vim:

```$ vim foo.go```

and then you decided to create a new go file like:

```:e cmd/bar/bar.go```

Once you finished with 'bar.go', you hit CTRL-^ to return to the
previously edited file (foo.go), but you unexpectedly end up in
```$RTP/vim-go/templates/hello_world.go```.

This PR addresses this issue by prefixing the :read command in
```go#template#create()``` with :keepalt.
