### PR TITLE
Consolidate configs

### DIFF
--- a/autoload/ctrlp/decls.vim
+++ b/autoload/ctrlp/decls.vim
@@ -65,7 +65,7 @@ function! ctrlp#decls#enter() abort
     return
   endif
   let command = printf("%s -format vim -mode decls", bin_path)
-  let command .= " -include ".  get(g:, "go_decls_includes", "func,type")
+  let command .= " -include ".  go#config#DeclsIncludes()
 
   call go#cmd#autowrite()
 

--- a/autoload/fzf/decls.vim
+++ b/autoload/fzf/decls.vim
@@ -63,7 +63,7 @@ function! s:source(mode,...) abort
     return
   endif
   let command = printf("%s -format vim -mode decls", bin_path)
-  let command .= " -include ".  get(g:, "go_decls_includes", "func,type")
+  let command .= " -include ".  go#config#DeclsIncludes()
 
   call go#cmd#autowrite()
 

--- a/autoload/go/alternate.vim
+++ b/autoload/go/alternate.vim
@@ -1,8 +1,3 @@
-" By default use edit (current buffer view) to switch
-if !exists("g:go_alternate_mode")
-  let g:go_alternate_mode = "edit"
-endif
-
 " Test alternates between the implementation of code and the test code.
 function! go#alternate#Switch(bang, cmd) abort
   let file = expand('%')
@@ -23,7 +18,7 @@ function! go#alternate#Switch(bang, cmd) abort
     call go#util#EchoError("couldn't find ".alt_file)
     return
   elseif empty(a:cmd)
-    execute ":" . g:go_alternate_mode . " " . alt_file
+    execute ":" . go#config#AlternateMode() . " " . alt_file
   else
     execute ":" . a:cmd . " " . alt_file
   endif

--- a/autoload/go/asmfmt.vim
+++ b/autoload/go/asmfmt.vim
@@ -56,13 +56,13 @@ function! go#asmfmt#Format() abort
 endfunction
 
 function! go#asmfmt#ToggleAsmFmtAutoSave() abort
-  if get(g:, "go_asmfmt_autosave", 0)
-    let g:go_asmfmt_autosave = 1
+  if go#config#AsmfmtAutosave()
+    call go#config#SetAsmfmtAutosave(1)
     call go#util#EchoProgress("auto asmfmt enabled")
     return
   end
 
-  let g:go_asmfmt_autosave = 0
+  call go#config#SetAsmfmtAutosave(0)
   call go#util#EchoProgress("auto asmfmt disabled")
 endfunction
 

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -21,7 +21,7 @@ function! go#cmd#Build(bang, ...) abort
 
   " Vim async.
   if go#util#has_job()
-    if get(g:, 'go_echo_command_info', 1)
+    if go#config#EchoCommandInfo()
       call go#util#EchoProgress("building dispatched ...")
     endif
 
@@ -33,7 +33,7 @@ function! go#cmd#Build(bang, ...) abort
 
   " Nvim async.
   elseif has('nvim')
-    if get(g:, 'go_echo_command_info', 1)
+    if go#config#EchoCommandInfo()
       call go#util#EchoProgress("building dispatched ...")
     endif
 
@@ -171,7 +171,7 @@ function! go#cmd#Install(bang, ...) abort
     " expand all wildcards(i.e: '%' to the current file name)
     let goargs = map(copy(a:000), "expand(v:val)")
 
-    if get(g:, 'go_echo_command_info', 1)
+    if go#config#EchoCommandInfo()
       call go#util#EchoProgress("installing dispatched ...")
     endif
 

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -77,7 +77,7 @@ endfunction
 " BuildTags sets or shows the current build tags used for tools
 function! go#cmd#BuildTags(bang, ...) abort
   if a:0
-    go#config#SetBuildTags(a:1)
+    call go#config#SetBuildTags(a:1)
     let tags = go#config#BuildTags()
     if empty(tags)
       call go#util#EchoSuccess("build tags are cleared")

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -77,21 +77,22 @@ endfunction
 " BuildTags sets or shows the current build tags used for tools
 function! go#cmd#BuildTags(bang, ...) abort
   if a:0
-    if a:0 == 1 && a:1 == '""'
-      unlet g:go_build_tags
+    go#config#SetBuildTags(a:1)
+    let tags = go#config#BuildTags()
+    if empty(tags)
       call go#util#EchoSuccess("build tags are cleared")
     else
-      let g:go_build_tags = a:1
-      call go#util#EchoSuccess("build tags are changed to: ". a:1)
+      call go#util#EchoSuccess("build tags are changed to: ". tags)
     endif
 
     return
   endif
 
-  if !exists('g:go_build_tags')
+  let tags = go#config#BuildTags()
+  if empty(tags)
     call go#util#EchoSuccess("build tags are not set")
   else
-    call go#util#EchoSuccess("current build tags: ". g:go_build_tags)
+    call go#util#EchoSuccess("current build tags: ". tags)
   endif
 endfunction
 

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -57,7 +57,7 @@ function! s:gocodeEnableOptions() abort
 
   let s:optionsEnabled = 1
 
-  call go#util#System(printf('%s set propose-builtins %s', go#util#Shellescape(bin_path), s:toBool(get(g:, 'go_gocode_propose_builtins', 1))))
+  call go#util#System(printf('%s set propose-builtins %s', go#util#Shellescape(bin_path), s:toBool(go#config#GocodeProposeBuiltins())))
   call go#util#System(printf('%s set autobuild %s', go#util#Shellescape(bin_path), s:toBool(get(g:, 'go_gocode_autobuild', 1))))
   call go#util#System(printf('%s set unimported-packages %s', go#util#Shellescape(bin_path), s:toBool(go#config#GocodeUnimportedPackages())))
 endfunction

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -58,7 +58,7 @@ function! s:gocodeEnableOptions() abort
   let s:optionsEnabled = 1
 
   call go#util#System(printf('%s set propose-builtins %s', go#util#Shellescape(bin_path), s:toBool(go#config#GocodeProposeBuiltins())))
-  call go#util#System(printf('%s set autobuild %s', go#util#Shellescape(bin_path), s:toBool(get(g:, 'go_gocode_autobuild', 1))))
+  call go#util#System(printf('%s set autobuild %s', go#util#Shellescape(bin_path), s:toBool(go#config#GocodeAutobuild())))
   call go#util#System(printf('%s set unimported-packages %s', go#util#Shellescape(bin_path), s:toBool(go#config#GocodeUnimportedPackages())))
 endfunction
 

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -1,12 +1,10 @@
-let s:sock_type = (has('win32') || has('win64')) ? 'tcp' : 'unix'
-
 function! s:gocodeCommand(cmd, args) abort
   let bin_path = go#path#CheckBinPath("gocode")
   if empty(bin_path)
     return []
   endif
 
-  let socket_type = get(g:, 'go_gocode_socket_type', s:sock_type)
+  let socket_type = go#config#GocodeSocketType()
 
   let cmd = [bin_path]
   let cmd = extend(cmd, ['-sock', socket_type])

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -250,13 +250,13 @@ function! go#complete#Complete(findstart, base) abort
 endfunction
 
 function! go#complete#ToggleAutoTypeInfo() abort
-  if get(g:, "go_auto_type_info", 0)
-    let g:go_auto_type_info = 0
+  if go#config#AutoTypeInfo()
+    call go#config#SetAutoTypeInfo(0)
     call go#util#EchoProgress("auto type info disabled")
     return
   end
 
-  let g:go_auto_type_info = 1
+  call go#config#SetAutoTypeInfo(1)
   call go#util#EchoProgress("auto type info enabled")
 endfunction
 

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -61,7 +61,7 @@ function! s:gocodeEnableOptions() abort
 
   call go#util#System(printf('%s set propose-builtins %s', go#util#Shellescape(bin_path), s:toBool(get(g:, 'go_gocode_propose_builtins', 1))))
   call go#util#System(printf('%s set autobuild %s', go#util#Shellescape(bin_path), s:toBool(get(g:, 'go_gocode_autobuild', 1))))
-  call go#util#System(printf('%s set unimported-packages %s', go#util#Shellescape(bin_path), s:toBool(get(g:, 'go_gocode_unimported_packages', 0))))
+  call go#util#System(printf('%s set unimported-packages %s', go#util#Shellescape(bin_path), s:toBool(go#config#GocodeUnimportedPackages())))
 endfunction
 
 function! s:toBool(val) abort

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -57,4 +57,8 @@ function! go#config#TemplateUsePkg() abort
   return get(g:, 'go_template_use_pkg', 0)
 endfunction
 
+function! go#config#TemplateTestFile() abort
+  return get(g:, 'go_template_test_file', "hello_world_test.go")
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -65,4 +65,8 @@ function! go#config#TemplateFile() abort
   return get(g:, 'go_template_file', "hello_world.go")
 endfunction
 
+function! go#config#StatuslineDuration() abort
+  return get(g:, 'go_statusline_duration', 60000)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -346,6 +346,10 @@ function! go#config#TextobjIncludeVariable() abort
   return get(g:, "go_textobj_include_variable", 1)
 endfunction
 
+function! go#config#BinPath() abort
+  return get(g:, "go_bin_path", "")
+endfunction
+
 " Set the default value. A value of "1" is a shortcut for this, for
 " compatibility reasons.
 if exists("g:go_gorename_prefill") && g:go_gorename_prefill == 1

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -220,4 +220,8 @@ function! go#config#SetAutoSameids(value) abort
   let g:go_auto_sameids = a:value
 endfunction
 
+function! go#config#AddtagsTransform() abort
+  return get(g:, 'go_addtags_transform', "snakecase")
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -212,4 +212,12 @@ function! go#config#SetDebugDiag(value) abort
   let g:go_debug_diag = a:value
 endfunction
 
