### PR TITLE
Show debug errors as errors and not progress

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -474,9 +474,16 @@ function! s:start_cb(ch, json) abort
   exe bufwinnr(oldbuf) 'wincmd w'
 endfunction
 
-function! s:starting(ch, msg) abort
+function! s:err_cb(ch, msg) abort
+  call go#util#EchoError(a:msg)
+  let s:state['message'] += [a:msg]
+endfunction
+
+function! s:out_cb(ch, msg) abort
   call go#util#EchoProgress(a:msg)
   let s:state['message'] += [a:msg]
+
+  " TODO: why do this in this callback?
   if stridx(a:msg, g:go_debug_address) != -1
     call ch_setoptions(a:ch, {
       \ 'out_cb': function('s:logger', ['OUT: ']),
@@ -563,8 +570,8 @@ function! go#debug#Start(is_test, ...) abort
     call go#util#EchoProgress('Starting GoDebug...')
     let s:state['message'] = []
     let s:state['job'] = job_start(l:cmd, {
-      \ 'out_cb': function('s:starting'),
-      \ 'err_cb': function('s:starting'),
+      \ 'out_cb': function('s:out_cb'),
+      \ 'err_cb': function('s:err_cb'),
       \ 'exit_cb': function('s:exit'),
       \ 'stoponexit': 'kill',
     \})


### PR DESCRIPTION
Show stderr as error, not progress.

It *still* only shows the last time, but that's the nature of outputting
stuff in a job callback: you don't get the "hit ENTER" prompt (which in
this case is *wanted*). I don't know if there is any way to fix that
(it's a problem we have in several commands)?

We can probably populate the quickfix like we do with `:GoInstall` and
such, but that's a PR for another day.

See #1742