### PR TITLE
Use Go 1.10 in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: go
+go:
+  - 1.10.x
 notifications:
   email: false
 matrix:

--- a/autoload/go/guru_test.vim
+++ b/autoload/go/guru_test.vim
@@ -1,10 +1,10 @@
 function Test_GuruScope_Set() abort
-  call go#guru#Scope("example.com/foo/bar")
+  silent call go#guru#Scope("example.com/foo/bar")
   let actual = go#config#GuruScope()
   call assert_equal(["example.com/foo/bar"], actual)
 
-  call go#guru#Scope('""')
-  let actual = go#config#GuruScope()
+  silent call go#guru#Scope('""')
+  silent let actual = go#config#GuruScope()
   call assert_equal([], actual, "setting scope to empty string should clear")
 
   if exists('g:go_guru_scope')

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -12,9 +12,9 @@ func! Test_Gometa() abort
   " call go#lint#ToggleMetaLinterAutoSave from lint.vim so that the file will
   " be autoloaded and the default for g:go_metalinter_enabled will be set so
   " we can capture it to restore it after the test is run.
-  call go#lint#ToggleMetaLinterAutoSave()
+  silent call go#lint#ToggleMetaLinterAutoSave()
   " And restore it back to its previous value
-  call go#lint#ToggleMetaLinterAutoSave()
+  silent call go#lint#ToggleMetaLinterAutoSave()
 
   let g:go_metalinter_enabled = ['golint']
 
@@ -45,9 +45,9 @@ func! Test_GometaWithDisabled() abort
   " call go#lint#ToggleMetaLinterAutoSave from lint.vim so that the file will
   " be autoloaded and the default for g:go_metalinter_disabled will be set so
   " we can capture it to restore it after the test is run.
-  call go#lint#ToggleMetaLinterAutoSave()
+  silent call go#lint#ToggleMetaLinterAutoSave()
   " And restore it back to its previous value
-  call go#lint#ToggleMetaLinterAutoSave()
+  silent call go#lint#ToggleMetaLinterAutoSave()
 
   let g:go_metalinter_disabled = ['vet']
 
@@ -80,9 +80,9 @@ func! Test_GometaAutoSave() abort
   " call go#lint#ToggleMetaLinterAutoSave from lint.vim so that the file will
   " be autoloaded and the default for g:go_metalinter_autosave_enabled will be
   " set so we can capture it to restore it after the test is run.
-  call go#lint#ToggleMetaLinterAutoSave()
+  silent call go#lint#ToggleMetaLinterAutoSave()
   " And restore it back to its previous value
-  call go#lint#ToggleMetaLinterAutoSave()
+  silent call go#lint#ToggleMetaLinterAutoSave()
 
   let g:go_metalinter_autosave_enabled = ['golint']
 
@@ -105,7 +105,8 @@ func! Test_Vet()
   compiler go
 
   let expected = [
-        \ {'lnum': 7, 'bufnr': bufnr('%'), 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'arg str for printf verb %d of wrong type: string'}
+        \ {'lnum': 7, 'bufnr': bufnr('%'), 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '',
+        \ 'text': 'Printf format %d has arg str of wrong type string'}
       \ ]
 
   let winnr = winnr()

--- a/autoload/go/test_test.vim
+++ b/autoload/go/test_test.vim
@@ -94,7 +94,7 @@ func! s:test(file, expected, ...) abort
   endif
 
   " run the tests
-  call call(function('go#test#Test'), args)
+  silent call call(function('go#test#Test'), args)
 
   let actual = getqflist()
   let start = reltime()

--- a/scripts/runtest.vim
+++ b/scripts/runtest.vim
@@ -14,6 +14,7 @@ let s:gopath = $GOPATH
 if !exists('g:test_verbose')
   let g:test_verbose = 0
 endif
+let g:go_echo_command_info = 0
 
 " Source the passed test file.
 source %


### PR DESCRIPTION
Also set `let g:go_echo_command_info = 0` and add some `silent`s to make
normal (non-failing) test output less noisy.