### PR TITLE
fix path separator of minisnip_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 FEATURES:
 
-* **Debugger support!**. Add integrated support for the [`delve`](https://github.com/derekparker/delve)
-  debugger. Use `:GoInstallBinaries` to install `dlv`, and see `:help go-debug`
-  to get started.
-  [[GH-1390]](https://github.com/fatih/vim-go/pull/1390).
+* **Debugger support!** Add integrated support for the
+  [`delve`](https://github.com/derekparker/delve) debugger. Use
+  `:GoInstallBinaries` to install `dlv`, and see `:help go-debug` to get
+  started.
+  [[GH-1390]](https://github.com/fatih/vim-go/pull/1390)
 
 IMPROVEMENTS:
 
@@ -56,6 +57,8 @@ BUG FIXES:
 * Show the file location of test errors when the message is empty or begins
   with a newline.
   [[GH-1664]](https://github.com/fatih/vim-go/pull/1664)
+* Fix minisnip on Windows.
+  [[GH-1698]](https://github.com/fatih/vim-go/pull/1698)
 
 
 BACKWARDS INCOMPATIBILITIES:

--- a/ftplugin/go/snippets.vim
+++ b/ftplugin/go/snippets.vim
@@ -40,7 +40,7 @@ function! s:GoMinisnip() abort
   endif
 
   if exists('g:minisnip_dir')
-    let g:minisnip_dir .= ':' . globpath(&rtp, 'gosnippets/minisnip')
+    let g:minisnip_dir .= (has('win32') ? ';' : ':') . globpath(&rtp, 'gosnippets/minisnip')
   else
     let g:minisnip_dir = globpath(&rtp, 'gosnippets/minisnip')
   endif

--- a/ftplugin/go/snippets.vim
+++ b/ftplugin/go/snippets.vim
@@ -40,7 +40,7 @@ function! s:GoMinisnip() abort
   endif
 
   if exists('g:minisnip_dir')
-    let g:minisnip_dir .= (has('win32') ? ';' : ':') . globpath(&rtp, 'gosnippets/minisnip')
+    let g:minisnip_dir .= go#util#PathListSep() . globpath(&rtp, 'gosnippets/minisnip')
   else
     let g:minisnip_dir = globpath(&rtp, 'gosnippets/minisnip')
   endif


### PR DESCRIPTION
path separator on Windows should be ';' not ':'