### PR TITLE
Add build tags 'g:go_build_tags' for gogetdoc

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -148,6 +148,11 @@ function! s:gogetdoc(json) abort
   let pos = shellescape(fname.':#'.offset)
 
   let cmd += ["-pos", pos]
+
+  if exists('g:go_build_tags')
+    let cmd += ["-tags", get(g:, 'go_build_tags')]
+  endif
+
   if a:json
     let cmd += ["-json"]
   endif


### PR DESCRIPTION
Specify build tags for `gogetdoc` command, with the `g:go_build_tags` setting.