### PR TITLE
cache import path lookups results

### DIFF
--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -54,8 +54,14 @@ function! go#package#Paths() abort
   return dirs
 endfunction
 
+let s:import_paths = {}
 " ImportPath returns the import path in the current directory it was executed
 function! go#package#ImportPath() abort
+  let dir = expand("%:p:h")
+  if has_key(s:import_paths, dir)
+    return s:import_paths[dir]
+  endif
+
   let out = go#tool#ExecuteInDir("go list")
   if go#util#ShellError() != 0
     return -1
@@ -68,6 +74,8 @@ function! go#package#ImportPath() abort
   if import_path[0] ==# '_'
     return -1
   endif
+
+  let s:import_paths[dir] = import_path
 
   return import_path
 endfunction


### PR DESCRIPTION
Cache the results of import path lookups so that go list doesn't have to
be run every time linting is run or go#guru#Sameids() is run, because go
list can take a noticeably long time to return results and has to be
executed synchronously for all of its current use cases.

This further reduces the likelihood that characters will be rendered at
the cursor position when in normal mode.