### PR TITLE
use window id instead of number in all async jobs

### DIFF
--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -33,7 +33,7 @@
 function go#job#Spawn(args)
   let cbs = {}
   let state = {
-        \ 'winnr': winnr(),
+        \ 'winid': win_getid(winnr()),
         \ 'dir': getcwd(),
         \ 'jobdir': fnameescape(expand("%:p:h")),
         \ 'messages': [],
@@ -104,15 +104,20 @@ function go#job#Spawn(args)
   let cbs.close_cb = function('s:close_cb', [], state)
 
   function state.show_errors(job, exit_status, data)
+    let l:winid = win_getid(winnr())
+    call win_gotoid(self.winid)
+
     let l:listtype = go#list#Type(self.for)
     if a:exit_status == 0
       call go#list#Clean(l:listtype)
+      call win_gotoid(l:winid)
       return
     endif
 
     let l:listtype = go#list#Type(self.for)
     if len(a:data) == 0
       call go#list#Clean(l:listtype)
+      call win_gotoid(l:winid)
       return
     endif
 
@@ -132,10 +137,11 @@ function go#job#Spawn(args)
     if empty(errors)
       " failed to parse errors, output the original content
       call go#util#EchoError(self.messages + [self.dir])
+      call win_gotoid(l:winid)
       return
     endif
 
-    if self.winnr == winnr()
+    if self.winid == l:winid
       call go#list#Window(l:listtype, len(errors))
       if !self.bang
         call go#list#JumpToFirst(l:listtype)

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -251,7 +251,7 @@ function! s:lint_job(args, autosave)
         \ 'exited': 0,
         \ 'closed': 0,
         \ 'exit_status': 0,
-        \ 'winnr': winnr(),
+        \ 'winid': win_getid(winnr()),
         \ 'autosave': a:autosave
       \ }
 
@@ -308,15 +308,14 @@ function! s:lint_job(args, autosave)
     endif
   endfunction
 
-
   function state.show_errors()
-    let l:winnr = winnr()
+    let l:winid = win_getid(winnr())
 
     " make sure the current window is the window from which gometalinter was
     " run when the listtype is locationlist so that the location list for the
     " correct window will be populated.
     if self.listtype == 'locationlist'
-      exe self.winnr . "wincmd w"
+      call win_gotoid(self.winid)
     endif
 
     let l:errorformat = '%f:%l:%c:%t%*[^:]:\ %m,%f:%l::%t%*[^:]:\ %m'
@@ -331,7 +330,7 @@ function! s:lint_job(args, autosave)
     " start of this function avoids the perception that the quickfix window
     " steals focus when linting takes a while.
     if self.autosave
-      exe l:winnr . "wincmd w"
+      call win_gotoid(self.winid)
     endif
 
     if get(g:, 'go_echo_command_info', 1)


### PR DESCRIPTION
Use window ids instead of window numbers to select windows in all async
job callbacks so that the correct window is selected even when the user
modifies the window layout between when the job is started and when the
callback is executed.