### PR TITLE
Flags to disabled gocode omnifunc.

### DIFF
--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -21,7 +21,9 @@ setlocal noexpandtab
 compiler go
 
 " Set gocode completion
-setlocal omnifunc=go#complete#Complete
+if get(g:, "go_omnifunc_enabled", 1)
+  setlocal omnifunc=go#complete#Complete
+endif
 
 if get(g:, "go_doc_keywordprg_enabled", 1)
   " keywordprg doesn't allow to use vim commands, override it


### PR DESCRIPTION
There are now other autocomplete available for go. I am currently using
YCM and I would like to disable gocode.

That's why I added a parameter: `g:go_omnifunc_enabled`.

Signed-off-by: Gianluca Arbezzano <gianarb92@gmail.com>