### PR TITLE
redraw before showing progress message only

### DIFF
--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -45,7 +45,7 @@ function! go#coverage#Buffer(bang, ...) abort
   let l:tmpname = tempname()
 
   if get(g:, 'go_echo_command_info', 1)
-    echon "vim-go: " | echohl Identifier | echon "testing ..." | echohl None
+    call go#util#EchoProgress("testing...")
   endif
 
   if go#util#has_job()

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -313,7 +313,6 @@ function! s:echo(msg, hi)
   " Tabs display as ^I or <09>, so manually expand them.
   let l:msg = map(l:msg, 'substitute(v:val, "\t", "        ", "")')
 
-  redraw
   exe 'echohl ' . a:hi
   for line in l:msg
     echom "vim-go: " . line
@@ -331,6 +330,7 @@ function! go#util#EchoWarning(msg)
   call s:echo(a:msg, 'WarningMsg')
 endfunction
 function! go#util#EchoProgress(msg)
+  redraw
   call s:echo(a:msg, 'Identifier')
 endfunction
 function! go#util#EchoInfo(msg)


### PR DESCRIPTION
Do not redraw before showing all messages; only progress messages will
cause a redraw.

Convert the progress message in `go#coverage#Buffer` to a call to
`go#util#EchoProgress`.