### PR TITLE
add  fmt.Errorf() snippet in UltiSnips

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -252,6 +252,11 @@ snippet fn "fmt.Println(...)"
 fmt.Println("${1:${VISUAL}}")
 endsnippet
 
+# Fmt Errorf debug
+snippet fe "fmt.Errorf(...)"
+fmt.Errorf("${1:${VISUAL}}")
+endsnippet
+
 # log printf
 snippet lf "log.Printf(...)"
 log.Printf("${1:${VISUAL}} = %+v\n", $1)

--- a/gosnippets/snippets/go.snip
+++ b/gosnippets/snippets/go.snip
@@ -219,6 +219,10 @@ abbr fmt.Printf(...)
 snippet fn
 abbr fmt.Println(...)
 	fmt.Println("${1}")
+# Fmt Errorf
+snippet fe
+abbr fmt.Errorf(...)
+	fmt.Errorf("${1}")
 # log printf
 snippet lf
 abbr log.Printf(...)


### PR DESCRIPTION
Hi! I have added an extra snippet to use the 'fe' combination to autocomplete the fmt.Errorf(...) in UltiSnips.