### PR TITLE
list: make Clean() more useful

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -148,7 +148,6 @@ function! go#fmt#update_file(source, target)
 
   if has_key(l:list_title, "title") && l:list_title['title'] == "Format"
     call go#list#Clean(l:listtype)
-    call go#list#Window(l:listtype)
   endif
 endfunction
 

--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -107,14 +107,12 @@ function go#job#Spawn(args)
     let l:listtype = go#list#Type(self.for)
     if a:exit_status == 0
       call go#list#Clean(l:listtype)
-      call go#list#Window(l:listtype)
       return
     endif
 
     let l:listtype = go#list#Type(self.for)
     if len(a:data) == 0
       call go#list#Clean(l:listtype)
-      call go#list#Window(l:listtype)
       return
     endif
 

--- a/autoload/go/jobcontrol.vim
+++ b/autoload/go/jobcontrol.vim
@@ -126,7 +126,6 @@ function! s:on_exit(job_id, exit_status, event) dict abort
   let l:listtype = go#list#Type(self.for)
   if a:exit_status == 0
     call go#list#Clean(l:listtype)
-    call go#list#Window(l:listtype)
 
     let self.state = "SUCCESS"
 

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -105,7 +105,6 @@ function! go#lint#Gometa(autosave, ...) abort
 
   if l:err == 0
     call go#list#Clean(l:listtype)
-    call go#list#Window(l:listtype)
     echon "vim-go: " | echohl Function | echon "[metalinter] PASS" | echohl None
   else
     " GoMetaLinter can output one of the two, so we look for both:
@@ -176,7 +175,6 @@ function! go#lint#Vet(bang, ...) abort
     echon "vim-go: " | echohl ErrorMsg | echon "[vet] FAIL" | echohl None
   else
     call go#list#Clean(l:listtype)
-    call go#list#Window(l:listtype)
     redraw | echon "vim-go: " | echohl Function | echon "[vet] PASS" | echohl None
   endif
 endfunction
@@ -229,7 +227,6 @@ function! go#lint#Errcheck(...) abort
     endif
   else
     call go#list#Clean(l:listtype)
-    call go#list#Window(l:listtype)
     echon "vim-go: " | echohl Function | echon "[errcheck] PASS" | echohl None
   endif
 

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -107,12 +107,21 @@ function! go#list#JumpToFirst(listtype) abort
   endif
 endfunction
 
-" Clean cleans the location list
+" Clean cleans and closes the location list 
 function! go#list#Clean(listtype) abort
   if a:listtype == "locationlist"
     lex []
   else
     cex []
+  endif
+
+  let autoclose_window = get(g:, 'go_list_autoclose', 1)
+  if autoclose_window
+    if a:listtype == "locationlist"
+      lclose
+    else
+      cclose
+    endif
   endif
 endfunction
 

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -18,14 +18,7 @@ function! go#list#Window(listtype, ...) abort
   " location list increases/decreases, cwindow will not resize when a new
   " updated height is passed. lopen in the other hand resizes the screen.
   if !a:0 || a:1 == 0
-    let autoclose_window = get(g:, 'go_list_autoclose', 1)
-    if autoclose_window
-      if a:listtype == "locationlist"
-        lclose
-      else
-        cclose
-      endif
-    endif
+    call go#list#Close(a:listtype)
     return
   endif
 
@@ -115,13 +108,20 @@ function! go#list#Clean(listtype) abort
     cex []
   endif
 
+  call go#list#Close(a:listtype)
+endfunction
+
+" Close closes the location list
+function! go#list#Close(listtype) abort
   let autoclose_window = get(g:, 'go_list_autoclose', 1)
-  if autoclose_window
-    if a:listtype == "locationlist"
-      lclose
-    else
-      cclose
-    endif
+  if !autoclose_window
+    return
+  endif
+
+  if a:listtype == "locationlist"
+    lclose
+  else
+    cclose
   endif
 endfunction
 

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -160,7 +160,6 @@ function s:parse_errors(exit_val, bang, out)
   " strip out newline on the end that gorename puts. If we don't remove, it
   " will trigger the 'Hit ENTER to continue' prompt
   call go#list#Clean(l:listtype)
-  call go#list#Window(l:listtype)
   call go#util#EchoSuccess(a:out[0])
 
   " refresh the buffer so we can see the new content

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -123,7 +123,6 @@ function s:cleanlist(winnr, listtype) abort
   let l:winnr = winnr()
   execute a:winnr . "wincmd w"
   call go#list#Clean(a:listtype)
-  call go#list#Window(a:listtype)
   execute l:winnr . "wincmd w"
 endfunction
 

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -94,7 +94,6 @@ function! go#test#Test(bang, compile, ...) abort
     call go#util#EchoError("[test] FAIL")
   else
     call go#list#Clean(l:listtype)
-    call go#list#Window(l:listtype)
 
     if a:compile
       call go#util#EchoSuccess("[test] SUCCESS")
@@ -246,7 +245,6 @@ function! s:show_errors(args, exit_val, messages) abort
     let l:listtype = go#list#Type("GoTest")
     if a:exit_val == 0
       call go#list#Clean(l:listtype)
-      call go#list#Window(l:listtype)
       return
     endif
 


### PR DESCRIPTION
After cleaning a list, there is no need to show the list anymore. That's
why we call `Window()` to invoke the close function. Remove all
`Window()` calls and make Clean() more useful to avoid adding the second
line. There is no single `Clean()` call independently, so it makes sense
to change the meaning