### PR TITLE
use dictionaries instead of closures to maintain job state

### DIFF
--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -19,10 +19,6 @@
 "     list of messages received from the channel. The default value will
 "     process the messages and manage the error list after the job exits and
 "     the channel is closed.
-"   'callback':
-"     A function to call when there is a message to read from the job's
-"     channel. The function will be passed two arguments: the channel and a
-"     message. See job-callback.
 
 " The return value is a dictionary with these keys:
 "   'callback':
@@ -36,14 +32,18 @@
 "     job-close_cb.
 function go#job#Spawn(args)
   let cbs = {}
-
-  let winnr = winnr()
-  let dir = getcwd()
-  let jobdir = fnameescape(expand("%:p:h"))
-  let messages = []
-  let args = a:args.cmd
-  let bang = 0
-  let for = "_job"
+  let state = {
+        \ 'winnr': winnr(),
+        \ 'dir': getcwd(),
+        \ 'jobdir': fnameescape(expand("%:p:h")),
+        \ 'messages': [],
+        \ 'args': a:args.cmd,
+        \ 'bang': 0,
+        \ 'for': "_job",
+        \ 'exited': 0,
+        \ 'exit_status': 0,
+        \ 'closed': 0
+      \ }
 
   if has_key(a:args, 'bang')
     let l:bang = a:args.bang
@@ -53,26 +53,24 @@ function go#job#Spawn(args)
     let l:for = a:args.for
   endif
 
-  let l:exited = 0
-  let l:exit_status = 0
-  let l:closed = 0
-
-  function! s:NopComplete(job, exit_status, data)
+  " do nothing in state.complete by default.
+  function state.complete(job, exit_status, data)
   endfunction
-
-  let Complete = funcref('s:NopComplete')
 
   if has_key(a:args, 'complete')
-    let Complete = a:args.complete
+    let state.complete = a:args.complete
   endif
 
-  function cbs.callback(chan, msg) dict closure
-    call add(messages, a:msg)
+  function! s:callback(chan, msg) dict
+    call add(self.messages, a:msg)
   endfunction
+  " explicitly bind callback so that to state so that within it, self will
+  " always refer to state. See :help Partial for more information.
+  let cbs.callback = function('s:callback', [], state)
 
-  function cbs.exit_cb(job, exitval) dict closure
-    let exit_status = a:exitval
-    let exited = 1
+  function! s:exit_cb(job, exitval) dict
+    let self.exit_status = a:exitval
+    let self.exited = 1
 
     if get(g:, 'go_echo_command_info', 1)
       if a:exitval == 0
@@ -82,31 +80,37 @@ function go#job#Spawn(args)
       endif
     endif
 
-    if closed
-      call Complete(a:job, exit_status, messages)
-      call s:show_errors(a:job, exit_status, messages)
+    if self.closed
+      call self.complete(a:job, self.exit_status, self.messages)
+      call self.show_errors(a:job, self.exit_status, self.messages)
     endif
   endfunction
+  " explicitly bind exit_cb so that to state so that within it, self will
+  " always refer to state. See :help Partial for more information.
+  let cbs.exit_cb = function('s:exit_cb', [], state)
 
-  function cbs.close_cb(ch) dict closure
-    let closed = 1
+  function! s:close_cb(ch) dict
+    let self.closed = 1
 
-    if exited
+    if self.exited
       let job = ch_getjob(a:ch)
-      call Complete(job, exit_status, messages)
-      call s:show_errors(job, exit_status, messages)
+      call self.complete(job, self.exit_status, self.messages)
+      call self.show_errors(job, self.exit_status, self.messages)
     endif
   endfunction
+  " explicitly bind close_cb so that to state so that within it, self will
+  " always refer to state. See :help Partial for more information.
+  let cbs.close_cb = function('s:close_cb', [], state)
 
-  function! s:show_errors(job, exit_status, data) closure
-    let l:listtype = go#list#Type(for)
+  function state.show_errors(job, exit_status, data)
+    let l:listtype = go#list#Type(self.for)
     if a:exit_status == 0
       call go#list#Clean(l:listtype)
       call go#list#Window(l:listtype)
       return
     endif
 
