### PR TITLE
Make quickfix window always occupy the full width

### DIFF
--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -42,7 +42,7 @@ function! go#list#Window(listtype, ...) abort
   if a:listtype == "locationlist"
     exe 'lopen ' . height
   else
-    exe 'copen ' . height
+    exe 'botright copen ' . height
   endif
 endfunction
 


### PR DESCRIPTION
When I run a vim-go command which causes the quickfix window to open,
that window is placed at the bottom of the rightmost column of windows
if there are vertical splits, which, I think is annoying.

To make it occupy the full width, we can use the `:botright` command
modifier for `:copen`.