### PR TITLE
Fix term enabled behavior

### DIFF
--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -19,8 +19,7 @@ function! go#term#newmode(bang, cmd, mode) abort
         \ 'cmd': a:cmd,
         \ 'bang' : a:bang,
         \ 'winnr': winnr(),
-        \ 'stdout': [],
-        \ 'stderr': []
+        \ 'stdout': []
       \ }
 
   " execute go build in the files directory
@@ -39,11 +38,13 @@ function! go#term#newmode(bang, cmd, mode) abort
 
   " explicitly bind callbacks to state so that within them, self will always
   " refer to state. See :help Partial for more information.
+  "
+  " Don't set an on_stderr, because it will be passed the same data as
+  " on_stdout. See https://github.com/neovim/neovim/issues/2836
   let job = {
         \ 'on_stdout': function('s:on_stdout', [], state),
-        \ 'on_stderr': function('s:on_stderr', [], state),
         \ 'on_exit' : function('s:on_exit', [], state),
-        \ }
+      \ }
 
   let state.id = termopen(a:cmd, job)
   let state.termwinnr = winnr()
@@ -78,10 +79,6 @@ endfunction
 
 function! s:on_stdout(job_id, data, event) dict abort
   call extend(self.stdout, a:data)
-endfunction
-
-function! s:on_stderr(job_id, data, event) dict abort
-    call extend(self.stderr, a:data)
 endfunction
 
 function! s:on_exit(job_id, exit_status, event) dict abort

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -51,8 +51,6 @@ function! go#term#newmode(bang, cmd, mode) abort
 
   execute cd . fnameescape(dir)
 
-  startinsert
-
   " resize new term if needed.
   let height = get(g:, 'go_term_height', winheight(0))
   let width = get(g:, 'go_term_width', winwidth(0))
@@ -67,8 +65,6 @@ function! go#term#newmode(bang, cmd, mode) abort
 
   " we also need to resize the pty, so there you go...
   call jobresize(state.id, width, height)
-
-  stopinsert
 
   if state.winnr !=# winnr()
     exe state.winnr . "wincmd w"

--- a/autoload/go/term_test.vim
+++ b/autoload/go/term_test.vim
@@ -1,0 +1,50 @@
+func! Test_GoTermNewMode()
+  if !has('nvim')
+    return
+  endif
+
+  try
+    let l:filename = 'term/term.go'
+    let l:tmp = gotest#load_fixture(l:filename)
+    exe 'cd ' . l:tmp . '/src/term'
+
+    let expected = expand('%:p')
+
+    let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
+
+    set nosplitright
+    call go#term#newmode(0, cmd, '')
+    let actual = expand('%:p')
+    call assert_equal(actual, l:expected)
+
+  finally
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
+func! Test_GoTermNewMode_SplitRight()
+  if !has('nvim')
+    return
+  endif
+
+  try
+    let l:filename = 'term/term.go'
+    let l:tmp = gotest#load_fixture(l:filename)
+    exe 'cd ' . l:tmp . '/src/term'
+
+    let expected = expand('%:p')
+
+    let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
+
+    set splitright
+    call go#term#newmode(0, cmd, '')
+    let actual = expand('%:p')
+    call assert_equal(actual, l:expected)
+
+  finally
+    call delete(l:tmp, 'rf')
+    set nosplitright
+  endtry
+endfunc
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/test-fixtures/term/term.go
+++ b/autoload/go/test-fixtures/term/term.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	println("hello, world")
+}


### PR DESCRIPTION
* Make sure that behavior is consistent when `g:go_term_enabled=1` regardless of the value of the `splitright` option.

* Remove the startinsert and stopinsert pair; they cancel each other out
and are unnecessary.

* remove superfluous stderr callback.