+function! go#config#AutoSameids() abort
+    return get(g:, 'go_auto_sameids', 0)
+endfunction
+
+function! go#config#SetAutoSameids(value) abort
+  let g:go_auto_sameids = a:value
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -288,4 +288,12 @@ function! go#config#DocMaxHeight() abort
   return get(g:, "go_doc_max_height", 20)
 endfunction
 
+function! go#config#AutoTypeInfo() abort
+  return get(g:, "go_auto_type_info", 0)
+endfunction
+
+function! go#config#SetAutoTypeInfo(value) abort
+  let g:go_auto_type_info = a:value
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -304,4 +304,8 @@ function! go#config#DeclsMode() abort
   return get(g:, "go_decls_mode", "")
 endfunction
 
+function! go#config#DocCommand() abort
+  return get(g:, "go_doc_command", ["godoc"])
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -10,4 +10,19 @@ function! go#config#VersionWarning() abort
   return get(g:, 'go_version_warning', 1)
 endfunction
 
+function! go#config#BuildTags() abort
+  return get(g:, 'go_build_tags', '')
+endfunction
+
+function! go#config#SetBuildTags(value) abort
+  if a:value == ""
+    if exists('g:go_build_tags')
+      unlet g:go_build_tags
+    endif
+    return
+  endif
+
+  let g:go_build_tags = a:value
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -61,4 +61,8 @@ function! go#config#TemplateTestFile() abort
   return get(g:, 'go_template_test_file', "hello_world_test.go")
 endfunction
 
+function! go#config#TemplateFile() abort
+  return get(g:, 'go_template_file', "hello_world.go")
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -202,4 +202,10 @@ function! go#config#DebugAddress() abort
   return get(g:, 'go_debug_address', '127.0.0.1:8181')
 endfunction
 
+function! go#config#DebugCommands() abort
+  " make sure g:go_debug_commands is set so that it can be added to easily.
+  let g:go_debug_commands = get(g:, 'go_debug_commands', {})
+  return g:go_debug_commands
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -276,4 +276,12 @@ function! go#config#SetFmtAutosave(value) abort
   let g:go_fmt_autosave = a:value
 endfunction
 
+function! go#config#AsmfmtAutosave() abort
+  return get(g:, "go_asmfmt_autosave", 0)
+endfunction
+
+function! go#config#SetAsmfmtAutosave(value) abort
+  let g:go_asmfmt_autosave = a:value
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -208,4 +208,8 @@ function! go#config#DebugCommands() abort
   return g:go_debug_commands
 endfunction
 
+function! go#config#SetDebugDiag(value) abort
+  let g:go_debug_diag = a:value
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -188,4 +188,14 @@ function! go#config#Debug() abort
   return get(g:, 'go_debug', [])
 endfunction
 
+function! go#config#DebugWindows() abort
+  return get(g:, 'go_debug_windows', {
+            \ 'stack': 'leftabove 20vnew',
+            \ 'out':   'botright 10new',
+            \ 'vars':  'leftabove 30vnew',
+            \ }
+         \ )
+
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -29,4 +29,8 @@ function! go#config#TestTimeout() abort
  return get(g:, 'go_test_timeout', '10s')
 endfunction
 
+function! go#config#TestShowName() abort
+  return get(g:, 'go_test_show_name', 0)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -320,4 +320,8 @@ function! go#config#FmtFailSilently() abort
   return get(g:, "go_fmt_fail_silently", 0)
 endfunction
 
+function! go#config#FmtExperimental() abort
+  return get(g:, "go_fmt_experimental", 0 )
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -328,4 +328,8 @@ function! go#config#PlayOpenBrowser() abort
   return get(g:, "go_play_open_browser", 1)
 endfunction
 
+function! go#config#GorenameBin() abort
+  return get(g:, "go_gorename_bin", "gorename")
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -180,4 +180,8 @@ function! go#config#DefMode() abort
   return get(g:, 'go_def_mode', 'guru')
 endfunction
 
+function! go#config#DeclsIncludes() abort
+  return get(g:, 'go_decls_includes', 'func,type')
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -45,4 +45,12 @@ function! go#config#TermMode() abort
   return get(g:, 'go_term_mode', 'vsplit')
 endfunction
 
+function! go#config#TermEnabled() abort
+  return get(g:, 'go_term_enabled', 0)
+endfunction
+
+function! go#config#SetTermEnabled(value) abort
+  let g:go_term_enabled = a:value
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -2,4 +2,8 @@ function! go#config#AutodetectGopath() abort
 	return get(g:, 'go_autodetect_gopath', 0)
 endfunction
 
+function! go#config#ListTypeCommands() abort
+  return get(g:, 'go_list_type_commands', {})
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -308,4 +308,8 @@ function! go#config#DocCommand() abort
   return get(g:, "go_doc_command", ["godoc"])
 endfunction
 
+function! go#config#FmtCommand() abort
+  return get(g:, "go_fmt_command", "gofmt")
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -256,4 +256,12 @@ function! go#config#ErrcheckBin() abort
   return get(g:, "go_errcheck_bin", "errcheck")
 endfunction
 
+function! go#config#MetalinterAutosave() abort
+  return get(g:, "go_metalinter_autosave", 0)
+endfunction
+
+function! go#config#SetMetalinterAutosave(value) abort
+  let g:go_metalinter_autosave = a:value
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -312,4 +312,8 @@ function! go#config#FmtCommand() abort
   return get(g:, "go_fmt_command", "gofmt")
 endfunction
 
+function! go#config#FmtOptions() abort
+  return get(g:, "go_fmt_options", {})
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -236,4 +236,8 @@ function! go#config#MetalinterCommand() abort
   return get(g:, "go_metalinter_command", "")
 endfunction
 
+function! go#config#MetalinterAutosaveEnabled() abort
+  return get(g:, 'go_metalinter_autosave_enabled', ['vet', 'golint'])
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -232,4 +232,8 @@ function! go#config#SetTemplateAutocreate(value) abort
   let g:go_template_autocreate = a:value
 endfunction
 
+function! go#config#MetalinterCommand() abort
+  return get(g:, "go_metalinter_command", "")
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -53,4 +53,8 @@ function! go#config#SetTermEnabled(value) abort
   let g:go_term_enabled = a:value
 endfunction
 
+function! go#config#TemplateUsePkg() abort
+  return get(g:, 'go_template_use_pkg', 0)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -107,4 +107,8 @@ function! go#config#ListType() abort
   return get(g:, 'go_list_type', '')
 endfunction
 
+function! go#config#ListAutoclose() abort
+  return get(g:, 'go_list_autoclose', 1)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -25,4 +25,8 @@ function! go#config#SetBuildTags(value) abort
   let g:go_build_tags = a:value
 endfunction
 
+function! go#config#TestTimeout() abort
+ return get(g:, 'go_test_timeout', '10s')
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -300,4 +300,8 @@ function! go#config#AlternateMode() abort
   return get(g:, "go_alternate_mode", "edit")
 endfunction
 
+function! go#config#DeclsMode() abort
+  return get(g:, "go_decls_mode", "")
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -33,4 +33,12 @@ function! go#config#TestShowName() abort
   return get(g:, 'go_test_show_name', 0)
 endfunction
 
+function! go#config#TermHeight() abort
+  return get(g:, 'go_term_height', winheight(0))
+endfunction
+
+function! go#config#TermWidth() abort
+  return get(g:, 'go_term_width', winwidth(0))
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -73,4 +73,22 @@ function! go#config#SnippetEngine() abort
   return get(g:, 'go_snippet_engine', 'automatic')
 endfunction
 
+function! go#config#PlayBrowserCommand() abort
+    if go#util#IsWin()
+        let go_play_browser_command = '!start rundll32 url.dll,FileProtocolHandler %URL%'
+    elseif go#util#IsMac()
+        let go_play_browser_command = 'open %URL%'
+    elseif executable('xdg-open')
+        let go_play_browser_command = 'xdg-open %URL%'
+    elseif executable('firefox')
+        let go_play_browser_command = 'firefox %URL% &'
+    elseif executable('chromium')
+        let go_play_browser_command = 'chromium %URL% &'
+    else
+        let go_play_browser_command = ''
+    endif
+
+    return get(g:, 'go_play_browser_command', go_play_browser_command)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -172,4 +172,8 @@ function! go#config#DocUrl() abort
   return godoc_url
 endfunction
 
+function! go#config#DefReuseBuffer() abort
+  return get(g:, 'go_def_reuse_buffer', 0)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -248,5 +248,8 @@ function! go#config#MetalinterDisabled() abort
   return get(g:, "go_metalinter_disabled", [])
 endfunction
 
+function! go#config#GolintBin() abort
+  return get(g:, "go_golint_bin", "golint")
+endfunction
 
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -103,4 +103,8 @@ function! go#config#MetalinterDeadline() abort
   return get(g:, 'go_metalinter_deadline', deadline)
 endfunction
 
+function! go#config#ListType() abort
+  return get(g:, 'go_list_type', '')
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -146,4 +146,8 @@ function! go#config#GocodeSocketType() abort
   return get(g:, 'go_gocode_socket_type', s:sock_type)
 endfunction
 
+function! go#config#GocodeProposeBuiltins() abort
+  return get(g:, 'go_gocode_propose_builtins', 1)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -324,4 +324,8 @@ function! go#config#FmtExperimental() abort
   return get(g:, "go_fmt_experimental", 0 )
 endfunction
 
+function! go#config#PlayOpenBrowser() abort
+  return get(g:, "go_play_open_browser", 1)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -158,4 +158,18 @@ function! go#config#EchoCommandInfo() abort
   return get(g:, 'go_echo_command_info', 1)
 endfunction
 
