### PR TITLE
add tabstop on err

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -169,7 +169,7 @@ endsnippet
 # error multiple return
 snippet errn, "Error return with two return values" !b
 if err != nil {
-	return ${1:nil}, err
+	return ${1:nil}, ${2:err}
 }
 ${0}
 endsnippet


### PR DESCRIPTION
Suggestion for a more robust errn, snippet. This arose by the need to format the error message at times. For example

if err != nil {
  return nil, fmt.Errorf("some context: %s", err)
}

The snippet will allow you to tabstop to the err keyword for replacement. 