### PR TITLE
Fix go build error parse

### DIFF
--- a/autoload/go/cmd_test.vim
+++ b/autoload/go/cmd_test.vim
@@ -6,7 +6,7 @@ func! Test_GoBuildErrors()
 
     " set the compiler type so that the errorformat option will be set
     " correctly.
-    compiler! go
+    compiler go
 
     let expected = [{'lnum': 4, 'bufnr': bufnr('%'), 'col': 2, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'undefined: notafunc'}]
     " clear the quickfix lists

--- a/autoload/go/cmd_test.vim
+++ b/autoload/go/cmd_test.vim
@@ -1,0 +1,30 @@
+func! Test_GoBuildErrors()
+  try
+    let l:filename = 'cmd/bad.go'
+    let l:tmp = gotest#load_fixture(l:filename)
+    exe 'cd ' . l:tmp . '/src/cmd'
+
+    " set the compiler type so that the errorformat option will be set
+    " correctly.
+    compiler! go
+
+    let expected = [{'lnum': 4, 'bufnr': bufnr('%'), 'col': 2, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'undefined: notafunc'}]
+    " clear the quickfix lists
+    call setqflist([], 'r')
+
+    call go#cmd#Build(1)
+
+    let actual = getqflist()
+    let start = reltime()
+    while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+      sleep 100m
+      let actual = getqflist()
+    endwhile
+
+    call gotest#assert_quickfix(actual, l:expected)
+  finally
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -62,6 +62,7 @@ function! s:spawn(bang, desc, for, args) abort
         \ 'status_dir' : status_dir,
         \ 'started_at' : started_at,
         \ 'for' : a:for,
+        \ 'errorformat': &errorformat,
         \ }
 
   " execute go build in the files directory
@@ -143,8 +144,9 @@ function! s:on_exit(job_id, exit_status, event) dict abort
     call go#util#EchoError("[" . self.status_type . "] FAILED")
   endif
 
-  let errors = go#tool#ParseErrors(std_combined)
-  let errors = go#tool#FilterValids(errors)
+  " parse the errors relative to self.jobdir
+  call go#list#ParseFormat(l:listtype, self.errorformat, std_combined, self.for)
+  let errors = go#list#Get(l:listtype)
 
   execute cd . fnameescape(dir)
 
@@ -156,7 +158,6 @@ function! s:on_exit(job_id, exit_status, event) dict abort
 
   " if we are still in the same windows show the list
   if self.winnr == winnr()
-    call go#list#Populate(l:listtype, errors, self.desc)
     call go#list#Window(l:listtype, len(errors))
     if !empty(errors) && !self.bang
       call go#list#JumpToFirst(l:listtype)

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -147,7 +147,7 @@ function! go#lint#Golint(...) abort
   endif
 
   let l:listtype = go#list#Type("GoLint")
-  call go#list#Parse(l:listtype, out)
+  call go#list#Parse(l:listtype, out, "GoLint")
   let errors = go#list#Get(l:listtype)
   call go#list#Window(l:listtype, len(errors))
   call go#list#JumpToFirst(l:listtype)
@@ -166,8 +166,9 @@ function! go#lint#Vet(bang, ...) abort
 
   let l:listtype = go#list#Type("GoVet")
   if go#util#ShellError() != 0
-    let errors = go#tool#ParseErrors(split(out, '\n'))
-    call go#list#Populate(l:listtype, errors, 'Vet')
+    let errorformat="%-Gexit status %\\d%\\+," . &errorformat
+    call go#list#ParseFormat(l:listtype, l:errorformat, out, "GoVet")
+    let errors = go#list#Get(l:listtype)
     call go#list#Window(l:listtype, len(errors))
     if !empty(errors) && !a:bang
       call go#list#JumpToFirst(l:listtype)

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -105,9 +105,10 @@ endfunc
 func! Test_Vet()
   let $GOPATH = fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint'
   silent exe 'e ' . $GOPATH . '/src/vet/vet.go'
