### PR TITLE
set build tag argument only when build tags are defined

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -11,13 +11,16 @@ endfunction
 function! go#cmd#Build(bang, ...) abort
   " Create our command arguments. go build discards any results when it
   " compiles multiple packages. So we pass the `errors` package just as an
-  " placeholder with the current folder (indicated with '.'). We also pass -i
-  " that tries to install the dependencies, this has the side effect that it
-  " caches the build results, so every other build is faster.
-  let l:args =
-        \ ['build', '-tags', go#config#BuildTags()] +
-        \ map(copy(a:000), "expand(v:val)") +
-        \ [".", "errors"]
+  " placeholder with the current folder (indicated with '.').
+  let l:args = ['build']
+
+  " check for any tags
+  let tags = go#config#BuildTags()
+  if tags isnot ''
+    call extend(l:args, ["-tags", tags])
+  endif
+
+  call extend(l:args,  map(copy(a:000), "expand(v:val)") + [".", "errors"])
 
   " Vim async.
   if go#util#has_job()
@@ -175,12 +178,19 @@ function! go#cmd#Install(bang, ...) abort
     " expand all wildcards(i.e: '%' to the current file name)
     let goargs = map(copy(a:000), "expand(v:val)")
 
+    " check for any tags
+    let tags = go#config#BuildTags()
+    if tags isnot ''
+      call extend(goargs, ["-tags", tags])
+    endif
+
     if go#config#EchoCommandInfo()
       call go#util#EchoProgress("installing dispatched ...")
     endif
 
+
     call s:cmd_job({
-          \ 'cmd': ['go', 'install', '-tags', go#config#BuildTags()] + goargs,
+          \ 'cmd': ['go', 'install'] + goargs,
           \ 'bang': a:bang,
           \ 'for': 'GoInstall',
           \})

--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -49,8 +49,16 @@ function! go#coverage#Buffer(bang, ...) abort
   endif
 
   if go#util#has_job()
+    let cmd = ['go', 'test', '-coverprofile', l:tmpname]
+
+    " check for any tags
+    let tags = go#config#BuildTags()
+    if tags isnot ''
+      call extend(cmd, ["-tags", tags])
+    endif
+
     call s:coverage_job({
-          \ 'cmd': ['go', 'test', '-tags', go#config#BuildTags(), '-coverprofile', l:tmpname] + a:000,
+          \ 'cmd': l:cmd + a:000,
           \ 'complete': function('s:coverage_callback', [l:tmpname]),
           \ 'bang': a:bang,
           \ 'for': 'GoTest',
@@ -58,7 +66,14 @@ function! go#coverage#Buffer(bang, ...) abort
     return
   endif
 
-  let args = [a:bang, 0, '-tags', go#config#BuildTags(), "-coverprofile", l:tmpname]
+  let args = [a:bang, 0, "-coverprofile", l:tmpname]
+
+  " check for any tags
+  let tags = go#config#BuildTags()
+  if tags isnot ''
+    call extend(args, ["-tags", tags])
+  endif
+
   if a:0
     call extend(args, a:000)
   endif
@@ -105,8 +120,17 @@ endfunction
 function! go#coverage#Browser(bang, ...) abort
   let l:tmpname = tempname()
   if go#util#has_job()
+
+    let cmd = ['go', 'test', '-coverprofile', l:tmpname]
+
+    " check for any tags
+    let tags = go#config#BuildTags()
+    if tags isnot ''
+      call extend(cmd, ["-tags", tags])
+    endif
+
     call s:coverage_job({
-          \ 'cmd': ['go', 'test', '-tags', go#config#BuildTags(), '-coverprofile', l:tmpname],
+          \ 'cmd': l:cmd,
           \ 'complete': function('s:coverage_browser_callback', [l:tmpname]),
           \ 'bang': a:bang,
           \ 'for': 'GoTest',

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -33,9 +33,15 @@ function! go#def#Jump(mode) abort
       return
     endif
 
-    let cmd = [bin_path, '-tags', go#config#BuildTags()]
-    let stdin_content = ""
+    let cmd = [bin_path]
 
+    " check for any tags
+    let tags = go#config#BuildTags()
+    if tags isnot ''
+      call extend(cmd, ["-tags", tags])
+    endif
+
+    let stdin_content = ""
     if &modified
       let content  = join(go#util#GetLines(), "\n")
       let stdin_content = fname . "\n" . strlen(content) . "\n" . content

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -139,7 +139,14 @@ function! s:gogetdoc(json) abort
   let fname = expand("%:p:gs!\\!/!")
   let pos = shellescape(fname.':#'.offset)
 
-  let cmd = [go#util#Shellescape(bin_path), '-tags', go#config#BuildTags(), '-pos', pos]
+  let cmd = [go#util#Shellescape(bin_path), '-pos', pos]
+
+  " check for any tags
+  let tags = go#config#BuildTags()
+  if tags isnot ''
+    call extend(cmd, ["-tags", tags])
+  endif
+
   if a:json
     let cmd += ["-json"]
   endif

--- a/autoload/go/fillstruct.vim
+++ b/autoload/go/fillstruct.vim
@@ -3,8 +3,13 @@ function! go#fillstruct#FillStruct() abort
       \ '-file', bufname(''),
       \ '-offset', go#util#OffsetCursor(),
       \ '-line', line('.')]
-      " Needs: https://github.com/davidrjenni/reftools/pull/14
-      "\ '-tags', go#config#BuildTags()]
+
+  " Needs: https://github.com/davidrjenni/reftools/pull/14
+"  " check for any tags
+"  let tags = go#config#BuildTags()
+"  if tags isnot ''
+"    call extend(cmd, ["-tags", tags])
+"  endif
 
   " Read from stdin if modified.
   if &modified

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -30,7 +30,13 @@ function! s:guru_cmd(args) range abort
   endif
 
   " start constructing the command
-  let cmd = [bin_path, '-tags', go#config#BuildTags()]
+  let cmd = [bin_path]
+
+  " check for any tags
+  let tags = go#config#BuildTags()
+  if tags isnot ''
+    call extend(cmd, ["-tags", tags])
+  endif
 
   let filename = fnamemodify(expand("%"), ':p:gs?\\?/?')
   if &modified

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -31,7 +31,13 @@ function! go#rename#Rename(bang, ...) abort
   let offset = go#util#has_job() ? offset : shellescape(offset)
   let to_identifier = go#util#has_job() ? to_identifier : shellescape(to_identifier)
 
-  let cmd = [bin_path, "-offset", offset, "-to", to_identifier, '-tags', go#config#BuildTags()]
+  let cmd = [bin_path, "-offset", offset, "-to", to_identifier]
+
+  " check for any tags
+  let tags = go#config#BuildTags()
+  if tags isnot ''
+    call extend(cmd, ["-tags", tags])
+  endif
 
   if go#util#has_job()
     call go#util#EchoProgress(printf("renaming to '%s' ...", to_identifier))

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -2,7 +2,13 @@
 " compile the tests instead of running them (useful to catch errors in the
 " test files). Any other argument is appended to the final `go test` command.
 function! go#test#Test(bang, compile, ...) abort
-  let args = ["test", '-tags', go#config#BuildTags()]
+  let args = ["test"]
+
+  " check for any tags
+  let tags = go#config#BuildTags()
+  if tags isnot ''
+    call extend(args, ["-tags", tags])
+  endif
 
   " don't run the test, only compile it. Useful to capture and fix errors.
   if a:compile


### PR DESCRIPTION
Only set build tag options when build tags are not empty; nvim (at
least) doesn't always properly quote an empty argument.

Fixes #1766 and #1767 