### PR TITLE
Allow configurable `go_templates_dir`

### DIFF
--- a/autoload/go/template.vim
+++ b/autoload/go/template.vim
@@ -23,7 +23,8 @@ function! go#template#create() abort
     else
       let l:template_file = get(g:, 'go_template_file', "hello_world.go")
     endif
-    let l:template_path = go#util#Join(l:root_dir, "templates", l:template_file)
+    let l:template_dir = get(g:, 'go_template_dir', go#util#Join(l:root_dir, "templates"))
+    let l:template_path = go#util#Join(l:template_dir, l:template_file)
     silent exe 'keepalt 0r ' . fnameescape(l:template_path)
   elseif l:package_name == -1 && l:go_template_use_pkg == 1
     " cwd is now the dir of the package

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1557,7 +1557,7 @@ Specifies whether `gocode` should use a different socket type. By default
 
 When a new Go file is created, vim-go automatically fills the buffer content
 with a Go code template. By default, the templates under the `templates`
-folder are used.  This can be changed with the |'g:go_template_dir'|, 
+directory are used.  This can be changed with the |'g:go_template_dir'|, 
 |'g:go_template_file'| and |'g:go_template_test_file'| settings.
 
 If the new file is created in an already prepopulated package (with other Go

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1557,8 +1557,8 @@ Specifies whether `gocode` should use a different socket type. By default
 
 When a new Go file is created, vim-go automatically fills the buffer content
 with a Go code template. By default, the templates under the `templates`
-folder are used.  This can be changed with the |'g:go_template_file'| and
-|'g:go_template_test_file'| settings.
+folder are used.  This can be changed with the |'g:go_template_dir'|, 
+|'g:go_template_file'| and |'g:go_template_test_file'| settings.
 
 If the new file is created in an already prepopulated package (with other Go
 files), in this case a Go code template with only the Go package declaration
@@ -1571,9 +1571,17 @@ By default it is enabled.
 >
   let g:go_template_autocreate = 1
 <
+                                                        *'g:go_template_dir'*
+
+Specifies the parent directory in which template files are stored.
+Checkout |'g:go_template_autocreate'| for more info. By default
+the `templates` folder included with vim-go is used.
+>
+  let g:go_template_dir = $HOME."/src/vim-templates"
+<
                                                         *'g:go_template_file'*
 
-Specifies the file under the `templates` folder that is used if a new Go file
+Specifies the file within the |'g:go_template_dir'| that is used if a new Go file
 is created. Checkout |'g:go_template_autocreate'| for more info. By default
 the `hello_world.go` file is used.
 >
@@ -1581,7 +1589,7 @@ the `hello_world.go` file is used.
 <
                                                    *'g:go_template_test_file'*
 
-Specifies the file under the `templates` folder that is used if a new Go test
+Specifies the file within the |'g:go_template_dir'| that is used if a new Go test
 file is created. Checkout |'g:go_template_autocreate'| for more info. By
 default the `hello_world_test.go` file is used.
 >


### PR DESCRIPTION
Defaults to the normal path within the plugin, but allows any other path to be set as the template directory.