+function! go#config#DocUrl() abort
+  let godoc_url = get(g:, 'go_doc_url', 'https://godoc.org')
+  if godoc_url isnot 'https://godoc.org'
+    " strip last '/' character if available
+    let last_char = strlen(godoc_url) - 1
+    if godoc_url[last_char] == '/'
+      let godoc_url = strpart(godoc_url, 0, last_char)
+    endif
+    " custom godoc installations expect /pkg before package names
+    let godoc_url .= "/pkg"
+  endif
+  return godoc_url
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -115,4 +115,26 @@ function! go#config#InfoMode() abort
   return get(g:, 'go_info_mode', 'gocode')
 endfunction
 
+function! go#config#GuruScope() abort
+  let scope = get(g:, 'go_guru_scope', [])
+
+  if !empty(scope)
+    " strip trailing slashes for each path in scope. bug:
+    " https://github.com/golang/go/issues/14584
+    let scopes = go#util#StripTrailingSlash(scope)
+  endif
+
+  return scope
+endfunction
+
+function! go#config#SetGuruScope(scope) abort
+  if empty(a:scope)
+    if exists('g:go_guru_scope')
+      unlet g:go_guru_scope
+    endif
+  else
+    let g:go_guru_scope = a:scope
+  endif
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -316,4 +316,8 @@ function! go#config#FmtOptions() abort
   return get(g:, "go_fmt_options", {})
 endfunction
 
+function! go#config#FmtFailSilently() abort
+  return get(g:, "go_fmt_fail_silently", 0)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -338,6 +338,10 @@ function! go#config#GorenamePrefill() abort
           \ ': go#util#camelcase(expand("<cword>"))')
 endfunction
 
+function! go#config#TextobjIncludeFunctionDoc() abort
+  return get(g:, "go_textobj_include_function_doc", 1)
+endfunction
+
 " Set the default value. A value of "1" is a shortcut for this, for
 " compatibility reasons.
 if exists("g:go_gorename_prefill") && g:go_gorename_prefill == 1

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -244,4 +244,9 @@ function! go#config#MetalinterEnabled() abort
   return get(g:, "go_metalinter_enabled", ['vet', 'golint', 'errcheck'])
 endfunction
 
+function! go#config#MetalinterDisabled() abort
+  return get(g:, "go_metalinter_disabled", [])
+endfunction
+
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -6,4 +6,8 @@ function! go#config#ListTypeCommands() abort
   return get(g:, 'go_list_type_commands', {})
 endfunction
 
+function! go#config#VersionWarning() abort
+  return get(g:, 'go_version_warning', 1)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -342,6 +342,10 @@ function! go#config#TextobjIncludeFunctionDoc() abort
   return get(g:, "go_textobj_include_function_doc", 1)
 endfunction
 
+function! go#config#TextobjIncludeVariable() abort
+  return get(g:, "go_textobj_include_variable", 1)
+endfunction
+
 " Set the default value. A value of "1" is a shortcut for this, for
 " compatibility reasons.
 if exists("g:go_gorename_prefill") && g:go_gorename_prefill == 1

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -153,4 +153,9 @@ endfunction
 function! go#config#GocodeAutobuild() abort
   return get(g:, 'go_gocode_autobuild', 1)
 endfunction
+
+function! go#config#EchoCommandInfo() abort
+  return get(g:, 'go_echo_command_info', 1)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -69,4 +69,8 @@ function! go#config#StatuslineDuration() abort
   return get(g:, 'go_statusline_duration', 60000)
 endfunction
 
+function! go#config#SnippetEngine() abort
+  return get(g:, 'go_snippet_engine', 'automatic')
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -296,4 +296,8 @@ function! go#config#SetAutoTypeInfo(value) abort
   let g:go_auto_type_info = a:value
 endfunction
 
+function! go#config#AlternateMode() abort
+  return get(g:, "go_alternate_mode", "edit")
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -176,4 +176,8 @@ function! go#config#DefReuseBuffer() abort
   return get(g:, 'go_def_reuse_buffer', 0)
 endfunction
 
+function! go#config#DefMode() abort
+  return get(g:, 'go_def_mode', 'guru')
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -252,4 +252,8 @@ function! go#config#GolintBin() abort
   return get(g:, "go_golint_bin", "golint")
 endfunction
 
+function! go#config#ErrcheckBin() abort
+  return get(g:, "go_errcheck_bin", "errcheck")
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -91,4 +91,16 @@ function! go#config#PlayBrowserCommand() abort
     return get(g:, 'go_play_browser_command', go_play_browser_command)
 endfunction
 
+function! go#config#MetalinterDeadline() abort
+  " gometalinter has a default deadline of 5 seconds only when asynchronous
+  " jobs are not supported.
+
+  let deadline = '5s'
+  if go#util#has_job() && has('lambda')
+    let deadline = ''
+  endif
+
+  return get(g:, 'go_metalinter_deadline', deadline)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -198,4 +198,8 @@ function! go#config#DebugWindows() abort
 
 endfunction
 
+function! go#config#DebugAddress() abort
+  return get(g:, 'go_debug_address', '127.0.0.1:8181')
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -137,4 +137,8 @@ function! go#config#SetGuruScope(scope) abort
   endif
 endfunction
 
+function! go#config#GocodeUnimportedPackages() abort
+  return get(g:, 'go_gocode_unimported_packages', 0)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -332,4 +332,16 @@ function! go#config#GorenameBin() abort
   return get(g:, "go_gorename_bin", "gorename")
 endfunction
 
+function! go#config#GorenamePrefill() abort
+  return get(g:, "go_gorename_prefill", 'expand("<cword>") =~# "^[A-Z]"' .
+          \ '? go#util#pascalcase(expand("<cword>"))' .
+          \ ': go#util#camelcase(expand("<cword>"))')
+endfunction
+
+" Set the default value. A value of "1" is a shortcut for this, for
+" compatibility reasons.
+if exists("g:go_gorename_prefill") && g:go_gorename_prefill == 1
+  unlet g:go_gorename_prefill
+endif
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -268,4 +268,12 @@ function! go#config#ListHeight() abort
   return get(g:, "go_list_height", 0)
 endfunction
 
+function! go#config#FmtAutosave() abort
+	return get(g:, "go_fmt_autosave", 1)
+endfunction
+
+function! go#config#SetFmtAutosave(value) abort
+  let g:go_fmt_autosave = a:value
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -224,4 +224,12 @@ function! go#config#AddtagsTransform() abort
   return get(g:, 'go_addtags_transform', "snakecase")
 endfunction
 
+function! go#config#TemplateAutocreate() abort
+  return get(g:, "go_template_autocreate", 1)
+endfunction
+
+function! go#config#SetTemplateAutocreate(value) abort
+  let g:go_template_autocreate = a:value
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -41,4 +41,8 @@ function! go#config#TermWidth() abort
   return get(g:, 'go_term_width', winwidth(0))
 endfunction
 
+function! go#config#TermMode() abort
+  return get(g:, 'go_term_mode', 'vsplit')
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -1,0 +1,5 @@
+function! go#config#AutodetectGopath() abort
+	return get(g:, 'go_autodetect_gopath', 0)
+endfunction
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -184,4 +184,8 @@ function! go#config#DeclsIncludes() abort
   return get(g:, 'go_decls_includes', 'func,type')
 endfunction
 
+function! go#config#Debug() abort
+  return get(g:, 'go_debug', [])
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -284,4 +284,8 @@ function! go#config#SetAsmfmtAutosave(value) abort
   let g:go_asmfmt_autosave = a:value
 endfunction
 
+function! go#config#DocMaxHeight() abort
+  return get(g:, "go_doc_max_height", 20)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -111,4 +111,8 @@ function! go#config#ListAutoclose() abort
   return get(g:, 'go_list_autoclose', 1)
 endfunction
 
+function! go#config#InfoMode() abort
+  return get(g:, 'go_info_mode', 'gocode')
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -264,4 +264,8 @@ function! go#config#SetMetalinterAutosave(value) abort
   let g:go_metalinter_autosave = a:value
 endfunction
 
+function! go#config#ListHeight() abort
+  return get(g:, "go_list_height", 0)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -240,4 +240,8 @@ function! go#config#MetalinterAutosaveEnabled() abort
   return get(g:, 'go_metalinter_autosave_enabled', ['vet', 'golint'])
 endfunction
 
+function! go#config#MetalinterEnabled() abort
+  return get(g:, "go_metalinter_enabled", ['vet', 'golint', 'errcheck'])
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -150,4 +150,7 @@ function! go#config#GocodeProposeBuiltins() abort
   return get(g:, 'go_gocode_propose_builtins', 1)
 endfunction
 
+function! go#config#GocodeAutobuild() abort
+  return get(g:, 'go_gocode_autobuild', 1)
+endfunction
 " vim: sw=2 ts=2 et

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -141,4 +141,9 @@ function! go#config#GocodeUnimportedPackages() abort
   return get(g:, 'go_gocode_unimported_packages', 0)
 endfunction
 
+let s:sock_type = (has('win32') || has('win64')) ? 'tcp' : 'unix'
+function! go#config#GocodeSocketType() abort
+  return get(g:, 'go_gocode_socket_type', s:sock_type)
+endfunction
+
 " vim: sw=2 ts=2 et

--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -64,15 +64,15 @@ function! go#coverage#Buffer(bang, ...) abort
   endif
 
   let disabled_term = 0
-  if get(g:, 'go_term_enabled')
+  if go#config#TermEnabled()
     let disabled_term = 1
-    let g:go_term_enabled = 0
+    call go#config#SetTermEnabled(0)
   endif
 
   let id = call('go#test#Test', args)
 
   if disabled_term
-    let g:go_term_enabled = 1
+    call go#config#SetTermEnabled(1)
   endif
 
   if has('nvim')

