### PR TITLE
Adds vim-plug post-update hook to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ for popular package managers:
 * [Pathogen](https://github.com/tpope/vim-pathogen)
   * `git clone https://github.com/fatih/vim-go.git ~/.vim/bundle/vim-go`
 * [vim-plug](https://github.com/junegunn/vim-plug)
-  * `Plug 'fatih/vim-go'`
+  * `Plug 'fatih/vim-go', { 'do': ':GoInstallBinaries' }`
 
 You will also need to install all the necessary binaries. vim-go makes it easy
 to install all of them by providing a command, `:GoInstallBinaries`, which will

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ for popular package managers:
 * [Pathogen](https://github.com/tpope/vim-pathogen)
   * `git clone https://github.com/fatih/vim-go.git ~/.vim/bundle/vim-go`
 * [vim-plug](https://github.com/junegunn/vim-plug)
-  * `Plug 'fatih/vim-go', { 'do': ':GoInstallBinaries' }`
+  * `Plug 'fatih/vim-go', { 'do': ':GoUpdateBinaries' }`
 
 You will also need to install all the necessary binaries. vim-go makes it easy
 to install all of them by providing a command, `:GoInstallBinaries`, which will

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -106,7 +106,7 @@ manager's install command.
 <
 *  https://github.com/gmarik/vundle >
 
-    Plugin 'fatih/vim-go'
+    Plugin 'fatih/vim-go', { 'do': ':GoInstallBinaries' }
 <
 *  Manual (not recommended) >
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -106,7 +106,7 @@ manager's install command.
 <
 *  https://github.com/gmarik/vundle >
 
-    Plugin 'fatih/vim-go', { 'do': ':GoInstallBinaries' }
+    Plugin 'fatih/vim-go', { 'do': ':GoUpdateBinaries' }
 <
 *  Manual (not recommended) >
 


### PR DESCRIPTION
I use `vim-plug` to manage my Vim plugins and I think we can include the post-update hook to the docs.