### PR TITLE
Make sure :GoDebugBreakpoint works after :GoDebugStop

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -224,6 +224,7 @@ function! s:clearState() abort
   let s:state['currentThread'] = {}
   let s:state['localVars'] = {}
   let s:state['functionArgs'] = {}
+  let s:state['message'] = []
   silent! sign unplace 9999
 endfunction
 
@@ -236,6 +237,7 @@ function! s:stop() abort
 endfunction
 
 function! go#debug#Stop() abort
+  " Remove signs.
   for k in keys(s:state['breakpoint'])
     let bt = s:state['breakpoint'][k]
     if bt.id >= 0
@@ -243,14 +245,17 @@ function! go#debug#Stop() abort
     endif
   endfor
 
-  for k in filter(map(split(execute('command GoDebug'), "\n")[1:], 'matchstr(v:val,"^\\s*\\zs\\S\\+")'), 'v:val!="GoDebugStart"')
+  " Remove all commands and add back the default commands.
+  for k in map(split(execute('command GoDebug'), "\n")[1:], 'matchstr(v:val, "^\\s*\\zs\\S\\+")')
     exe 'delcommand' k
   endfor
-  for k in map(split(execute('map <Plug>(go-debug-'), "\n")[1:], 'matchstr(v:val,"^n\\s\\+\\zs\\S\\+")')
+  command! -nargs=* -complete=customlist,go#package#Complete GoDebugStart call go#debug#Start(<f-args>)
+  command! -nargs=? GoDebugBreakpoint call go#debug#Breakpoint(<f-args>)
+
+  " Remove all mappings.
+  for k in map(split(execute('map <Plug>(go-debug-'), "\n")[1:], 'matchstr(v:val, "^n\\s\\+\\zs\\S\\+")')
     exe 'unmap' k
   endfor
-
-  command! -nargs=* -complete=customlist,go#package#Complete GoDebugStart call go#debug#Start(<f-args>)
 
   call s:stop()
 
@@ -816,8 +821,9 @@ endfunction
 
 " Toggle breakpoint.
 function! go#debug#Breakpoint(...) abort
-  let filename = fnamemodify(expand('%'), ':p:gs!\\!/!')
+  let l:filename = fnamemodify(expand('%'), ':p:gs!\\!/!')
 
+  " Get line number from argument.
   if len(a:000) > 0
     let linenr = str2nr(a:1)
     if linenr is 0
@@ -833,7 +839,7 @@ function! go#debug#Breakpoint(...) abort
     let found = v:none
     for k in keys(s:state.breakpoint)
       let bt = s:state.breakpoint[k]
-      if bt.file == filename && bt.line == linenr
+      if bt.file == l:filename && bt.line == linenr
         let found = bt
         break
       endif
@@ -849,14 +855,14 @@ function! go#debug#Breakpoint(...) abort
     " Add breakpoint.
     else
       if s:isActive()
-        let res = s:call_jsonrpc('RPCServer.CreateBreakpoint', {'Breakpoint':{'file': filename, 'line': linenr}})
+        let res = s:call_jsonrpc('RPCServer.CreateBreakpoint', {'Breakpoint': {'file': l:filename, 'line': linenr}})
         let bt = res.result.Breakpoint
         exe 'sign place '. bt.id .' line=' . bt.line . ' name=godebugbreakpoint file=' . bt.file
         let s:state['breakpoint'][bt.id] = bt
       else
         let id = len(s:state['breakpoint']) + 1
-        let s:state['breakpoint'][id] = {'id': id, 'file': filename, 'line': linenr}
-        exe 'sign place '. id .' line=' . linenr . ' name=godebugbreakpoint file=' . filename
+        let s:state['breakpoint'][id] = {'id': id, 'file': l:filename, 'line': linenr}
+        exe 'sign place '. id .' line=' . linenr . ' name=godebugbreakpoint file=' . l:filename
       endif
     endif
   catch


### PR DESCRIPTION
Fixes #1691

1. Run `command GoDebugBreakpoint` after making it available again.
2. Clear `message` too in `s:clearState()`, so that `s:isActive()` works
   correct.