### PR TITLE
Add :GoDebugTest

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -516,6 +516,11 @@ function! go#debug#Start(...) abort
 
   let l:is_test = bufname('')[-8:] is# '_test.go'
 
+  " cd in to test directory; this is also what running "go test" does.
+  if l:is_test
+    lcd %:p:h
+  endif
+
   let dlv = go#path#CheckBinPath("dlv")
   if empty(dlv)
     return

--- a/autoload/go/textobj.vim
+++ b/autoload/go/textobj.vim
@@ -17,6 +17,7 @@ endif
 " < >
 " t for tag
 
+" Select a function in visual mode.
 function! go#textobj#Function(mode) abort
   let offset = go#util#OffsetCursor()
 
@@ -98,23 +99,8 @@ function! go#textobj#Function(mode) abort
   call cursor(info.rbrace.line-1, 1)
 endfunction
 
-function! go#textobj#FunctionJump(mode, direction) abort
-  " get count of the motion. This should be done before all the normal
-  " expressions below as those reset this value(because they have zero
-  " count!). We abstract -1 because the index starts from 0 in motion.
-  let l:cnt = v:count1 - 1
-
-  " set context mark so we can jump back with  '' or ``
-  normal! m'
-
-  " select already previously selected visual content and continue from there.
-  " If it's the first time starts with the visual mode. This is needed so
-  " after selecting something in visual mode, every consecutive motion
-  " continues.
-  if a:mode == 'v'
-    normal! gv
-  endif
-
+" Get the location of the previous or next function.
+function! go#textobj#FunctionLocation(direction, cnt) abort
   let offset = go#util#OffsetCursor()
 
   let fname = shellescape(expand("%:p"))
@@ -131,7 +117,7 @@ function! go#textobj#FunctionJump(mode, direction) abort
   endif
 
   let command = printf("%s -format vim -file %s -offset %s", bin_path, fname, offset)
-  let command .= ' -shift ' . l:cnt
+  let command .= ' -shift ' . a:cnt
 
   if a:direction == 'next'
     let command .= ' -mode next'
@@ -149,14 +135,40 @@ function! go#textobj#FunctionJump(mode, direction) abort
     return
   endif
 
+  echom l:out
+
   " if exists, delete it as we don't need it anymore
   if exists("l:tmpname")
     call delete(l:tmpname)
   endif
 
-  " convert our string dict representation into native Vim dictionary type
-  let result = eval(out)
-  if type(result) != 4 || !has_key(result, 'fn')
+  let l:result = json_decode(out)
+  if type(l:result) != 4 || !has_key(l:result, 'fn')
+    return
+  endif
+
+  return l:result
+endfunction
+
+function! go#textobj#FunctionJump(mode, direction) abort
+  " get count of the motion. This should be done before all the normal
+  " expressions below as those reset this value(because they have zero
+  " count!). We abstract -1 because the index starts from 0 in motion.
+  let l:cnt = v:count1 - 1
+
+  " set context mark so we can jump back with  '' or ``
+  normal! m'
+
+  " select already previously selected visual content and continue from there.
+  " If it's the first time starts with the visual mode. This is needed so
+  " after selecting something in visual mode, every consecutive motion
+  " continues.
+  if a:mode == 'v'
+    normal! gv
+  endif
+
+  let l:result = go#textobj#FunctionLocation(a:direction, l:cnt)
+  if !l:result
     return
   endif
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1855,9 +1855,9 @@ newer, as its new caching will speed up recompiles.
                                                               *go-debug-intro*
 GETTING STARTED WITH THE DEBUGGER~
 
-Use |:GoDebugStart| to start the debugger. The first argument is the package
-name, and any arguments after that will be passed on to the program; for
-example:
+Use |:GoDebugStart| or |:GoDebugTest| to start the debugger. The first
+argument is the package name, and any arguments after that will be passed on
+to the program; for example:
 >
     :GoDebugStart . -someflag value
 <
@@ -1896,18 +1896,23 @@ rest of the commands and mappings become available after starting debug mode.
 
     Start the debug mode for [pkg]; this does several things:
 
-      * Start `dlv debug` for [pkg], or `dlv test` if the current buffer's
-        filename ends with `_test.go`.
       * Setup the debug windows according to |'g:go_debug_windows'|.
       * Make the `:GoDebug*` commands and `(go-debug-*)` mappings available.
 
-  The current directory is used if [pkg] is empty. Any other arguments will
-  be passed to the program.
+    The current directory is used if [pkg] is empty. Any other arguments will
+    be passed to the program.
 
-  Use `-test.flag` to pass flags to `go test` when debugging a test; for
-  example `-test.v` or `-test.run TestFoo`
+    Use |:GoDebugStop| to stop `dlv` and exit debugging mode.
 
-  Use |:GoDebugStop| to stop `dlv` and exit debugging mode.
+                                                                *:GoDebugTest*
+:GoDebugTest [pkg] [program-args]
+
+    Behaves the same as |:GoDebugStart| but runs `dlv test` instead of
+    `dlv debug` so you can debug tests.
+
+    Use `-test.flag` to pass flags to `go test` when debugging a test; for
+    example `-test.v` or `-test.run TestFoo`
+
 
                                                              *:GoDebugRestart*
 :GoDebugRestart

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -100,7 +100,8 @@ command! -nargs=0 GoFillStruct call go#fillstruct#FillStruct()
 
 " -- debug
 if !exists(':GoDebugStart')
-  command! -nargs=* -complete=customlist,go#package#Complete GoDebugStart call go#debug#Start(<f-args>)
+  command! -nargs=* -complete=customlist,go#package#Complete GoDebugStart call go#debug#Start(0, <f-args>)
+  command! -nargs=* -complete=customlist,go#package#Complete GoDebugTest  call go#debug#Start(1, <f-args>)
   command! -nargs=? GoDebugBreakpoint call go#debug#Breakpoint(<f-args>)
 endif
 


### PR DESCRIPTION
This fixes the two issues reported in #1690.

The first issue is fixed by cd-ing in to directory before debugging
test files. This is also what `go test` does ad seems to work well
in my testing.

---

The second issue is fixed by adding `:GoDebugTest`:

Imagine I'm editing `a_test.go`, which is failing. To investigate I want
to add a breakpoint in a function in `a.go`. The current procedure for
that is something like:

- `:e a.go`
- `:GoDebugBreakpoint`
- `:e a_test.go`
- `:GoDebugStart`
- `<F5>`
- Buffer will switch back to `a.go`

The `:e_test.go` is needed because the only way to run `dlv test`
instead of `dlv debug` is to have the current buffer end in `_test.go`.

I think this is rather awkward, so add `:GoDebugTest` instead of trying
to guess what the users wants so you now can do:

- `:e a.go`
- `:GoDebugBreakpoint`
- `:GoDebugTest`
- `<F5>`