--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -44,7 +44,7 @@ function! go#coverage#Buffer(bang, ...) abort
   let s:toggle = 1
   let l:tmpname = tempname()
 
-  if get(g:, 'go_echo_command_info', 1)
+  if go#config#EchoCommandInfo()
     call go#util#EchoProgress("testing...")
   endif
 

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -59,9 +59,6 @@ endfunction
 
 function! s:call_jsonrpc(method, ...) abort
   if go#util#HasDebug('debugger-commands')
-    if !exists('g:go_debug_commands')
-      let g:go_debug_commands = []
-    endif
     echom 'sending to dlv ' . a:method
   endif
 

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -1,9 +1,5 @@
 scriptencoding utf-8
 
-if !exists('g:go_debug_address')
-  let g:go_debug_address = '127.0.0.1:8181'
-endif
-
 if !exists('s:state')
   let s:state = {
       \ 'rpcid': 1,
@@ -477,7 +473,7 @@ function! s:out_cb(ch, msg) abort
   let s:state['message'] += [a:msg]
 
   " TODO: why do this in this callback?
-  if stridx(a:msg, g:go_debug_address) != -1
+  if stridx(a:msg, go#config#DebugAddress()) != -1
     call ch_setoptions(a:ch, {
       \ 'out_cb': function('s:logger', ['OUT: ']),
       \ 'err_cb': function('s:logger', ['ERR: ']),
@@ -552,7 +548,7 @@ function! go#debug#Start(is_test, ...) abort
           \ '--headless',
           \ '--api-version', '2',
           \ '--log',
-          \ '--listen', g:go_debug_address,
+          \ '--listen', go#config#DebugAddress(),
           \ '--accept-multiclient',
     \]
 

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -562,8 +562,10 @@ function! go#debug#Start(is_test, ...) abort
           \ '--listen', g:go_debug_address,
           \ '--accept-multiclient',
     \]
-    if get(g:, 'go_build_tags', '') isnot ''
-      let l:cmd += ['--build-flags', '--tags=' . g:go_build_tags]
+
+    let buildtags = go#config#BuildTags()
+    if buildtags isnot ''
+      let l:cmd += ['--build-flags', '--tags=' . buildtags]
     endif
     let l:cmd += l:args
 

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -1,13 +1,5 @@
 scriptencoding utf-8
 
-if !exists('g:go_debug_windows')
-  let g:go_debug_windows = {
-        \ 'stack': 'leftabove 20vnew',
-        \ 'out':   'botright 10new',
-        \ 'vars':  'leftabove 30vnew',
-        \ }
-endif
-
 if !exists('g:go_debug_address')
   let g:go_debug_address = '127.0.0.1:8181'
 endif
@@ -416,8 +408,9 @@ function! s:start_cb(ch, json) abort
     return
   endif
 
-  if exists('g:go_debug_windows["stack"]') && g:go_debug_windows['stack'] != ''
-    exe 'silent ' . g:go_debug_windows['stack']
+  let debugwindows = go#config#DebugWindows()
+  if has_key(debugwindows, "stack") && debugwindows['stack'] != ''
+    exe 'silent ' . debugwindows['stack']
     silent file `='__GODEBUG_STACKTRACE__'`
     setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
     setlocal filetype=godebugstacktrace
@@ -425,16 +418,16 @@ function! s:start_cb(ch, json) abort
     nmap <buffer> q <Plug>(go-debug-stop)
   endif
 
-  if exists('g:go_debug_windows["out"]') && g:go_debug_windows['out'] != ''
-    exe 'silent ' . g:go_debug_windows['out']
+  if has_key(debugwindows, "out") && debugwindows['out'] != ''
+    exe 'silent ' . debugwindows['out']
     silent file `='__GODEBUG_OUTPUT__'`
     setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
     setlocal filetype=godebugoutput
     nmap <buffer> q <Plug>(go-debug-stop)
   endif
 
-  if exists('g:go_debug_windows["vars"]') && g:go_debug_windows['vars'] != ''
-    exe 'silent ' . g:go_debug_windows['vars']
+  if has_key(debugwindows, "vars") && debugwindows['vars'] != ''
+    exe 'silent ' . debugwindows['vars']
     silent file `='__GODEBUG_VARIABLES__'`
     setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
     setlocal filetype=godebugvariables

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -13,7 +13,7 @@ if !exists('s:state')
       \}
 
   if go#util#HasDebug('debugger-state')
-    let g:go_debug_diag = s:state
+     call go#config#SetDebugDiag(s:state)
   endif
 endif
 
@@ -507,7 +507,7 @@ function! go#debug#Start(is_test, ...) abort
   let s:start_args = a:000
 
   if go#util#HasDebug('debugger-state')
-    let g:go_debug_diag = s:state
+    call go#config#DebugDiag(s:state)
   endif
 
   " cd in to test directory; this is also what running "go test" does.

--- a/autoload/go/decls.vim
+++ b/autoload/go/decls.vim
@@ -1,11 +1,8 @@
-if !exists('g:go_decls_mode')
-  let g:go_decls_mode = ''
-endif
-
 function! go#decls#Decls(mode, ...) abort
-  if g:go_decls_mode == 'ctrlp'
+  let decls_mode = go#config#DeclsMode()
+  if decls_mode == 'ctrlp'
     call ctrlp#init(call("ctrlp#decls#cmd", [a:mode] + a:000))
-  elseif g:go_decls_mode == 'fzf'
+  elseif decls_mode == 'fzf'
     call call("fzf#decls#cmd", [a:mode] + a:000)
   else
     if globpath(&rtp, 'plugin/ctrlp.vim') != ""

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -8,7 +8,7 @@ function! go#def#Jump(mode) abort
   " godef which also has it's own quirks. But this issue come up so many
   " times I've decided to support both. By default we still use guru as it
   " covers all edge cases, but now anyone can switch to godef if they wish
-  let bin_name = get(g:, 'go_def_mode', 'guru')
+  let bin_name = go#config#DefMode()
   if bin_name == 'godef'
     if &modified
       " Write current unsaved buffer to a temp file and use the modified content

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -138,7 +138,7 @@ function! go#def#jump_to_declaration(out, mode, bin_name) abort
   if filename != fnamemodify(expand("%"), ':p:gs?\\?/?')
     " jump to existing buffer if, 1. we have enabled it, 2. the buffer is loaded
     " and 3. there is buffer window number we switch to
-    if get(g:, 'go_def_reuse_buffer', 0) && bufloaded(filename) != 0 && bufwinnr(filename) != -1
+    if go#config#DefReuseBuffer() && bufloaded(filename) != 0 && bufwinnr(filename) != -1
       " jumpt to existing buffer if it exists
       execute bufwinnr(filename) . 'wincmd w'
     else

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -42,8 +42,8 @@ function! go#def#Jump(mode) abort
       call add(cmd, "-modified")
     endif
 
-    if exists('g:go_build_tags')
-      let tags = get(g:, 'go_build_tags')
+    let tags = go#config#BuildTags()
+    if !empty(tags)
       call extend(cmd, ["-tags", tags])
     endif
 

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -29,13 +29,11 @@ function! go#doc#OpenBrowser(...) abort
     let name = out["name"]
     let decl = out["decl"]
 
-    let godoc_url = s:custom_godoc_url()
+    let godoc_url = go#config#DocUrl()
     let godoc_url .= "/" . import
     if decl !~ "^package"
       let godoc_url .= "#" . name
     endif
-
-    echo godoc_url
 
     call go#tool#OpenBrowser(godoc_url)
     return
@@ -50,7 +48,7 @@ function! go#doc#OpenBrowser(...) abort
   let exported_name = pkgs[1]
 
   " example url: https://godoc.org/github.com/fatih/set#Set
-  let godoc_url = s:custom_godoc_url() . "/" . pkg . "#" . exported_name
+  let godoc_url = go#config#DocUrl() . "/" . pkg . "#" . exported_name
   call go#tool#OpenBrowser(godoc_url)
 endfunction
 
@@ -204,20 +202,6 @@ function! s:godocWord(args) abort
   endif
 
   return [pkg, exported_name]
-endfunction
-
-function! s:custom_godoc_url() abort
-  let godoc_url = get(g:, 'go_doc_url', 'https://godoc.org')
-  if godoc_url isnot 'https://godoc.org'
-    " strip last '/' character if available
-    let last_char = strlen(godoc_url) - 1
-    if godoc_url[last_char] == '/'
-      let godoc_url = strpart(godoc_url, 0, last_char)
-    endif
-    " custom godoc installations expect /pkg before package names
-    let godoc_url .= "/pkg"
-  endif
-  return godoc_url
 endfunction
 
 " vim: sw=2 ts=2 et

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -4,10 +4,6 @@
 
 let s:buf_nr = -1
 
-if !exists("g:go_doc_command")
-  let g:go_doc_command = ["godoc"]
-endif
-
 function! go#doc#OpenBrowser(...) abort
   " check if we have gogetdoc as it gives us more and accurate information.
   " Only supported if we have json_decode as it's not worth to parse the plain
@@ -55,11 +51,11 @@ endfunction
 function! go#doc#Open(newmode, mode, ...) abort
   " With argument: run "godoc [arg]".
   if len(a:000)
-    if empty(go#path#CheckBinPath(g:go_doc_command[0]))
+    if empty(go#path#CheckBinPath(go#config#DocCommand()[0]))
       return
     endif
 
-    let command = printf("%s %s", go#util#Shelljoin(g:go_doc_command), join(a:000, ' '))
+    let command = printf("%s %s", go#util#Shelljoin(go#config#DocCommand()), join(a:000, ' '))
     let out = go#util#System(command)
   " Without argument: run gogetdoc on cursor position.
   else

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -95,7 +95,7 @@ function! s:GodocView(newposition, position, content) abort
   if !is_visible
     if a:position == "split"
       " cap window height to 20, but resize it for smaller contents
-      let max_height = get(g:, "go_doc_max_height", 20)
+      let max_height = go#config#DocMaxHeight()
       let content_height = len(split(a:content, "\n"))
       if content_height > max_height
         exe 'resize ' . max_height

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -5,10 +5,6 @@
 " fmt.vim: Vim command to format Go files with gofmt (and gofmt compatible
 " toorls, such as goimports).
 
-if !exists('g:go_fmt_fail_silently')
-  let g:go_fmt_fail_silently = 0
-endif
-
 if !exists("g:go_fmt_experimental")
   let g:go_fmt_experimental = 0
 endif
@@ -67,7 +63,7 @@ function! go#fmt#Format(withGoimport) abort
 
   if go#util#ShellError() == 0
     call go#fmt#update_file(l:tmpname, expand('%'))
-  elseif g:go_fmt_fail_silently == 0
+  elseif go#config#FmtFailSilently()
     let errors = s:parse_errors(expand('%'), out)
     call s:show_errors(errors)
   endif

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -5,10 +5,6 @@
 " fmt.vim: Vim command to format Go files with gofmt (and gofmt compatible
 " toorls, such as goimports).
 
-if !exists("g:go_fmt_command")
-  let g:go_fmt_command = "gofmt"
-endif
-
 if !exists('g:go_fmt_options')
   let g:go_fmt_options = ''
 endif
@@ -64,7 +60,7 @@ function! go#fmt#Format(withGoimport) abort
     let l:tmpname = tr(l:tmpname, '\', '/')
   endif
 
-  let bin_name = g:go_fmt_command
+  let bin_name = go#config#FmtCommand()
   if a:withGoimport == 1
     let bin_name = "goimports"
   endif

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -254,13 +254,13 @@ function! s:show_errors(errors) abort
 endfunction
 
 function! go#fmt#ToggleFmtAutoSave() abort
-  if get(g:, "go_fmt_autosave", 1)
-    let g:go_fmt_autosave = 0
+  if go#config#FmtAutosave()
+    call go#config#FmtAutosave(0)
     call go#util#EchoProgress("auto fmt disabled")
     return
   end
 
-  let g:go_fmt_autosave = 1
+  call go#config#FmtAutosave(1)
   call go#util#EchoProgress("auto fmt enabled")
 endfunction
 

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -5,10 +5,6 @@
 " fmt.vim: Vim command to format Go files with gofmt (and gofmt compatible
 " toorls, such as goimports).
 
-if !exists('g:go_fmt_options')
-  let g:go_fmt_options = ''
-endif
-
 if !exists('g:go_fmt_fail_silently')
   let g:go_fmt_fail_silently = 0
 endif
@@ -182,9 +178,9 @@ function! s:fmt_cmd(bin_name, source, target)
   " add the options for binary (if any). go_fmt_options was by default of type
   " string, however to allow customization it's now a dictionary of binary
   " name mapping to options.
-  let opts = g:go_fmt_options
-  if type(g:go_fmt_options) == type({})
-    let opts = has_key(g:go_fmt_options, a:bin_name) ? g:go_fmt_options[a:bin_name] : ""
+  let opts = go#config#FmtOptions()
+  if type(opts) == type({})
+    let opts = has_key(opts, a:bin_name) ? opts[a:bin_name] : ""
   endif
   call extend(cmd, split(opts, " "))
 

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -5,10 +5,6 @@
 " fmt.vim: Vim command to format Go files with gofmt (and gofmt compatible
 " toorls, such as goimports).
 
-if !exists("g:go_fmt_experimental")
-  let g:go_fmt_experimental = 0
-endif
-
 "  we have those problems :
 "  http://stackoverflow.com/questions/12741977/prevent-vim-from-updating-its-undo-tree
 "  http://stackoverflow.com/questions/18532692/golang-formatter-and-vim-how-to-destroy-history-record?rq=1
@@ -18,7 +14,7 @@ endif
 "  this and have VimL experience, please look at the function for
 "  improvements, patches are welcome :)
 function! go#fmt#Format(withGoimport) abort
-  if g:go_fmt_experimental == 1
+  if go#config#FmtExperimental()
     " Using winsaveview to save/restore cursor state has the problem of
     " closing folds on save:
     "   https://github.com/fatih/vim-go/issues/502
@@ -71,7 +67,7 @@ function! go#fmt#Format(withGoimport) abort
   " We didn't use the temp file, so clean up
   call delete(l:tmpname)
 
-  if g:go_fmt_experimental == 1
+  if go#config#FmtExperimental()
     " restore our undo history
     silent! exe 'rundo ' . tmpundofile
     call delete(tmpundofile)

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -44,8 +44,8 @@ function! s:guru_cmd(args) range abort
   endif
 
   " check for any tags
-  if exists('g:go_build_tags')
-    let tags = get(g:, 'go_build_tags')
+  let tags = go#config#BuildTags()
+  if !empty(tags)
     call extend(cmd, ["-tags", tags])
     let result.tags = tags
   endif

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -508,20 +508,20 @@ function! s:same_ids_highlight(exit_val, output, mode) abort
   call go#guru#ClearSameIds() " run after calling guru to reduce flicker.
 
   if a:output[0] !=# '{'
-    if !get(g:, 'go_auto_sameids', 0)
+    if !go#config#AutoSameids()
       call go#util#EchoError(a:output)
     endif
     return
   endif
 
   let result = json_decode(a:output)
-  if type(result) != type({}) && !get(g:, 'go_auto_sameids', 0)
+  if type(result) != type({}) && !go#config#AutoSameids()
     call go#util#EchoError("malformed output from guru")
     return
   endif
 
   if !has_key(result, 'sameids')
-    if !get(g:, 'go_auto_sameids', 0)
+    if !go#config#AutoSameids()
       call go#util#EchoError("no same_ids founds for the given identifier")
     endif
     return
@@ -547,7 +547,7 @@ function! s:same_ids_highlight(exit_val, output, mode) abort
     call matchaddpos('goSameId', [[str2nr(pos[-2]), str2nr(pos[-1]), str2nr(poslen)]])
   endfor
 
-  if get(g:, "go_auto_sameids", 0)
+  if go#config#AutoSameids()
     " re-apply SameIds at the current cursor position at the time the buffer
     " is redisplayed: e.g. :edit, :GoRename, etc.
     augroup vim-go-sameids
@@ -589,15 +589,15 @@ function! go#guru#ToggleSameIds() abort
 endfunction
 
 function! go#guru#AutoToogleSameIds() abort
-  if get(g:, "go_auto_sameids", 0)
+  if go#config#AutoSameids()
     call go#util#EchoProgress("sameids auto highlighting disabled")
     call go#guru#ClearSameIds()
-    let g:go_auto_sameids = 0
+    call go#config#SetAutoSameids(0)
     return
   endif
 
   call go#util#EchoSuccess("sameids auto highlighting enabled")
-  let g:go_auto_sameids = 1
+  call go#config#SetAutoSameids(1)
 endfunction
 
 

--- a/autoload/go/guru_test.vim
+++ b/autoload/go/guru_test.vim
@@ -1,0 +1,15 @@
+function Test_GuruScope_Set() abort
+  call go#guru#Scope("example.com/foo/bar")
+  let actual = go#config#GuruScope()
+  call assert_equal(["example.com/foo/bar"], actual)
+
+  call go#guru#Scope('""')
+  let actual = go#config#GuruScope()
+  call assert_equal([], actual, "setting scope to empty string should clear")
+
+  if exists('g:go_guru_scope')
+    unlet g:go_guru_scope
+  endif
+endfunction
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -73,7 +73,7 @@ function go#job#Spawn(args)
     let self.exit_status = a:exitval
     let self.exited = 1
 
-    if get(g:, 'go_echo_command_info', 1)
+    if go#config#EchoCommandInfo()
       if a:exitval == 0
         call go#util#EchoSuccess("SUCCESS")
       else

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -129,7 +129,7 @@ function! s:on_exit(job_id, exit_status, event) dict abort
 
     let self.state = "SUCCESS"
 
-    if get(g:, 'go_echo_command_info', 1)
+    if go#config#EchoCommandInfo()
       call go#util#EchoSuccess("[" . self.status_type . "] SUCCESS")
     endif
 
@@ -139,7 +139,7 @@ function! s:on_exit(job_id, exit_status, event) dict abort
 
   let self.state = "FAILED"
 
-  if get(g:, 'go_echo_command_info', 1)
+  if go#config#EchoCommandInfo()
     call go#util#EchoError("[" . self.status_type . "] FAILED")
   endif
 

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -1,7 +1,3 @@
-if !exists("g:go_metalinter_enabled")
-  let g:go_metalinter_enabled = ['vet', 'golint', 'errcheck']
-endif
-
 if !exists("g:go_metalinter_disabled")
   let g:go_metalinter_disabled = []
 endif
@@ -31,7 +27,7 @@ function! go#lint#Gometa(autosave, ...) abort
 
   if a:autosave || empty(go#config#MetalinterCommand())
     " linters
-    let linters = a:autosave ? go#config#MetalinterAutosaveEnabled() : g:go_metalinter_enabled
+    let linters = a:autosave ? go#config#MetalinterAutosaveEnabled() : go#config#MetalinterEnabled()
     for linter in linters
       let cmd += ["--enable=".linter]
     endfor

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -1,7 +1,3 @@
-if !exists("g:go_metalinter_disabled")
-  let g:go_metalinter_disabled = []
-endif
-
 if !exists("g:go_golint_bin")
   let g:go_golint_bin = "golint"
 endif
@@ -32,7 +28,7 @@ function! go#lint#Gometa(autosave, ...) abort
       let cmd += ["--enable=".linter]
     endfor
 
-    for linter in g:go_metalinter_disabled
+    for linter in go#config#MetalinterDisabled()
       let cmd += ["--disable=".linter]
     endfor
 

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -1,7 +1,3 @@
-if !exists("g:go_errcheck_bin")
-  let g:go_errcheck_bin = "errcheck"
-endif
-
 function! go#lint#Gometa(autosave, ...) abort
   if a:0 == 0
     let goargs = [expand('%:p:h')]
@@ -158,7 +154,7 @@ function! go#lint#Errcheck(...) abort
     let import_path = go#util#Shelljoin(a:000)
   endif
 
-  let bin_path = go#path#CheckBinPath(g:go_errcheck_bin)
+  let bin_path = go#path#CheckBinPath(go#config#ErrcheckBin())
   if empty(bin_path)
     return
   endif

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -195,13 +195,13 @@ function! go#lint#Errcheck(...) abort
 endfunction
 
 function! go#lint#ToggleMetaLinterAutoSave() abort
-  if get(g:, "go_metalinter_autosave", 0)
-    let g:go_metalinter_autosave = 0
+  if go#config#MetalinterAutosave()
+    call go#config#SetMetalinterAutosave(0)
     call go#util#EchoProgress("auto metalinter disabled")
     return
   end
 
-  let g:go_metalinter_autosave = 1
+  call go#config#SetMetalinterAutosave(1)
   call go#util#EchoProgress("auto metalinter enabled")
 endfunction
 

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -1,7 +1,3 @@
-if !exists("g:go_metalinter_command")
-  let g:go_metalinter_command = ""
-endif
-
 if !exists("g:go_metalinter_autosave_enabled")
   let g:go_metalinter_autosave_enabled = ['vet', 'golint']
 endif
@@ -37,7 +33,7 @@ function! go#lint#Gometa(autosave, ...) abort
   let cmd = [bin_path]
   let cmd += ["--disable-all"]
 
-  if a:autosave || empty(g:go_metalinter_command)
+  if a:autosave || empty(go#config#MetalinterCommand())
     " linters
     let linters = a:autosave ? g:go_metalinter_autosave_enabled : g:go_metalinter_enabled
     for linter in linters
@@ -56,7 +52,7 @@ function! go#lint#Gometa(autosave, ...) abort
     let cmd += ["--tests"]
   else
     " the user wants something else, let us use it.
-    let cmd += split(g:go_metalinter_command, " ")
+    let cmd += split(go#config#MetalinterCommand(), " ")
   endif
 
   if a:autosave

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -1,7 +1,3 @@
-if !exists("g:go_metalinter_autosave_enabled")
-  let g:go_metalinter_autosave_enabled = ['vet', 'golint']
-endif
-
 if !exists("g:go_metalinter_enabled")
   let g:go_metalinter_enabled = ['vet', 'golint', 'errcheck']
 endif
@@ -35,7 +31,7 @@ function! go#lint#Gometa(autosave, ...) abort
 
   if a:autosave || empty(go#config#MetalinterCommand())
     " linters
-    let linters = a:autosave ? g:go_metalinter_autosave_enabled : g:go_metalinter_enabled
+    let linters = a:autosave ? go#config#MetalinterAutosaveEnabled() : g:go_metalinter_enabled
     for linter in linters
       let cmd += ["--enable=".linter]
     endfor

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -1,7 +1,3 @@
-if !exists("g:go_golint_bin")
-  let g:go_golint_bin = "golint"
-endif
-
 if !exists("g:go_errcheck_bin")
   let g:go_errcheck_bin = "errcheck"
 endif
@@ -98,7 +94,7 @@ endfunction
 " Golint calls 'golint' on the current directory. Any warnings are populated in
 " the location list
 function! go#lint#Golint(...) abort
-  let bin_path = go#path#CheckBinPath(g:go_golint_bin)
+  let bin_path = go#path#CheckBinPath(go#config#GolintBin())
   if empty(bin_path)
     return
   endif

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -320,7 +320,7 @@ function! s:lint_job(args, autosave)
       exe l:winnr . "wincmd w"
     endif
 
-    if get(g:, 'go_echo_command_info', 1)
+    if go#config#EchoCommandInfo()
       call go#util#EchoSuccess("linting finished")
     endif
   endfunction
@@ -335,7 +335,7 @@ function! s:lint_job(args, autosave)
 
   call job_start(a:args.cmd, start_options)
 
-  if get(g:, 'go_echo_command_info', 1)
+  if go#config#EchoCommandInfo()
     call go#util#EchoProgress("linting started ...")
   endif
 endfunction

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -86,7 +86,6 @@ func! Test_GometaAutoSave() abort
   " And restore it back to its previous value
   call go#lint#ToggleMetaLinterAutoSave()
 
-  let orig_go_metalinter_autosave_enabled = g:go_metalinter_autosave_enabled
   let g:go_metalinter_autosave_enabled = ['golint']
 
   call go#lint#Gometa(1)
@@ -99,7 +98,7 @@ func! Test_GometaAutoSave() abort
   endwhile
 
   call gotest#assert_quickfix(actual, expected)
-  let g:go_metalinter_autosave_enabled = orig_go_metalinter_autosave_enabled
+  unlet g:go_metalinter_autosave_enabled
 endfunc
 
 func! Test_Vet()

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -16,7 +16,6 @@ func! Test_Gometa() abort
   " And restore it back to its previous value
   call go#lint#ToggleMetaLinterAutoSave()
 
-  let orig_go_metalinter_enabled = g:go_metalinter_enabled
   let g:go_metalinter_enabled = ['golint']
 
   call go#lint#Gometa(0, $GOPATH . '/src/foo')
@@ -29,7 +28,7 @@ func! Test_Gometa() abort
   endwhile
 
   call gotest#assert_quickfix(actual, expected)
-  let g:go_metalinter_enabled = orig_go_metalinter_enabled
+  unlet g:go_metalinter_enabled
 endfunc
 
 func! Test_GometaWithDisabled() abort

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -49,7 +49,6 @@ func! Test_GometaWithDisabled() abort
   " And restore it back to its previous value
   call go#lint#ToggleMetaLinterAutoSave()
 
-  let orig_go_metalinter_disabled = g:go_metalinter_disabled
   let g:go_metalinter_disabled = ['vet']
 
   call go#lint#Gometa(0, $GOPATH . '/src/foo')
@@ -62,7 +61,7 @@ func! Test_GometaWithDisabled() abort
   endwhile
 
   call gotest#assert_quickfix(actual, expected)
-  let g:go_metalinter_disabled = orig_go_metalinter_disabled
+  unlet g:go_metalinter_disabled
 endfunc
 
 func! Test_GometaAutoSave() abort

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -2,10 +2,6 @@ if !exists("g:go_list_type")
   let g:go_list_type = ""
 endif
 
-if !exists("g:go_list_type_commands")
-  let g:go_list_type_commands = {}
-endif
-
 " Window opens the list with the given height up to 10 lines maximum.
 " Otherwise g:go_loclist_height is used.
 "
@@ -169,7 +165,7 @@ function! go#list#Type(for) abort
     let l:listtype = "quickfix"
   endif
 
-  return get(g:go_list_type_commands, a:for, l:listtype)
+  return get(go#config#ListTypeCommands(), a:for, l:listtype)
 endfunction
 
 " vim: sw=2 ts=2 et

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -14,7 +14,7 @@ function! go#list#Window(listtype, ...) abort
     return
   endif
 
-  let height = get(g:, "go_list_height", 0)
+  let height = go#config#ListHeight()
   if height == 0
     " prevent creating a large location height for a large set of numbers
     if a:1 > 10

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -105,7 +105,7 @@ endfunction
 
 " Close closes the location list
 function! go#list#Close(listtype) abort
-  let autoclose_window = get(g:, 'go_list_autoclose', 1)
+  let autoclose_window = go#config#ListAutoclose()
   if !autoclose_window
     return
   endif

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -1,7 +1,3 @@
-if !exists("g:go_list_type")
-  let g:go_list_type = ""
-endif
-
 " Window opens the list with the given height up to 10 lines maximum.
 " Otherwise g:go_loclist_height is used.
 "
@@ -122,13 +118,12 @@ function! go#list#Close(listtype) abort
 endfunction
 
 function! s:listtype(listtype) abort
-  if g:go_list_type == "locationlist"
-    return "locationlist"
-  elseif g:go_list_type == "quickfix"
-    return "quickfix"
+  let listtype = go#config#ListType()
+  if empty(listtype)
+    return a:listtype
   endif
 
-  return a:listtype
+  return listtype
 endfunction
 
 " s:default_list_type_commands is the defaults that will be used for each of

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -121,13 +121,14 @@ endfunction
 
 " BinPath returns the binary path of installed go tools.
 function! go#path#BinPath() abort
-  let bin_path = ""
+  let bin_path = go#config#BinPath()
+  if bin_path != ""
+    return bin_path
+  endif
 
   " check if our global custom path is set, if not check if $GOBIN is set so
   " we can use it, otherwise use default GOPATH
-  if exists("g:go_bin_path")
-    let bin_path = g:go_bin_path
-  elseif $GOBIN != ""
+  if $GOBIN != ""
     let bin_path = $GOBIN
   else
     let go_paths = split(go#path#Default(), go#util#PathListSep())

--- a/autoload/go/play.vim
+++ b/autoload/go/play.vim
@@ -1,8 +1,3 @@
-if !exists("g:go_play_open_browser")
-  let g:go_play_open_browser = 1
-endif
-
-
 function! go#play#Share(count, line1, line2) abort
   if !executable('curl')
     echohl ErrorMsg | echomsg "vim-go: require 'curl' command" | echohl None
@@ -34,7 +29,7 @@ function! go#play#Share(count, line1, line2) abort
     let @+ = url
   endif
 
-  if g:go_play_open_browser != 0
+  if go#config#PlayOpenBrowser()
     call go#tool#OpenBrowser(url)
   endif
 

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -1,22 +1,10 @@
-" Set the default value. A value of "1" is a shortcut for this, for
-" compatibility reasons.
-function! s:default() abort
-  if !exists("g:go_gorename_prefill") || g:go_gorename_prefill == 1
-    let g:go_gorename_prefill = 'expand("<cword>") =~# "^[A-Z]"' .
-          \ '? go#util#pascalcase(expand("<cword>"))' .
-          \ ': go#util#camelcase(expand("<cword>"))'
-  endif
-endfunction
-call s:default()
-
 function! go#rename#Rename(bang, ...) abort
-  call s:default()
-
   let to_identifier = ""
   if a:0 == 0
     let ask = printf("vim-go: rename '%s' to: ", expand("<cword>"))
-    if g:go_gorename_prefill != ''
-      let to_identifier = input(ask, eval(g:go_gorename_prefill))
+    let prefill = go#config#GorenamePrefill()
+    if prefill != ''
+      let to_identifier = input(ask, eval(prefill))
     else
       let to_identifier = input(ask)
     endif

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -1,7 +1,3 @@
-if !exists("g:go_gorename_bin")
-  let g:go_gorename_bin = "gorename"
-endif
-
 " Set the default value. A value of "1" is a shortcut for this, for
 " compatibility reasons.
 function! s:default() abort
@@ -33,7 +29,7 @@ function! go#rename#Rename(bang, ...) abort
   endif
 
   " return with a warning if the bin doesn't exist
-  let bin_path = go#path#CheckBinPath(g:go_gorename_bin)
+  let bin_path = go#path#CheckBinPath(go#config#GorenameBin())
   if empty(bin_path)
     return
   endif

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -50,8 +50,8 @@ function! go#rename#Rename(bang, ...) abort
   let cmd = [bin_path, "-offset", offset, "-to", to_identifier]
 
   " check for any tags
-  if exists('g:go_build_tags')
-    let tags = get(g:, 'go_build_tags')
+  let tags = go#config#BuildTags()
+  if !empty(tags)
     call extend(cmd, ["-tags", tags])
   endif
 

--- a/autoload/go/statusline.vim
+++ b/autoload/go/statusline.vim
@@ -26,7 +26,7 @@ function! go#statusline#Show() abort
   " lazy initialiation of the cleaner
   if !s:timer_id
     " clean every 60 seconds all statuses
-    let interval = get(g:, 'go_statusline_duration', 60000)
+    let interval = go#config#StatuslineDuration()
     let s:timer_id = timer_start(interval, function('go#statusline#Clear'), {'repeat': -1})
   endif
 

--- a/autoload/go/tags.vim
+++ b/autoload/go/tags.vim
@@ -122,7 +122,7 @@ func s:create_cmd(args) abort
   let l:offset = a:args.offset
   let l:mode = a:args.mode
   let l:cmd_args = a:args.cmd_args
-  let l:modifytags_transform = get(g:, 'go_addtags_transform', "snakecase")
+  let l:modifytags_transform = go#config#AddtagsTransform()
 
   " start constructing the command
   let cmd = [bin_path]

--- a/autoload/go/template.vim
+++ b/autoload/go/template.vim
@@ -1,7 +1,7 @@
 let s:current_file = expand("<sfile>")
 
 function! go#template#create() abort
-  let l:go_template_use_pkg = get(g:, 'go_template_use_pkg', 0)
+  let l:go_template_use_pkg = go#config#TemplateUsePkg()
   let l:root_dir = fnamemodify(s:current_file, ':h:h:h')
 
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '

--- a/autoload/go/template.vim
+++ b/autoload/go/template.vim
@@ -40,13 +40,13 @@ function! go#template#create() abort
 endfunction
 
 function! go#template#ToggleAutoCreate() abort
-  if get(g:, "go_template_autocreate", 1)
-    let g:go_template_autocreate = 0
+  if go#config#TemplateAutocreate()
+    call go#config#SetTemplateAutocreate(0)
     call go#util#EchoProgress("auto template create disabled")
     return
   end
 
-  let g:go_template_autocreate = 1
+  call go#config#SetTemplateAutocreate(1)
   call go#util#EchoProgress("auto template create enabled")
 endfunction
 

--- a/autoload/go/template.vim
+++ b/autoload/go/template.vim
@@ -19,7 +19,7 @@ function! go#template#create() abort
   if l:package_name == -1 && l:go_template_use_pkg != 1
     let l:filename = fnamemodify(expand("%"), ':t')
     if l:filename =~ "_test.go$"
-      let l:template_file = get(g:, 'go_template_test_file', "hello_world_test.go")
+      let l:template_file = go#config#TemplateTestFile()
     else
       let l:template_file = get(g:, 'go_template_file', "hello_world.go")
     endif

--- a/autoload/go/template.vim
+++ b/autoload/go/template.vim
@@ -21,7 +21,7 @@ function! go#template#create() abort
     if l:filename =~ "_test.go$"
       let l:template_file = go#config#TemplateTestFile()
     else
-      let l:template_file = get(g:, 'go_template_file', "hello_world.go")
+      let l:template_file = go#config#TemplateFile()
     endif
     let l:template_path = go#util#Join(l:root_dir, "templates", l:template_file)
     silent exe 'keepalt 0r ' . fnameescape(l:template_path)

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -1,18 +1,14 @@
-if has('nvim') && !exists("g:go_term_mode")
-  let g:go_term_mode = 'vsplit'
-endif
-
 " new creates a new terminal with the given command. Mode is set based on the
 " global variable g:go_term_mode, which is by default set to :vsplit
 function! go#term#new(bang, cmd) abort
-  return go#term#newmode(a:bang, a:cmd, g:go_term_mode)
+  return go#term#newmode(a:bang, a:cmd, go#config#TermMode())
 endfunction
 
 " new creates a new terminal with the given command and window mode.
 function! go#term#newmode(bang, cmd, mode) abort
   let mode = a:mode
   if empty(mode)
-    let mode = g:go_term_mode
+    let mode = go#config#TermMode()
   endif
 
   let state = {

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -52,8 +52,8 @@ function! go#term#newmode(bang, cmd, mode) abort
   execute cd . fnameescape(dir)
 
   " resize new term if needed.
-  let height = get(g:, 'go_term_height', winheight(0))
-  let width = get(g:, 'go_term_width', winwidth(0))
+  let height = go#config#TermHeight()
+  let width = go#config#TermWidth()
 
   " Adjust the window width or height depending on whether it's a vertical or
   " horizontal split.

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -10,8 +10,8 @@ function! go#test#Test(bang, compile, ...) abort
     call extend(args, ["-c", "-o", testfile])
   endif
 
-  if exists('g:go_build_tags')
-    let tags = get(g:, 'go_build_tags')
+  let tags = go#config#BuildTags()
+  if !empty(tags)
     call extend(args, ["-tags", tags])
   endif
 

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -35,7 +35,7 @@ function! go#test#Test(bang, compile, ...) abort
     call add(args, printf("-timeout=%s", timeout))
   endif
 
-  if get(g:, 'go_echo_command_info', 1)
+  if go#config#EchoCommandInfo()
     if a:compile
       call go#util#EchoProgress("compiling tests ...")
     else
@@ -186,7 +186,7 @@ function! s:test_job(args) abort
       let status.state = "failed"
     endif
 
-    if get(g:, 'go_echo_command_info', 1)
+    if go#config#EchoCommandInfo()
       if a:exitval == 0
         if self.compile_test
           call go#util#EchoSuccess("[test] SUCCESS")

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -58,7 +58,7 @@ function! go#test#Test(bang, compile, ...) abort
     return
   elseif has('nvim')
     " use nvims's job functionality
-    if get(g:, 'go_term_enabled', 0)
+    if go#config#TermEnabled()
       let id = go#term#new(a:bang, ["go"] + args)
     else
       let id = go#jobcontrol#Spawn(a:bang, "test", "GoTest", args)

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -278,8 +278,8 @@ function! s:show_errors(args, exit_val, messages) abort
 endfunction
 
 
-let s:efm= ""
-let s:go_test_show_name=0
+let s:efm = ""
+let s:go_test_show_name = 0
 
 function! s:errorformat() abort
   " NOTE(arslan): once we get JSON output everything will be easier :).
@@ -288,7 +288,7 @@ function! s:errorformat() abort
   "   https://github.com/golang/go/issues/2981.
   let goroot = go#util#goroot()
 
-  let show_name=get(g:, 'go_test_show_name', 0)
+  let show_name = go#config#TestShowName()
   if s:efm != "" && s:go_test_show_name == show_name
     return s:efm
   endif

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -31,7 +31,7 @@ function! go#test#Test(bang, compile, ...) abort
     call extend(args, goargs, 1)
   else
     " only add this if no custom flags are passed
-    let timeout  = get(g:, 'go_test_timeout', '10s')
+    let timeout = go#config#TestTimeout()
     call add(args, printf("-timeout=%s", timeout))
   endif
 
@@ -130,7 +130,7 @@ function! go#test#Func(bang, ...) abort
     call extend(args, a:000)
   else
     " only add this if no custom flags are passed
-    let timeout  = get(g:, 'go_test_timeout', '10s')
+    let timeout = go#config#TestTimeout()
     call add(args, printf("-timeout=%s", timeout))
   endif
 

--- a/autoload/go/test_test.vim
+++ b/autoload/go/test_test.vim
@@ -69,7 +69,7 @@ func! Test_GoTestShowName() abort
 
   let g:go_test_show_name=1
   call s:test('showname/showname_test.go', expected)
-  let g:go_test_show_name=0
+  unlet g:go_test_show_name
 endfunc
 
 func! s:test(file, expected, ...) abort

--- a/autoload/go/textobj.vim
+++ b/autoload/go/textobj.vim
@@ -1,7 +1,3 @@
-if !exists("g:go_textobj_include_function_doc")
-  let g:go_textobj_include_function_doc = 1
-endif
-
 if !exists("g:go_textobj_include_variable")
   let g:go_textobj_include_variable = 1
 endif
@@ -33,7 +29,7 @@ function! go#textobj#Function(mode) abort
   let command = printf("%s -format vim -file %s -offset %s", bin_path, fname, offset)
   let command .= " -mode enclosing"
 
-  if g:go_textobj_include_function_doc
+  if go#config#TextobjIncludeFunctionDoc()
     let command .= " -parse-comments"
   endif
 
@@ -59,7 +55,7 @@ function! go#textobj#Function(mode) abort
   if a:mode == 'a'
     " anonymous functions doesn't have associated doc. Also check if the user
     " want's to include doc comments for function declarations
-    if has_key(info, 'doc') && g:go_textobj_include_function_doc
+    if has_key(info, 'doc') && go#config#TextobjIncludeFunctionDoc()
       call cursor(info.doc.line, info.doc.col)
     elseif info['sig']['name'] == '' && g:go_textobj_include_variable
       " one liner anonymous functions
@@ -121,7 +117,7 @@ function! go#textobj#FunctionLocation(direction, cnt) abort
     let command .= ' -mode prev'
   endif
 
-  if g:go_textobj_include_function_doc
+  if go#config#TextobjIncludeFunctionDoc()
     let command .= " -parse-comments"
   endif
 
@@ -186,7 +182,7 @@ function! go#textobj#FunctionJump(mode, direction) abort
   endif
 
   if a:mode == 'v' && a:direction == 'prev'
-    if has_key(info, 'doc') && g:go_textobj_include_function_doc
+    if has_key(info, 'doc') && go#config#TextobjIncludeFunctionDoc()
       keepjumps call cursor(info.doc.line, 1)
     else
       keepjumps call cursor(info.func.line, 1)

--- a/autoload/go/textobj.vim
+++ b/autoload/go/textobj.vim
@@ -1,7 +1,3 @@
-if !exists("g:go_textobj_enabled")
-  let g:go_textobj_enabled = 1
-endif
-
 if !exists("g:go_textobj_include_function_doc")
   let g:go_textobj_include_function_doc = 1
 endif

--- a/autoload/go/textobj.vim
+++ b/autoload/go/textobj.vim
@@ -1,7 +1,3 @@
-if !exists("g:go_textobj_include_variable")
-  let g:go_textobj_include_variable = 1
-endif
-
 " ( ) motions
 " { } motions
 " s for sentence
@@ -57,7 +53,7 @@ function! go#textobj#Function(mode) abort
     " want's to include doc comments for function declarations
     if has_key(info, 'doc') && go#config#TextobjIncludeFunctionDoc()
       call cursor(info.doc.line, info.doc.col)
-    elseif info['sig']['name'] == '' && g:go_textobj_include_variable
+    elseif info['sig']['name'] == '' && go#config#TextobjIncludeVariable()
       " one liner anonymous functions
       if info.lbrace.line == info.rbrace.line
         " jump to first nonblack char, to get the correct column

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -198,30 +198,8 @@ function! go#tool#Exists(importpath) abort
     return 0
 endfunction
 
-" following two functions are from: https://github.com/mattn/gist-vim
-" thanks  @mattn
-function! s:get_browser_command() abort
-    let go_play_browser_command = get(g:, 'go_play_browser_command', '')
-    if go_play_browser_command == ''
-        if go#util#IsWin()
-            let go_play_browser_command = '!start rundll32 url.dll,FileProtocolHandler %URL%'
-        elseif go#util#IsMac()
-            let go_play_browser_command = 'open %URL%'
-        elseif executable('xdg-open')
-            let go_play_browser_command = 'xdg-open %URL%'
-        elseif executable('firefox')
-            let go_play_browser_command = 'firefox %URL% &'
-        elseif executable('chromium')
-            let go_play_browser_command = 'chromium %URL% &'
-        else
-            let go_play_browser_command = ''
-        endif
-    endif
-    return go_play_browser_command
-endfunction
-
 function! go#tool#OpenBrowser(url) abort
-    let cmd = s:get_browser_command()
+    let cmd = go#config#PlayBrowserCommand()
     if len(cmd) == 0
         redraw
         echohl WarningMsg

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -75,7 +75,7 @@ function! go#tool#Imports() abort
 endfunction
 
 function! go#tool#Info(auto) abort
-  let l:mode = get(g:, 'go_info_mode', 'gocode')
+  let l:mode = go#config#InfoMode()
   if l:mode == 'gocode'
     call go#complete#Info(a:auto)
   elseif l:mode == 'guru'

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -259,7 +259,7 @@ endfunction
 " snippetcase converts the given word to given preferred snippet setting type
 " case.
 function! go#util#snippetcase(word) abort
-  let l:snippet_case = get(g:, 'go_addtags_transform', "snakecase")
+  let l:snippet_case = go#config#AddtagsTransform()
   if l:snippet_case == "snakecase"
     return go#util#snakecase(a:word)
   elseif l:snippet_case == "camelcase"

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -397,7 +397,7 @@ endfunction
 
 " Report if the user enabled a debug flag in g:go_debug.
 function! go#util#HasDebug(flag)
-  return index(get(g:, 'go_debug', []), a:flag) >= 0
+  return index(go#config#Debug(), a:flag) >= 0
 endfunction
 
 " vim: sw=2 ts=2 et

--- a/autoload/unite/sources/decls.vim
+++ b/autoload/unite/sources/decls.vim
@@ -28,7 +28,7 @@ function! s:source.gather_candidates(args, context) abort
     return []
   endif
 
-  let l:include = get(g:, 'go_decls_includes', 'func,type')
+  let l:include = go#config#DeclsIncludes()
   let l:command = printf('%s -format vim -mode decls -include %s -%s %s', l:bin_path, l:include, l:mode, shellescape(l:path))
   let l:candidates = []
   try

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -58,7 +58,7 @@ if get(g:, "go_textobj_enabled", 1)
   xnoremap <buffer> <silent> [[ :<c-u>call go#textobj#FunctionJump('v', 'prev')<cr>
 endif
 
-if get(g:, "go_auto_type_info", 0) || get(g:, "go_auto_sameids", 0)
+if get(g:, "go_auto_type_info", 0) || go#config#AutoSameids()
   let &l:updatetime= get(g:, "go_updatetime", 800)
 endif
 

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -58,7 +58,7 @@ if get(g:, "go_textobj_enabled", 1)
   xnoremap <buffer> <silent> [[ :<c-u>call go#textobj#FunctionJump('v', 'prev')<cr>
 endif
 
-if get(g:, "go_auto_type_info", 0) || go#config#AutoSameids()
+if go#config#AutoTypeInfo() || go#config#AutoSameids()
   let &l:updatetime= get(g:, "go_updatetime", 800)
 endif
 

--- a/ftplugin/go/snippets.vim
+++ b/ftplugin/go/snippets.vim
@@ -47,7 +47,7 @@ function! s:GoMinisnip() abort
 endfunction
 
 
-let s:engine = get(g:, 'go_snippet_engine', 'automatic')
+let s:engine = go#config#SnippetEngine()
 if s:engine is? "automatic"
   if get(g:, 'did_plugin_ultisnips') is 1
     call s:GoUltiSnips()

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -11,7 +11,7 @@ let g:go_loaded_install = 1
 " Version 7.4.1689 was chosen because that's what the most recent Ubuntu LTS
 " release (16.04) uses.
 if
-      \ get(g:, 'go_version_warning', 1) != 0 &&
+      \ go#config#VersionWarning() != 0 &&
       \ (v:version < 704 || (v:version == 704 && !has('patch1689')))
       \ && !has('nvim')
   echohl Error

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -263,7 +263,7 @@ augroup vim-go
   autocmd BufWinEnter *.go call go#guru#ClearSameIds()
 
   autocmd BufEnter *.go
-        \  if get(g:, 'go_autodetect_gopath', 0) && !exists('b:old_gopath')
+        \  if go#config#AutodetectGopath() && !exists('b:old_gopath')
         \|   let b:old_gopath = exists('$GOPATH') ? $GOPATH : -1
         \|   let $GOPATH = go#path#Detect()
         \| endif


### PR DESCRIPTION
Consolidate (nearly) all the config values into `autoload/go/config.vim`. The value of doing this is:
* Defaults don't have to be repeated in multiple places(e.g. avoid proliferation of `get(g:, "go_build_tags", "")`)
* Makes it easier to change default values (related to ☝️ ).
* There's a consistent pattern of using getters and setters instead of trying to apply a heuristic to determine when a configuration value should be given a getter and setter and then trying to monitor to make sure that value is always accessed via the getter and setter.

All getter and setter functions are in a new file, `autoload/go/config.vim`. All of the getters are named by stripping off the `g:go_` prefix, and then applying the conventional rules for converting snake case to PascalCase. This simple transformation, if we continue to follow the pattern it establishes, will make it easy on contributors to always know what the getter for a particular configuration value is named. Setters are named similarly, but are prefixed with `Set`.

I considered putting the getter and setter functions closer to where they're often used, but trying to do so would leave some unanswerable questions about what the getters for some values should be named.

This also sets us up to start preferring buffer, window, and tab local values over global values so that users can have fine grained control of the workspaces within a single session of Vim.

I did each of these in individual commits to make reviewing easier. I can squash it after reviews are complete if that's desirable.