-    let l:listtype = go#list#Type(for)
+    let l:listtype = go#list#Type(self.for)
     if len(a:data) == 0
       call go#list#Clean(l:listtype)
       call go#list#Window(l:listtype)
@@ -115,21 +119,21 @@ function go#job#Spawn(args)
 
     let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
     try
-      execute cd jobdir
+      execute cd self.jobdir
       let errors = go#tool#ParseErrors(a:data)
       let errors = go#tool#FilterValids(errors)
     finally
-      execute cd . fnameescape(dir)
+      execute cd . fnameescape(self.dir)
     endtry
 
     if empty(errors)
       " failed to parse errors, output the original content
-      call go#util#EchoError(messages + [dir])
+      call go#util#EchoError(self.messages + [self.dir])
       return
     endif
 
-    if winnr == winnr()
-      call go#list#Populate(l:listtype, errors, join(args))
+    if self.winnr == winnr()
+      call go#list#Populate(l:listtype, errors, join(self.args))
       call go#list#Window(l:listtype, len(errors))
       if !bang
         call go#list#JumpToFirst(l:listtype)

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -246,10 +246,17 @@ function! go#lint#ToggleMetaLinterAutoSave() abort
 endfunction
 
 function! s:lint_job(args, autosave)
-  let status_dir = expand('%:p:h')
-  let started_at = reltime()
+  let state = {
+        \ 'status_dir': expand('%:p:h'),
+        \ 'started_at': reltime(),
+        \ 'messages': [],
+        \ 'exited': 0,
+        \ 'closed': 0,
+        \ 'exit_status': 0,
+        \ 'winnr': winnr()
+      \ }
 
-  call go#statusline#Update(status_dir, {
+  call go#statusline#Update(state.status_dir, {
         \ 'desc': "current status",
         \ 'type': "gometalinter",
         \ 'state': "analysing",
@@ -259,26 +266,18 @@ function! s:lint_job(args, autosave)
   call go#cmd#autowrite()
 
   if a:autosave
-    let l:listtype = go#list#Type("GoMetaLinterAutoSave")
+    let state.listtype = go#list#Type("GoMetaLinterAutoSave")
   else
-    let l:listtype = go#list#Type("GoMetaLinter")
+    let state.listtype = go#list#Type("GoMetaLinter")
   endif
 
-  let l:errformat = '%f:%l:%c:%t%*[^:]:\ %m,%f:%l::%t%*[^:]:\ %m'
-
-  let l:messages = []
-  let l:exited = 0
-  let l:closed = 0
-  let l:exit_status = 0
-  let l:winnr = winnr()
-
-  function! s:callback(chan, msg) closure
-    call add(messages, a:msg)
+  function! s:callback(chan, msg) dict closure
+    call add(self.messages, a:msg)
   endfunction
 
