### PR TITLE
Add :GoIssue to open bug reports on GitHub for vim-go

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,14 +9,13 @@
 
 ### Configuration (**MUST** fill this out):
 
-* Vim version (first two lines from `:version`):
-
-* Go version (`go version`):
-
-* Go environment (`go env`):
-
 * vim-go version:
 
 * `vimrc` you used to reproduce (use a *minimal* vimrc with other plugins disabled; do not link to a 2,000 line vimrc):
 
+* Vim version (first three lines from `:version`):
+
+* Go version (`go version`):
+
+* Go environment (`go env`):
 

--- a/autoload/go/issue.vim
+++ b/autoload/go/issue.vim
@@ -1,0 +1,34 @@
+let s:templatepath = go#util#Join(expand('<sfile>:p:h:h:h'), '.github', 'ISSUE_TEMPLATE.md')
+
+function! go#issue#New() abort
+  let body = substitute(s:issuebody(), '[^A-Za-z0-9_.~-]', '\="%".printf("%02X",char2nr(submatch(0)))', 'g')
+  let url = "https://github.com/fatih/vim-go/issues/new?body=" . l:body
+  call go#tool#OpenBrowser(l:url)
+endfunction
+
+function! s:issuebody() abort
+  let lines = readfile(s:templatepath)
+
+  let rtrimpat = '[[:space:]]\+$'
+  let body = []
+  for l in lines
+    let body = add(body, l)
+
+    if l =~ '^\* Vim version'
+      redir => out
+        silent version
+      redir END
+      let body = extend(body, split(out, "\n")[0:2])
+    elseif l =~ '^\* Go version'
+      let [out, err] = go#util#Exec(['go', 'version'])
+      let body = add(body, substitute(l:out, rtrimpat, '', ''))
+    elseif l =~ '^\* Go environment'
+      let [out, err] = go#util#Exec(['go', 'env'])
+      let body = add(body, substitute(l:out, rtrimpat, '', ''))
+    endif
+  endfor
+
+  return join(body, "\n")
+endfunction
+
+" vim: sw=2 ts=2 et

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -157,6 +157,11 @@ The following plugins are supported for use with vim-go:
 ==============================================================================
 COMMANDS                                                         *go-commands*
 
+                                                        *:GoReportGitHubIssue*
+:GoReportGitHubIssue
+    GoReportGitHubIssue opens the default browser and starts a new bug report
+    with useful system information.
+
                                                                      *:GoPath*
 :GoPath [path]
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -106,4 +106,7 @@ if !exists(':GoDebugStart')
   command! -nargs=? GoDebugBreakpoint call go#debug#Breakpoint(<f-args>)
 endif
 
+" -- issue
+command! -nargs=0 GoReportGitHubIssue call go#issue#New()
+
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
Add a new command, `:GoIssue`, to make it easier for users to open bug reports with most system information filled in.

I'm not completely happy with the name of the command and am open to other suggestions. I thought about using `:GoBug`, but that may lead people to believe that it's `go bug`. `:VimGoBug` also doesn't seem right, because none of the other commands start with `VimGo` :thinking:.