### PR TITLE
snippets per Go spec

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -264,7 +264,7 @@ case ${1:x}:
 	${2:action}
 endsnippet
 
-snippet default "default entry"
+snippet cde "case default entry" m
 default:
 	${1:action}
 endsnippet
@@ -306,8 +306,8 @@ endsnippet
 ## Select statements
 snippet select "select statement"
 select {
-case ${1:x} ${2::=} ${3:<-c}:
-	${4:action}
+case ${1:x} ${2::=} ${3:<-}${4:c}:
+	${5:action}
 }
 ${0}
 endsnippet

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -43,6 +43,7 @@ snippet st "struct type"
 struct {
 	${1:field} ${2:type}
 }
+${0}
 endsnippet
 
 snippet ste "struct entry"
@@ -122,6 +123,7 @@ snippet func "function declaration"
 func ${1:name}(${2:args}) ${3:returned} {
 	${4:action}
 }
+${0}
 endsnippet
 
 ## Method Declarations
@@ -129,6 +131,7 @@ snippet meth "method declaration"
 func (${1:reciever}) ${2:name} ${3:returned} {
 	${5:action}
 }
+${0}
 endsnippet
 
 # Expressions
@@ -147,6 +150,7 @@ snippet funcl "composite literal function (anonymous function)"
 func(${1:args}) ${2:returned} {
 	${4:action}
 }
+${0}
 endsnippet 
 
 ## simple slice expression
@@ -305,6 +309,7 @@ select {
 case ${1:x} ${2:=} ${3:<-c}:
 	${4:action}
 }
+${0}
 endsnippet
 
 snippet scase "select case entry"

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -306,7 +306,7 @@ endsnippet
 ## Select statements
 snippet select "select statement"
 select {
-case ${1:x} ${2:=} ${3:<-c}:
+case ${1:x} ${2::=} ${3:<-c}:
 	${4:action}
 }
 ${0}

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -1,463 +1,425 @@
 # Snippets for Go
 
+# Organized to reflect the sectioning of the Go spec found here: https://golang.org/ref/spec
+
 priority -10
 
-# shorthand variable declaration
-snippet : "v := value"
-${1} := ${0}
+# Types
+snippet type "aggregate type definition"
+type (
+	${1:A} ${2:type}
+)
 endsnippet
 