-  function! s:exit_cb(job, exitval) closure
-    let exited = 1
-    let exit_status = a:exitval
+  function! s:exit_cb(job, exitval) dict
+    let self.exited = 1
+    let self.exit_status = a:exitval
 
     let status = {
           \ 'desc': 'last status',
@@ -290,50 +289,52 @@ function! s:lint_job(args, autosave)
       let status.state = "failed"
     endif
 
-    let elapsed_time = reltimestr(reltime(started_at))
+    let elapsed_time = reltimestr(reltime(self.started_at))
     " strip whitespace
     let elapsed_time = substitute(elapsed_time, '^\s*\(.\{-}\)\s*$', '\1', '')
     let status.state .= printf(" (%ss)", elapsed_time)
 
-    call go#statusline#Update(status_dir, status)
+    call go#statusline#Update(self.status_dir, status)
 
-    if closed
-      call s:show_errors()
+    if self.closed
+      call self.show_errors()
     endif
   endfunction
 
-  function! s:close_cb(ch) closure
-    let closed = 1
+  function! s:close_cb(ch) dict
+    let self.closed = 1
 
-    if exited
-      call s:show_errors()
+    if self.exited
+      call self.show_errors()
     endif
   endfunction
 
 
-  function! s:show_errors() closure
+  function state.show_errors()
     " make sure the current window is the window from which gometalinter was
     " run when the listtype is locationlist so that the location list for the
     " correct window will be populated.
-    if l:listtype == 'locationlist'
-      exe l:winnr . "wincmd w"
+    if self.listtype == 'locationlist'
+      exe self.winnr . "wincmd w"
     endif
 
     let l:errorformat = '%f:%l:%c:%t%*[^:]:\ %m,%f:%l::%t%*[^:]:\ %m'
-    call go#list#ParseFormat(l:listtype, l:errorformat, messages, 'GoMetaLinter')
+    call go#list#ParseFormat(self.listtype, l:errorformat, self.messages, 'GoMetaLinter')
 
-    let errors = go#list#Get(l:listtype)
-    call go#list#Window(l:listtype, len(errors))
+    let errors = go#list#Get(self.listtype)
+    call go#list#Window(self.listtype, len(errors))
 
     if get(g:, 'go_echo_command_info', 1)
       call go#util#EchoSuccess("linting finished")
     endif
   endfunction
 
+  " explicitly bind the callbacks to state so that self within them always
+  " refers to state. See :help Partial for more information.
   let start_options = {
-        \ 'callback': funcref("s:callback"),
-        \ 'exit_cb': funcref("s:exit_cb"),
-        \ 'close_cb': funcref("s:close_cb"),
+        \ 'callback': funcref("s:callback", [], state),
+        \ 'exit_cb': funcref("s:exit_cb", [], state),
+        \ 'close_cb': funcref("s:close_cb", [], state),
         \ }
 
   call job_start(a:args.cmd, start_options)

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -72,20 +72,22 @@ function! go#rename#Rename(bang, ...) abort
 endfunction
 
 function s:rename_job(args)
-  let exited = 0
-  let closed = 0
-  let exitval = 0
-  let messages = []
+  let state = {
+        \ 'exited': 0,
+        \ 'closed': 0,
+        \ 'exitval': 0,
+        \ 'messages': [],
+        \ 'status_dir': expand('%:p:h'),
+        \ 'bang': a:args.bang
+      \ }
 
-  function! s:callback(chan, msg) closure
-    call add(messages, a:msg)
+  function! s:callback(chan, msg) dict
+    call add(self.messages, a:msg)
   endfunction
 
-  let status_dir =  expand('%:p:h')
-
-  function! s:exit_cb(job, exitval) closure
-    let exited = 1
-    let exitval = a:exitval
+  function! s:exit_cb(job, exitval) dict
+    let self.exited = 1
+    let self.exitval = a:exitval
 
     let status = {
           \ 'desc': 'last status',
@@ -97,28 +99,30 @@ function s:rename_job(args)
       let status.state = "failed"
     endif
 
-    call go#statusline#Update(status_dir, status)
+    call go#statusline#Update(self.status_dir, status)
 
-    if closed
-      call s:parse_errors(a:exitval, a:args.bang, messages)
+    if self.closed
+      call s:parse_errors(self.exitval, self.bang, self.messages)
     endif
   endfunction
 
-  function! s:close_cb(ch) closure
-    let closed = 1
+  function! s:close_cb(ch) dict
+    let self.closed = 1
 
-    if exited
-      call s:parse_errors(exitval, a:args.bang, messages)
+    if self.exited
+      call s:parse_errors(self.exitval, self.bang, self.messages)
     endif
   endfunction
 
+  " explicitly bind the callbacks to state so that self within them always
+  " refers to state. See :help Partial for more information.
   let start_options = {
-        \ 'callback': funcref("s:callback"),
-        \ 'exit_cb': funcref("s:exit_cb"),
-        \ 'close_cb': funcref("s:close_cb"),
+        \ 'callback': funcref("s:callback", [], state),
+        \ 'exit_cb': funcref("s:exit_cb", [], state),
+        \ 'close_cb': funcref("s:close_cb", [], state),
         \ }
 
-  call go#statusline#Update(status_dir, {
+  call go#statusline#Update(state.status_dir, {
         \ 'desc': "current status",
         \ 'type': "gorename",
         \ 'state': "started",

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -139,9 +139,6 @@ function! go#test#Func(bang, ...) abort
 endfunction
 
 function! s:test_job(args) abort
-  let status_dir = expand('%:p:h')
-  let started_at = reltime()
-
   let status = {
         \ 'desc': 'current status',
         \ 'type': "test",
@@ -152,23 +149,29 @@ function! s:test_job(args) abort
     let status.state = "compiling"
   endif
 
-  call go#statusline#Update(status_dir, status)
-
   " autowrite is not enabled for jobs
   call go#cmd#autowrite()
 
-  let l:exited = 0
-  let l:closed = 0
-  let l:exitval = 0
-  let messages = []
+  let state = {
+        \ 'exited': 0,
+        \ 'closed': 0,
+        \ 'exitval': 0,
+        \ 'messages': [],
+        \ 'args': a:args,
+        \ 'compile_test': a:args.compile_test,
+        \ 'status_dir': expand('%:p:h'),
+        \ 'started_at': reltime()
+      \ }
 
-  function! s:callback(chan, msg) closure
-    call add(messages, a:msg)
+  call go#statusline#Update(state.status_dir, status)
+
+  function! s:callback(chan, msg) dict
+    call add(self.messages, a:msg)
   endfunction
 
-  function! s:exit_cb(job, exitval) closure
-    let exited = 1
-    let exitval = a:exitval
+  function! s:exit_cb(job, exitval) dict
+    let self.exited = 1
+    let self.exitval = a:exitval
 
     let status = {
           \ 'desc': 'last status',
@@ -176,7 +179,7 @@ function! s:test_job(args) abort
           \ 'state': "pass",
           \ }
 
-    if a:args.compile_test
+    if self.compile_test
       let status.state = "success"
     endif
 
@@ -186,7 +189,7 @@ function! s:test_job(args) abort
 
     if get(g:, 'go_echo_command_info', 1)
       if a:exitval == 0
-        if a:args.compile_test
+        if self.compile_test
           call go#util#EchoSuccess("[test] SUCCESS")
         else
           call go#util#EchoSuccess("[test] PASS")
@@ -196,31 +199,33 @@ function! s:test_job(args) abort
       endif
     endif
 
-    let elapsed_time = reltimestr(reltime(started_at))
+    let elapsed_time = reltimestr(reltime(self.started_at))
     " strip whitespace
     let elapsed_time = substitute(elapsed_time, '^\s*\(.\{-}\)\s*$', '\1', '')
     let status.state .= printf(" (%ss)", elapsed_time)
 
-    call go#statusline#Update(status_dir, status)
+    call go#statusline#Update(self.status_dir, status)
 
-    if closed
-      call s:show_errors(a:args, l:exitval, messages)
+    if self.closed
+      call s:show_errors(self.args, self.exitval, self.messages)
     endif
   endfunction
 
-  function! s:close_cb(ch) closure
-    let closed = 1
+  function! s:close_cb(ch) dict
+    let self.closed = 1
 
-    if exited
-      call s:show_errors(a:args, l:exitval, messages)
+    if self.exited
+      call s:show_errors(self.args, self.exitval, self.messages)
     endif
   endfunction
 
+  " explicitly bind the callbacks to state so that self within them always
+  " refers to state. See :help Partial for more information.
   let start_options = {
-        \ 'callback': funcref("s:callback"),
-        \ 'exit_cb': funcref("s:exit_cb"),
-        \ 'close_cb': funcref("s:close_cb"),
-        \ }
+        \ 'callback': funcref("s:callback", [], state),
+        \ 'exit_cb': funcref("s:exit_cb", [], state),
+        \ 'close_cb': funcref("s:close_cb", [], state)
+      \ }
 
   " pre start
   let dir = getcwd()


### PR DESCRIPTION
Refactor vim8 async jobs to use dictionaries to maintain job state instead of closures so that multiple running jobs don't close over the same variable.

Fixes #1681