### PR TITLE
cmd: go 1.10 maintains a build cache now

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -17,7 +17,7 @@ function! go#cmd#Build(bang, ...) abort
   let args =
         \ ["build"] +
         \ map(copy(a:000), "expand(v:val)") +
-        \ ["-i", ".", "errors"]
+        \ [".", "errors"]
 
   " Vim async.
   if go#util#has_job()


### PR DESCRIPTION
We don't need this hack anymore to speed up building.