-# anonymous function
-snippet anon "fn := func() { ... }"
-${1:fn} := func() {
-	${2:${VISUAL}}
+## Boolean types
+snippet t "true"
+true
+endsnippet
+
+snippet f "false"
+false
+endsnippet
+
+## Array types
+snippet a "array type"
+[${1:}]${2:type}
+endsnippet
+
+snippet al "array literal"
+[${1:}]${2:type}{${3:values}}
+endsnippet
+
+## Slice types
+snippet s "slice type"
+[]${1:type}
+endsnippet
+
+snippet sl "slice literal"
+[]${1:type}{${2:values}}
+endsnippet
+
+## Struct types
+snippet st "struct type" 
+struct {
+	${1:field} ${2:type}
+}
+endsnippet
+
+snippet ste "struct entry"
+${1:field} ${2:type}
+endsnippet
+
+## Function types
+snippet fn "function type"
+func(${1:arguments}) ${2:returned}
+endsnippet
+
+## Interface types
+
+## Map types
+snippet map "map type"
+map[${1:type}]${2:type}
+endsnippet
+
+## Channel types
+snippet chan "channel type"
+chan ${1:type}
+endsnippet
+
+snippet rchan "recieve only channel"
+<-chan ${1:type}
+endsnippet
+
+snippet schan "send only channel"
+chan<- ${1:type}
+endsnippet
+
+# Declarations and scope
+
+## Constant declarations
+snippet cnst "constant declaration"
+const (
+	${1:name} ${2:type} = ${3:value}
+)
+endsnippet
+
+snippet cnste "constant declaration entry"
+${1:name} ${2:type} = ${3:value}
+endsnippet
+
+#TODO: Iota
+
+## Type declarations
+snippet typea "type alias declaration"
+type (
+	${1:alias} = ${2:type}
+)
+${0}
+endsnippet
+
+snippet typeae "type alias entry"
+${1:alias} = ${2:type}
+endsnippet
+
+snippet typed "type definition declaration"
+type (
+	${1:identifier} ${2:type}
+)
+${0}
+endsnippet
+
+snippet typede "type definition entry"
+${1:identifier} ${2:type}
+endsnippet 
+
+## Variable declarations
+snippet : "short variable definition"
+${1:x} := ${2:y}
+endsnippet
+
+## Function declarations
+snippet func "function declaration"
+func ${1:name}(${2:args}) ${3:returned} {
+	${4:action}
+}
+endsnippet
+
+## Method Declarations
+snippet meth "method declaration"
+func (${1:reciever}) ${2:name} ${3:returned} {
+	${5:action}
+}
+endsnippet
+
+# Expressions
+
+## composite literals
+snippet cmpl "composite literal expression"
+${1:x} := ${2:type}{${3}}
+endsnippet
+
+snippet cmplp "composite literal pointer expression"
+${1:x} := &${2:type}{${3}}
+endsnippet 
+
+## function litearls
+snippet funcl "composite literal function (anonymous function)"
+func(${1:args}) ${2:returned} {
+	${4:action}
+}
+endsnippet 
+
+## simple slice expression
+snippet ss "simple slice expression"
+${1:x}[${2:low} : ${3:high}]
+endsnippet
+
+## full slice expression
+snippet fs "full slice expression"
+${1:x}[${2:low} : ${3:high} : ${4:max}]
+endsnippet
+
+## type assertion
+snippet ta "type assertion"
+${1:x}, ok := ${2:y}.(${3:type})
+endsnippet
+
+# Statements
+## Terminating statements
+snippet p "panic"
+panic(${1:x})
+endsnippet
+
+## Send Statements
+snippet send "send value onto channel"
+${1:ch} <- ${2:${VISUAL}}
+endsnippet
+
+## IncDec statements
+snippet inc "increment variable"
+${1:${VISUAL:x}} += ${2:1}
+endsnippet
+
+snippet dec "increment variable"
+${1:${VISUAL:x}} -= ${2:1}
+endsnippet
+
+## Assignment Statements
+snippet = "sets variable equal to operand"
+${1} = ${2}
+endsnippet
+
+snippet =t "tuple assignment"
+${1:x}, ${2:y} = ${3:${VISUAL}}
+endsnippet
+
+snippet =b "set blank"
+_ = ${1:${VISUAL}}
+endsnippet
+
+snippet =bte "blank error in tuple return"
+${1:x}, _ = ${2:${VISUAL}}
+endsnippet
+
+snippet =x "swap variables"
+${1:a}, ${2:b} = $2, $1
+endsnippet
+
+## If Statements
+snippet if "if statement"
+if ${1:x} ${2:=} ${3:y} {
+	${4:action}
 }
 ${0}
 endsnippet
 
-# append
-snippet ap "append(slice, value)"
-append(${1:slice}, ${0:value})
+snippet ife "if statement with expression"
+if ${1:x} := ${2:f()}; $1 ${3: > y} {
+	${4:action}
+}
+${0}
 endsnippet
 
-# append assignment
-snippet ap= "a = append(a, value)"
-${1:slice} = append($1, ${0:value})
-endsnippet
+## Switch Statements
+snippet switch "bare switch statement"
+switch {
+case ${1:condition}:
+	${2:action}	
+}
+${0}
+endsnippet 
 
-# break
-snippet br "break"
-break
-endsnippet
-
-# channel
-snippet ch "chan Type"
-chan ${0:int}
-endsnippet
-
-# case
-snippet case "case ...:"
-case ${1:value}:
-	${0:${VISUAL}}
-endsnippet
-
-# constant
-snippet con "const XXX Type = ..."
-const ${1:NAME} ${2:Type} = ${0:0}
-endsnippet
-
-# constants
-snippet cons "const ( ... )"
-const (
-	${1:NAME} ${2:Type} = ${3:value}
-	${0}
-)
-endsnippet
-
-# constants with iota
-snippet iota "const ( ... = iota )"
-const (
-	${1:NAME} ${2:Type} = iota
-	${0}
-)
-endsnippet
-
-# continue
-snippet cn "continue"
-continue
-endsnippet
-
-# default case
-snippet default "default: ..."
+snippet switchv "switch on a variable"
+switch ${1:x} {
 default:
-	${0:${VISUAL}}
-endsnippet
-
-# defer
-snippet df "defer someFunction()"
-defer ${1:func}(${2})
-${0}
-endsnippet
-
-snippet def "defer func() { ... }"
-defer func() {
-	${0:${VISUAL}}
-}()
-endsnippet
-
-# defer recover
-snippet defr
-defer func() {
-	if err := recover(); err != nil {
-		${0:${VISUAL}}
-	}
-}()
-endsnippet
-
-# gpl
-snippet gpl
-/*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; either version 2 of the License, or
-* (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*
-* You should have received a copy of the GNU General Public License
-* along with this program; if not, see <http://www.gnu.org/licenses/>.
-*
-* Copyright (C) ${1:Author}, `!v strftime("%Y")`
-*/
-${0}
-endsnippet
-
-# import
-snippet import "import ( ... )"
-import (
-	"${1:package}"
-)
-endsnippet
-
-# full interface snippet
-snippet interface "interface I { ... }"
-type ${1:Interface} interface {
-	${2:/* TODO: add methods */}
-}
-endsnippet
-
-# if condition
-snippet if "if ... { ... }"
-if ${1:condition} {
-	${0:${VISUAL}}
-}
-endsnippet
-
-# else snippet
-snippet else
-else {
-	${0:${VISUAL}}
-}
-endsnippet
-
-# if inline error
-snippet ife "If with inline erro"
-if err := ${1:condition}; err != nil {
-	${0:${VISUAL}}
-}
-endsnippet
-
-# error snippet
-snippet errn "Error return " !b
-if err != nil {
-	return err
+	${2:action}
+case ${3:y}:
+	${4:action}
 }
 ${0}
 endsnippet
 
-# error log snippet
-snippet errl "Error with log.Fatal(err)" !b
-if err != nil {
-	log.Fatal(err)
+snippet switchi "switch on variable with initializer"
+switch ${1:x} := ${2:fn()}; $1 {
+case ${3:x}:
+	${4:action}
 }
 ${0}
 endsnippet
 
-# error multiple return
-snippet errn, "Error return with two return values" !b
-if err != nil {
-	return ${1:nil}, ${2:err}
+snippet tswitch "type switch"
+switch ${1:x} := ${2:y}.(type) {
+case ${3:z}:
+	${4:action}
 }
 ${0}
 endsnippet
 
-# error panic
-snippet errp "Error panic" !b
-if err != nil {
-	panic(${1})
+snippet case "case entry"
+case ${1:x}:
+	${2:action}
+endsnippet
+
+snippet default "default entry"
+default:
+	${1:action}
+endsnippet
+
+## For statements
+snippet for "for statement with no condition"
+for {
+	${1:action}
 }
 ${0}
 endsnippet
 
-# error test
-snippet errt "Error test fatal " !b
-if err != nil {
-	t.Fatal(err)
+snippet forc "for with a condition"
+for ${1:x} ${2:=} ${3:x} {
+	${4:action}
 }
 ${0}
 endsnippet
 
-# error handle
-snippet errh "Error handle and return" !b
-if err != nil {
-	${1}
-	return
+snippet forcc "for with a for clause"
+for ${1:i} := ${2:0}; ${3:$1} ${4:<} ${5:y}; ${6:i++} { 
+	${7:action}
 }
 ${0}
 endsnippet
 
-# json field tag
-snippet json "\`json:key\`"
-\`json:"${1:`!v  go#util#snippetcase(matchstr(getline("."), '\w\+'))`}"\`
+snippet forr "for with a range statement"
+for ${1:i}, ${2:x} := range ${3:y} {
+	${4:action}
+}
+${0}
 endsnippet
 
-# yaml field tag
-snippet yaml "\`yaml:key\`"
-\`yaml:"${1:`!v  go#util#snippetcase(matchstr(getline("."), '\w\+'))`}"\`
+## Go statements
+snippet g "go statement"
+go ${1:x}
 endsnippet
 
-# fallthrough
+## Select statements
+snippet select "select statement"
+select {
+case ${1:x} ${2:=} ${3:<-c}:
+	${4:action}
+}
+endsnippet
+
+snippet scase "select case entry"
+case ${1:x} <- ${2:y}:
+	${3:action}
+endsnippet
+
+## Return statements
+snippet r "return"
+return ${1:x}
+endsnippet
+
+## Break statements
+snippet b "break"
+break ${0}
+endsnippet
+
+## Continue statements
+snippet c "continue"
+continue ${0}
+endsnippet
+
+## Goto statements
+snippet gt "goto"
+goto ${1:x}
+endsnippet
+
+## Fallthrough Statements
 snippet ft "fallthrough"
 fallthrough
 endsnippet
 
-# for loop
-snippet for "for ... { ... }"
-for ${1} {
-	${0:${VISUAL}}
-}
+## Defer statements
+snippet dfr "defer"
+defer ${1:${VISUAL:fn()}}
 endsnippet
 
-# for integer loop
-snippet fori "for 0..N-1 { ... }"
-for ${1:i} := 0; $1 < ${2:N}; $1++ {
-	${0:${VISUAL}}
-}
+# Built-in functions
+snippet c "close"
+close(${1:args})
 endsnippet
 
-# for range loop
-snippet forr "for k, v := range items { ... }"
-for ${2:k}, ${3:v} := range ${1} {
-	${0:${VISUAL}}
-}
+snippet mk "make"
+make(${1:args})
 endsnippet
 
-# function
-snippet func "func Function(...) [error] { ... }"
-func ${1:name}(${2:params})${3/(.+)/ /}`!p opening_par(snip, 3)`$3`!p closing_par(snip, 3)` {
-	${0:${VISUAL}}
-}
+snippet app "append to"
+${1:x} := append($1, ${2:value})
 endsnippet
 
-# Fmt Printf debug
-snippet ff "fmt.Printf(...)"
-fmt.Printf("${1:${VISUAL}} = %+v\n", $1)
+snippet del "delete a map element"
+delete(${1:map}, ${2:key})
 endsnippet
 
-# Fmt Println debug
-snippet fn "fmt.Println(...)"
-fmt.Println("${1:${VISUAL}}")
-endsnippet
-
-# Fmt Errorf debug
-snippet fe "fmt.Errorf(...)"
-fmt.Errorf("${1:${VISUAL}}")
-endsnippet
-
-# log printf
-snippet lf "log.Printf(...)"
-log.Printf("${1:${VISUAL}} = %+v\n", $1)
-endsnippet
-
-# log println
-snippet ln "log.Println(...)"
-log.Println("${1:${VISUAL}}")
-endsnippet
-
-# make
-snippet make "make(Type, size)"
-make(${1:[]string}, ${2:0})${0}
-endsnippet
-
-# map
-snippet map "map[Type]Type"
-map[${1:string}]${0:int}
-endsnippet
-
-# main()
-snippet main "func main() { ... }"
-func main() {
-	${0:${VISUAL}}
-}
-endsnippet
-
-# method
-snippet meth "func (self Type) Method(...) [error] { ... }"
-func (${1:receiver} ${2:type}) ${3:name}(${4:params})${5/(.+)/ /}`!p opening_par(snip, 5)`$5`!p closing_par(snip, 5)` {
-	${0:${VISUAL}}
-}
-endsnippet
-
-# ok
-snippet ok "if !ok { ... }"
-if !ok {
-	${0:${VISUAL}}
-}
-endsnippet
-
-# package
-snippet package "package ..."
-// Package $1 provides ${2:...}
-package ${1:main}
-${0}
-endsnippet
-
-# panic
-snippet pn "panic()"
-panic("${0:msg}")
-endsnippet
-
-# return
-snippet rt "return"
-return ${0:${VISUAL}}
-endsnippet
-
-# select
-snippet select "select { case a := <-chan: ... }"
-select {
-case ${1:v1} := <-${2:chan1}
-	${0}
-}
-endsnippet
-
-# struct
-snippet st "type T struct { ... }"
-type ${1:Type} struct {
-${0}
-}
-endsnippet
-
-# switch
-snippet switch "switch x { ... }"
-switch ${1:var} {
-case ${2:value1}:
-	${0}
-}
-endsnippet
-
-# sprintf
-snippet sp "fmt.Sprintf(...)"
-fmt.Sprintf("%${1:s}", ${2:var})
-endsnippet
-
-# goroutine named function
-snippet go "go someFunc(...)"
-go ${1:funcName}(${0})
-endsnippet
-
-# goroutine anonymous function
-snippet gof "go func() { ... }()"
-go func() {
-	${1:${VISUAL}}
-}()
-${0}
-endsnippet
-
-# test function
-snippet test "func TestXYZ(t *testing.T) { ... }"
-func Test${1:Function}(t *testing.T) {
-	${0:${VISUAL}}
-}
-endsnippet
-
-snippet hf "http.HandlerFunc" !b
-func ${1:handler}(w http.ResponseWriter, r *http.Request) {
-	${0:fmt.Fprintf(w, "hello world")}
-}
-endsnippet
-
-snippet hhf "mux.HandleFunc" !b
-${1:http}.HandleFunc("${2:/}", func(w http.ResponseWriter, r *http.Request) {
-	${0:fmt.Fprintf(w, "hello world")}
-})
-endsnippet
-
-# quick test server
-snippet tsrv "httptest.NewServer"
-ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintln(w, ${1:`response`})
-}))
-defer ts.Close()
-
-${0:someUrl} = ts.URL
-endsnippet
-
-# test error handling
-snippet ter "if err != nil { t.Errorf(...) }"
+# Errors
+snippet err "if err != nil; return" 
 if err != nil {
-	t.Errorf("${0:message}")
+	return ${1:err}
 }
+${0}
 endsnippet
 
-# test fatal error
-snippet terf "if err != nil { t.Fatalf(...) }"
+snippet erf "if err != nil; return formatted"
 if err != nil {
-	t.Fatalf("${0:message}")
+	return fmt.Errorf(${1:err})
 }
+${0}
 endsnippet
 
-snippet example "func ExampleXYZ() { ... }"
-func Example${1:Method}() {
-	${0:${VISUAL}}
-	// Output:
+snippet errh  "if err != nil; handle and return"
+if err != nil {
+	${1:action}
+	return ${1:err}
 }
+${0}
 endsnippet
 
-snippet benchmark "func BenchmarkXYZ(b *testing.B) { ... }"
-func Benchmark${1:Method}(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		${0:${VISUAL}}
-	}
+snippet errhf "if err != nil; handle and return formatted"
+if err != nil {
+	${1:action}
+	return fmt.Errorf(${1:err})
 }
+${0}
 endsnippet
 
-# variable declaration
-snippet var "var x Type [= ...]"
-var ${1:x} ${2:Type}${3: = ${0:value}}
-endsnippet
-
-# variables declaration
-snippet vars "var ( ... )"
-var (
-	${1:x} ${2:Type}${3: = ${0:value}}
-)
-endsnippet
-
-# equals fails the test if exp is not equal to act.
-snippet eq "equals: test two identifiers with DeepEqual"
-if !reflect.DeepEqual(${1:expected}, ${2:actual}) {
-	_, file, line, _ := runtime.Caller(0)
-	fmt.Printf("%s:%d:\n\n\texp: %#v\n\n\tgot: %#v\n\n", filepath.Base(file), line, $1, $2)
-	t.FailNow()
+snippet errl "if err != nil; log and return"
+if err != nil {
+	log.Println(${1:err})
+	return ${2:err}
 }
+${0}
 endsnippet
 
-global !p
+snippet errlf "if err != nil; log and return"
+if err != nil {
+	log.Printf(${1:err})
+	return ${2:err}
+}
+${0}
+endsnippet
 
-import re
+# Printing
+snippet pl "fmt.Println"
+fmt.Println(${1:args})
+endsnippet
 
-# Automatically wrap return types with parentheses
+snippet pf "fmt.Printf"
+fmt.Printf(${1:args})
+endsnippet
 
-def return_values(s):
-	# remove everything wrapped in parentheses
-	s = re.sub("\(.*?\)|\([^)]*$", "", s)
-	return len(s.split(","))
+snippet ll "log.Println"
+log.Println(${1:args})
+endsnippet
 
-def opening_par(snip, pos):
-	if return_values(t[pos]) > 1 and not t[pos].startswith("("):
-		snip.rv = "("
-	else:
-		snip.rv = ""
+snippet lf "log.Printf"
+log.Printf(${1:args})
+endsnippet
 
-def closing_par(snip, pos):
-	if return_values(t[pos]) > 1:
-		snip.rv = ")"
-	else:
-		snip.rv = ""
-
-endglobal
-
-# vim:ft=snippets:


### PR DESCRIPTION
Branch begins to create compossible snippets using the Go spec as reference. Idea is to have snippets be able to be nested when creating structure like Switches. For sample

switch\<tab\> creates

```
switch {
  case "somecase":
    someaction()
}
```

When inside this switch case doing the following creates another case statement

```
switch {
  case "somecase":
    someaction()
  case\<tab\>
}
```

There's still some snippets that need to be defined but the majority of the Go spec is accounted for.

One nasty issue is that SuperTab begins to evaluate gocode completion when inside brackets. So unfortunately this was not possible for me to do:

```
al\<tab\>

[]Bool{t\<tab\>, t\<tab\>}
```

We would expect t<tab> to expand to "true" however supertab kicks in with omni complete. Maybe this can be fixed by changing my trigger key for Utlisnips - not sure. 