+  compiler go
 
   let expected = [
-        \ {'lnum': 7, 'bufnr': bufnr('%'), 'col': 0, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'arg str for printf verb %d of wrong type: string'}
+        \ {'lnum': 7, 'bufnr': bufnr('%'), 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'arg str for printf verb %d of wrong type: string'}
       \ ]
 
   let winnr = winnr()

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -3,7 +3,7 @@ func! Test_Gometa() abort
   silent exe 'e ' . $GOPATH . '/src/lint/lint.go'
 
   let expected = [
-        \ {'lnum': 5, 'bufnr': 3, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingFooDoc should have comment or be unexported (golint)'}
+        \ {'lnum': 5, 'bufnr': bufnr('%')+1, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingFooDoc should have comment or be unexported (golint)'}
       \ ]
 
   " clear the quickfix lists
@@ -37,7 +37,7 @@ func! Test_GometaWithDisabled() abort
   silent exe 'e ' . $GOPATH . '/src/lint/lint.go'
 
   let expected = [
-        \ {'lnum': 5, 'bufnr': 3, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingFooDoc should have comment or be unexported (golint)'}
+        \ {'lnum': 5, 'bufnr': bufnr('%')+1, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingFooDoc should have comment or be unexported (golint)'}
       \ ]
 
   " clear the quickfix lists
@@ -71,7 +71,7 @@ func! Test_GometaAutoSave() abort
   silent exe 'e ' . $GOPATH . '/src/lint/lint.go'
 
   let expected = [
-        \ {'lnum': 5, 'bufnr': 2, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported (golint)'}
+        \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported (golint)'}
       \ ]
 
   let winnr = winnr()
@@ -100,6 +100,31 @@ func! Test_GometaAutoSave() abort
 
   call gotest#assert_quickfix(actual, expected)
   let g:go_metalinter_autosave_enabled = orig_go_metalinter_autosave_enabled
+endfunc
+
+func! Test_Vet()
+  let $GOPATH = fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint'
+  silent exe 'e ' . $GOPATH . '/src/vet/vet.go'
+
+  let expected = [
+        \ {'lnum': 7, 'bufnr': bufnr('%'), 'col': 0, 'valid': 1, 'vcol': 0, 'nr': 0, 'type': '', 'pattern': '', 'text': 'arg str for printf verb %d of wrong type: string'}
+      \ ]
+
+  let winnr = winnr()
+
+  " clear the location lists
+  call setqflist([], 'r')
+
+  call go#lint#Vet(1)
+
+  let actual = getqflist()
+  let start = reltime()
+  while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+    sleep 100m
+    let actual = getqflist()
+  endwhile
+
+  call gotest#assert_quickfix(actual, expected)
 endfunc
 
 " vim: sw=2 ts=2 et

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -79,13 +79,7 @@ function! go#list#ParseFormat(listtype, errformat, items, title) abort
   " parse and populate the location list
   let &errorformat = a:errformat
   try
-    if a:listtype == "locationlist"
-      lgetexpr a:items
-      if has("patch-7.4.2200") | call setloclist(0, [], 'a', {'title': a:title}) | endif
-    else
-      cgetexpr a:items
-      if has("patch-7.4.2200") | call setqflist([], 'a', {'title': a:title}) | endif
-    endif
+    call go#list#Parse(a:listtype, a:items, a:title)
   finally
     "restore back
     let &errorformat = old_errorformat
@@ -94,11 +88,13 @@ endfunction
 
 " Parse parses the given items based on the global errorformat and
 " populates the list.
-function! go#list#Parse(listtype, items) abort
+function! go#list#Parse(listtype, items, title) abort
   if a:listtype == "locationlist"
     lgetexpr a:items
+    if has("patch-7.4.2200") | call setloclist(0, [], 'a', {'title': a:title}) | endif
   else
     cgetexpr a:items
+    if has("patch-7.4.2200") | call setqflist([], 'a', {'title': a:title}) | endif
   endif
 endfunction
 

--- a/autoload/go/test-fixtures/cmd/bad.go
+++ b/autoload/go/test-fixtures/cmd/bad.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	notafunc()
+}

--- a/autoload/go/test-fixtures/lint/src/vet/vet.go
+++ b/autoload/go/test-fixtures/lint/src/vet/vet.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+func main() {
+	str := "hello world!"
+	fmt.Printf("%d\n", str)
+}


### PR DESCRIPTION
Errors from `:GoBuild` were including the column number in the quickfix error's `text` message instead of it parsing it into in the quick fix error's `col` field, because `errorformat` wasn't being using used parse the errors when `go build` was run asynchronously.

This PR uses `go#list#Parse` to parse the errors so that the result in vim8 and Neovim is the same as it is in vim7.4.

While I was at it, I added a test for `:GoVet` and modified it to also use `go#list#Parse`.