### PR TITLE
Fix shell escaping for :GoDoc, :GoDef

### DIFF
--- a/autoload/ctrlp/decls.vim
+++ b/autoload/ctrlp/decls.vim
@@ -60,36 +60,35 @@ function! ctrlp#decls#enter() abort
   let s:current_dir = fnameescape(expand('%:p:h'))
   let s:decls = []
 
-  let bin_path = go#path#CheckBinPath('motion')
-  if empty(bin_path)
-    return
-  endif
-  let command = printf("%s -format vim -mode decls", bin_path)
-  let command .= " -include ".  go#config#DeclsIncludes()
+  let l:cmd = ['motion',
+        \ '-format', 'vim',
+        \ '-mode', 'decls',
+        \ '-include', go#config#DeclsIncludes(),
+        \ ]
 
   call go#cmd#autowrite()
 
   if s:mode == 0
     " current file mode
-    let fname = expand("%:p")
+    let l:fname = expand("%:p")
     if exists('s:target')
-      let fname = s:target
+      let l:fname = s:target
     endif
 
-    let command .= printf(" -file %s", fname)
+    let cmd += ['-file', l:fname]
   else
     " all functions mode
-    let dir = expand("%:p:h")
+    let l:dir = expand("%:p:h")
     if exists('s:target')
-      let dir = s:target
+      let l:dir = s:target
     endif
 
-    let command .= printf(" -dir %s", dir)
+    let cmd += ['-dir', l:dir]
   endif
 
-  let out = go#util#System(command)
-  if go#util#ShellError() != 0
-    call go#util#EchoError(out)
+  let [l:out, l:err] = go#util#Exec(l:cmd)
+  if l:err
+    call go#util#EchoError(l:out)
     return
   endif
 

--- a/autoload/fzf/decls.vim
+++ b/autoload/fzf/decls.vim
@@ -58,35 +58,34 @@ function! s:source(mode,...) abort
   let s:current_dir = expand('%:p:h')
   let ret_decls = []
 
-  let bin_path = go#path#CheckBinPath('motion')
-  if empty(bin_path)
-    return
-  endif
-  let command = printf("%s -format vim -mode decls", bin_path)
-  let command .= " -include ".  go#config#DeclsIncludes()
+  let l:cmd = ['motion',
+        \ '-format', 'vim',
+        \ '-mode', 'decls',
+        \ '-include', go#config#DeclsIncludes(),
+        \ ]
 
   call go#cmd#autowrite()
 
   if a:mode == 0
     " current file mode
-    let fname = expand("%:p")
+    let l:fname = expand("%:p")
     if a:0 && !empty(a:1)
-      let fname = a:1
+      let l:fname = a:1
     endif
 
-    let command .= printf(" -file %s", shellescape(fname))
+    let cmd += ['-file', l:fname]
   else
     " all functions mode
     if a:0 && !empty(a:1)
       let s:current_dir = a:1
     endif
 
-    let command .= printf(" -dir %s", shellescape(s:current_dir))
+    let l:cmd += ['-dir', s:current_dir]
   endif
 
-  let out = go#util#System(command)
-  if go#util#ShellError() != 0
-    call go#util#EchoError(out)
+  let [l:out, l:err] = go#util#Exec(l:cmd)
+  if l:err
+    call go#util#EchoError(l:out)
     return
   endif
 

--- a/autoload/go/asmfmt.vim
+++ b/autoload/go/asmfmt.vim
@@ -28,28 +28,27 @@ function! go#asmfmt#Format() abort
   call writefile(go#util#GetLines(), l:tmpname)
 
   " Run asmfmt.
-  let path = go#path#CheckBinPath("asmfmt")
-  if empty(path)
+  let [l:out, l:err] = go#util#Exec(['asmfmt', '-w', l:tmpname])
+  if l:err
+    call go#util#EchoError(l:out)
     return
   endif
-  let out = go#util#System(path . ' -w ' . l:tmpname)
 
-  " If there's no error, replace the current file with the output.
-  if go#util#ShellError() == 0
-    " Remove undo point caused by BufWritePre.
-    try | silent undojoin | catch | endtry
+  " Remove undo point caused by BufWritePre.
+  try | silent undojoin | catch | endtry
 
-    " Replace the current file with the temp file; then reload the buffer.
-    let old_fileformat = &fileformat
-    " save old file permissions
-    let original_fperm = getfperm(expand('%'))
-    call rename(l:tmpname, expand('%'))
-    " restore old file permissions
-    call setfperm(expand('%'), original_fperm)
-    silent edit!
-    let &fileformat = old_fileformat
-    let &syntax = &syntax
-  endif
+  " Replace the current file with the temp file; then reload the buffer.
+  let old_fileformat = &fileformat
+
+  " save old file permissions
+  let original_fperm = getfperm(expand('%'))
+  call rename(l:tmpname, expand('%'))
+
+  " restore old file permissions
+  call setfperm(expand('%'), original_fperm)
+  silent edit!
+  let &fileformat = old_fileformat
+  let &syntax = &syntax
 
   " Restore the cursor/window positions.
   call winrestview(l:curw)

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -50,16 +50,16 @@ function! s:gocodeEnableOptions() abort
     return
   endif
 
-  let bin_path = go#path#CheckBinPath("gocode")
-  if empty(bin_path)
+  let l:bin_path = go#path#CheckBinPath("gocode")
+  if empty(l:bin_path)
     return
   endif
 
   let s:optionsEnabled = 1
 
-  call go#util#System(printf('%s set propose-builtins %s', go#util#Shellescape(bin_path), s:toBool(go#config#GocodeProposeBuiltins())))
-  call go#util#System(printf('%s set autobuild %s', go#util#Shellescape(bin_path), s:toBool(go#config#GocodeAutobuild())))
-  call go#util#System(printf('%s set unimported-packages %s', go#util#Shellescape(bin_path), s:toBool(go#config#GocodeUnimportedPackages())))
+  call go#util#Exec(['gocode', 'set', 'propose-builtins', s:toBool(go#config#GocodeProposeBuiltins())])
+  call go#util#Exec(['gocode', 'set', 'autobuild', s:toBool(go#config#GocodeAutobuild())])
+  call go#util#Exec(['gocode', 'set', 'unimported-packages', s:toBool(go#config#GocodeUnimportedPackages())])
 endfunction
 
 function! s:toBool(val) abort

--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -126,10 +126,8 @@ function! go#coverage#Browser(bang, ...) abort
     return
   endif
 
-
   if go#util#ShellError() == 0
-    let openHTML = 'go tool cover -html='.l:tmpname
-    call go#tool#ExecuteInDir(openHTML)
+    call go#tool#ExecuteInDir(['go', 'tool', 'cover', '-html=' . l:tmpname])
   endif
 
   call delete(l:tmpname)
@@ -332,8 +330,7 @@ endfunction
 
 function! s:coverage_browser_callback(coverfile, job, exit_status, data)
   if a:exit_status == 0
-    let openHTML = 'go tool cover -html='.a:coverfile
-    call go#tool#ExecuteInDir(openHTML)
+    call go#tool#ExecuteInDir(['go', 'tool', 'cover', '-html=' . a:coverfile])
   endif
 
   call delete(a:coverfile)
@@ -366,8 +363,7 @@ function! s:coverage_browser_handler(job, exit_status, data) abort
 
   let l:tmpname = s:coverage_browser_handler_jobs[a:job.id]
   if a:exit_status == 0
-    let openHTML = 'go tool cover -html='.l:tmpname
-    call go#tool#ExecuteInDir(openHTML)
+    call go#tool#ExecuteInDir(['go', 'tool', 'cover', '-html=' . l:tmpname])
   endif
 
   call delete(l:tmpname)

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -28,12 +28,7 @@ function! go#def#Jump(mode) abort
       call delete(l:tmpname)
     endif
   elseif bin_name == 'guru'
-    let bin_path = go#path#CheckBinPath("guru")
-    if empty(bin_path)
-      return
-    endif
-
-    let cmd = [bin_path, '-tags', go#config#BuildTags()]
+    let cmd = [bin_name, '-tags', go#config#BuildTags()]
     let stdin_content = ""
 
     if &modified
@@ -42,8 +37,7 @@ function! go#def#Jump(mode) abort
       call add(cmd, "-modified")
     endif
 
-    let fname = fname.':#'.go#util#OffsetCursor()
-    call extend(cmd, ["definition", fname])
+    call extend(cmd, ["definition", fname . ':#' . go#util#OffsetCursor()])
 
     if go#util#has_job()
       let l:spawn_args = {
@@ -61,18 +55,17 @@ function! go#def#Jump(mode) abort
       return
     endif
 
-    let command = join(cmd, " ")
     if &modified
-      let out = go#util#System(command, stdin_content)
+      let [l:out, l:err] = go#util#Exec(l:cmd, stdin_content)
     else
-      let out = go#util#System(command)
+      let [l:out, l:err] = go#util#Exec(l:cmd)
     endif
   else
     call go#util#EchoError('go_def_mode value: '. bin_name .' is not valid. Valid values are: [godef, guru]')
     return
   endif
 
-  if go#util#ShellError() != 0
+  if l:err
     call go#util#EchoError(out)
     return
   endif

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -17,16 +17,14 @@ function! go#def#Jump(mode) abort
       let fname = l:tmpname
     endif
 
-    let bin_path = go#path#CheckBinPath("godef")
-    if empty(bin_path)
-      return
-    endif
-    let command = printf("%s -f=%s -o=%s -t", go#util#Shellescape(bin_path),
-      \ go#util#Shellescape(fname), go#util#OffsetCursor())
-    let out = go#util#System(command)
+    let [l:out, l:err] = go#util#Exec(['godef',
+          \ '-f=' . l:fname,
+          \ '-o=' . go#util#OffsetCursor(),
+          \ '-t'])
     if exists("l:tmpname")
       call delete(l:tmpname)
     endif
+
   elseif bin_name == 'guru'
     let cmd = [bin_name, '-tags', go#config#BuildTags()]
     let stdin_content = ""

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -55,8 +55,7 @@ function! go#doc#Open(newmode, mode, ...) abort
       return
     endif
 
-    let command = printf("%s %s", go#util#Shelljoin(go#config#DocCommand()), join(a:000, ' '))
-    let out = go#util#System(command)
+    let [l:out, l:err] = go#util#Exec(go#config#DocCommand() + a:000)
   " Without argument: run gogetdoc on cursor position.
   else
     let [l:out, l:err] = s:gogetdoc(0)

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -10,8 +10,8 @@ function! go#doc#OpenBrowser(...) abort
   " non-json output of gogetdoc
   let bin_path = go#path#CheckBinPath('gogetdoc')
   if !empty(bin_path) && exists('*json_decode')
-    let json_out = s:gogetdoc(1)
-    if go#util#ShellError() != 0
+    let [l:json_out, l:err] = s:gogetdoc(1)
+    if l:err
       call go#util#EchoError(json_out)
       return
     endif
@@ -59,13 +59,13 @@ function! go#doc#Open(newmode, mode, ...) abort
     let out = go#util#System(command)
   " Without argument: run gogetdoc on cursor position.
   else
-    let out = s:gogetdoc(0)
+    let [l:out, l:err] = s:gogetdoc(0)
     if out == -1
       return
     endif
   endif
 
-  if go#util#ShellError() != 0
+  if l:err
     call go#util#EchoError(out)
     return
   endif
@@ -129,31 +129,20 @@ function! s:GodocView(newposition, position, content) abort
 endfunction
 
 function! s:gogetdoc(json) abort
-  " check if we have 'gogetdoc' and use it automatically
-  let bin_path = go#path#CheckBinPath('gogetdoc')
-  if empty(bin_path)
-    return -1
-  endif
-
-  let offset = go#util#OffsetCursor()
-  let fname = expand("%:p:gs!\\!/!")
-  let pos = shellescape(fname.':#'.offset)
-
-  let cmd = [go#util#Shellescape(bin_path), '-tags', go#config#BuildTags(), '-pos', pos]
+  let l:cmd = [
+        \ 'gogetdoc',
+        \ '-tags', go#config#BuildTags(),
+        \ '-pos', expand("%:p:gs!\\!/!") . ':#' . go#util#OffsetCursor()]
   if a:json
-    let cmd += ["-json"]
+    let l:cmd += ['-json']
   endif
-
-  let command = join(cmd, " ")
 
   if &modified
-    let command .= " -modified"
-    let out = go#util#System(command, go#util#archive())
-  else
-    let out = go#util#System(command)
+    let l:cmd += ['-modified']
+    return go#util#Exec(l:cmd, go#util#archive())
   endif
 
-  return out
+  return go#util#Exec(l:cmd)
 endfunction
 
 " returns the package and exported name. exported name might be empty.

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -54,10 +54,10 @@ function! go#fmt#Format(withGoimport) abort
   endif
 
   let current_col = col('.')
-  let out = go#fmt#run(bin_name, l:tmpname, expand('%'))
+  let [l:out, l:err] = go#fmt#run(bin_name, l:tmpname, expand('%'))
   let diff_offset = len(readfile(l:tmpname)) - line('$')
 
-  if go#util#ShellError() == 0
+  if l:err == 0
     call go#fmt#update_file(l:tmpname, expand('%'))
   elseif go#config#FmtFailSilently()
     let errors = s:parse_errors(expand('%'), out)
@@ -138,34 +138,16 @@ endfunction
 " run runs the gofmt/goimport command for the given source file and returns
 " the output of the executed command. Target is the real file to be formatted.
 function! go#fmt#run(bin_name, source, target)
-  let cmd = s:fmt_cmd(a:bin_name, a:source, a:target)
-  if empty(cmd)
+  let l:cmd = s:fmt_cmd(a:bin_name, a:source, a:target)
+  if empty(l:cmd)
     return
   endif
-
-  let command = join(cmd, " ")
-
-  " execute our command...
-  let out = go#util#System(command)
-
-  return out
+  return go#util#Exec(l:cmd)
 endfunction
 
-" fmt_cmd returns a dict that contains the command to execute gofmt (or
-" goimports). args is dict with
+" fmt_cmd returns the command to run as a list.
 function! s:fmt_cmd(bin_name, source, target)
-  " check if the user has installed command binary.
-  " For example if it's goimports, let us check if it's installed,
-  " if not the user get's a warning via go#path#CheckBinPath()
-  let bin_path = go#path#CheckBinPath(a:bin_name)
-  if empty(bin_path)
-    return []
-  endif
-
-  " start constructing the command
-  let bin_path = go#util#Shellescape(bin_path)
-  let cmd = [bin_path]
-  call add(cmd, "-w")
+  let l:cmd = [a:bin_name, '-w']
 
   " add the options for binary (if any). go_fmt_options was by default of type
   " string, however to allow customization it's now a dictionary of binary
@@ -180,9 +162,9 @@ function! s:fmt_cmd(bin_name, source, target)
     " lazy check if goimports support `-srcdir`. We should eventually remove
     " this in the future
     if !exists('b:goimports_vendor_compatible')
-      let out = go#util#System(bin_path . " --help")
-      if out !~ "-srcdir"
-        call go#util#EchoWarning(printf("vim-go: goimports (%s) does not support srcdir. Update with: :GoUpdateBinaries", bin_path))
+      let [l:out, l:err] = go#util#Exec([a:bin_name, '--help'])
+      if l:out !~ "-srcdir"
+        call go#util#EchoWarning(printf("vim-go: goimports (%s) does not support srcdir. Update with: :GoUpdateBinaries", a:bin_name))
       else
         let b:goimports_vendor_compatible = 1
       endif

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -175,7 +175,7 @@ function! s:fmt_cmd(bin_name, source, target)
       set noshellslash
       " use the filename without the fully qualified name if the tree is
       " symlinked into the GOPATH, goimports won't work properly.
-      call extend(cmd, ["-srcdir", shellescape(a:target)])
+      call extend(cmd, ["-srcdir", a:target])
       let &shellslash = ssl_save
     endif
   endif

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -32,7 +32,6 @@ function! s:guru_cmd(args) range abort
   " start constructing the command
   let cmd = [bin_path, '-tags', go#config#BuildTags()]
 
-  let filename = fnamemodify(expand("%"), ':p:gs?\\?/?')
   if &modified
     let result.stdin_content = go#util#archive()
     call add(cmd, "-modified")
@@ -73,8 +72,8 @@ function! s:guru_cmd(args) range abort
     let pos = printf("#%s,#%s", pos1, pos2)
   endif
 
-  let filename .= ':'.pos
-  call extend(cmd, [mode, filename])
+  let l:filename = fnamemodify(expand("%"), ':p:gs?\\?/?') . ':' . pos
+  call extend(cmd, [mode, l:filename])
 
   let result.cmd = cmd
   return result

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -52,12 +52,14 @@ function! s:guru_cmd(args) range abort
     endif
   endif
 
-    " now add the scope to our command if there is any
+  " Add the scope.
   if !empty(scopes)
     " create shell-safe entries of the list
-    if !has("nvim") && !go#util#has_job() | let scopes = go#util#Shelllist(scopes) | endif
+    if !has("nvim") && !go#util#has_job()
+      let scopes = go#util#Shelllist(scopes)
+    endif
 
-    " guru expect a comma-separated list of patterns, construct it
+    " guru expect a comma-separated list of patterns.
     let l:scope = join(scopes, ",")
     let result.scope = l:scope
     call extend(cmd, ["-scope", l:scope])

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -97,22 +97,20 @@ function! s:sync_guru(args) abort
     endif
   endif
 
-
   " run, forrest run!!!
-  let command = join(result.cmd, " ")
-  if has_key(result, 'stdin_content')
-    let out = go#util#System(command, result.stdin_content)
+  if has_key(l:result, 'stdin_content')
+    let [l:out, l:err] = go#util#Exec(l:result.cmd, l:result.stdin_content)
   else
-    let out = go#util#System(command)
+    let [l:out, l:err] = go#util#Exec(l:result.cmd)
   endif
 
   if has_key(a:args, 'custom_parse')
-    call a:args.custom_parse(go#util#ShellError(), out, a:args.mode)
+    call a:args.custom_parse(l:err, l:out, a:args.mode)
   else
-    call s:parse_guru_output(go#util#ShellError(), out, a:args.mode)
+    call s:parse_guru_output(l:err, l:out, a:args.mode)
   endif
 
-  return out
+  return l:out
 endfunc
 
 " use vim or neovim job api as appropriate

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -53,11 +53,6 @@ function! s:guru_cmd(args) range abort
 
   " Add the scope.
   if !empty(scopes)
-    " create shell-safe entries of the list
-    if !has("nvim") && !go#util#has_job()
-      let scopes = go#util#Shelllist(scopes)
-    endif
-
     " guru expect a comma-separated list of patterns.
     let l:scope = join(scopes, ",")
     let result.scope = l:scope

--- a/autoload/go/import.vim
+++ b/autoload/go/import.vim
@@ -27,8 +27,8 @@ function! go#import#SwitchImport(enabled, localname, path, bang) abort
   endif
 
   if a:bang == "!"
-    let out = go#util#System("go get -u -v ".shellescape(path))
-    if go#util#ShellError() != 0
+    let [l:out, l:err] = go#util#Exec(['go', 'get', '-u', '-v', path])
+    if err != 0
       call s:Error("Can't find import: " . path . ":" . out)
     endif
   endif

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -90,27 +90,21 @@ endfunction
 " Golint calls 'golint' on the current directory. Any warnings are populated in
 " the location list
 function! go#lint#Golint(...) abort
-  let bin_path = go#path#CheckBinPath(go#config#GolintBin())
-  if empty(bin_path)
-    return
-  endif
-  let bin_path = go#util#Shellescape(bin_path)
-
   if a:0 == 0
-    let out = go#util#System(bin_path . " " . go#util#Shellescape(go#package#ImportPath()))
+    let [l:out, l:err] = go#util#Exec([go#config#GolintBin(), go#package#ImportPath()])
   else
-    let out = go#util#System(bin_path . " " . go#util#Shelljoin(a:000))
+    let [l:out, l:err] = go#util#Exec([go#config#GolintBin()] + a:000)
   endif
 
-  if empty(out)
-    echon "vim-go: " | echohl Function | echon "[lint] PASS" | echohl None
+  if empty(l:out)
+    call go#util#EchoSuccess('[lint] PASS')
     return
   endif
 
   let l:listtype = go#list#Type("GoLint")
-  call go#list#Parse(l:listtype, out, "GoLint")
-  let errors = go#list#Get(l:listtype)
-  call go#list#Window(l:listtype, len(errors))
+  call go#list#Parse(l:listtype, l:out, "GoLint")
+  let l:errors = go#list#Get(l:listtype)
+  call go#list#Window(l:listtype, len(l:errors))
   call go#list#JumpToFirst(l:listtype)
 endfunction
 
@@ -118,26 +112,28 @@ endfunction
 " the location list
 function! go#lint#Vet(bang, ...) abort
   call go#cmd#autowrite()
-  echon "vim-go: " | echohl Identifier | echon "calling vet..." | echohl None
+
+  call go#util#EchoProgress('calling vet...')
+
   if a:0 == 0
-    let out = go#util#System('go vet ' . go#util#Shellescape(go#package#ImportPath()))
+    let [l:out, l:err] = go#util#Exec(['go', 'vet', go#package#ImportPath()])
   else
-    let out = go#util#System('go tool vet ' . go#util#Shelljoin(a:000))
+    let [l:out, l:err] = go#util#Exec(['go', 'tool', 'vet'] + a:000)
   endif
 
   let l:listtype = go#list#Type("GoVet")
-  if go#util#ShellError() != 0
-    let errorformat="%-Gexit status %\\d%\\+," . &errorformat
+  if l:err != 0
+    let errorformat = "%-Gexit status %\\d%\\+," . &errorformat
     call go#list#ParseFormat(l:listtype, l:errorformat, out, "GoVet")
     let errors = go#list#Get(l:listtype)
     call go#list#Window(l:listtype, len(errors))
     if !empty(errors) && !a:bang
       call go#list#JumpToFirst(l:listtype)
     endif
-    echon "vim-go: " | echohl ErrorMsg | echon "[vet] FAIL" | echohl None
+    call go#util#EchoError('[vet] FAIL')
   else
     call go#list#Clean(l:listtype)
-    redraw | echon "vim-go: " | echohl Function | echon "[vet] PASS" | echohl None
+    call go#util#EchoSuccess('[vet] PASS')
   endif
 endfunction
 
@@ -145,42 +141,34 @@ endfunction
 " the location list
 function! go#lint#Errcheck(...) abort
   if a:0 == 0
-    let import_path = go#package#ImportPath()
+    let l:import_path = go#package#ImportPath()
     if import_path == -1
-      echohl Error | echomsg "vim-go: package is not inside GOPATH src" | echohl None
+      call go#util#EchoError('package is not inside GOPATH src')
       return
     endif
   else
-    let import_path = go#util#Shelljoin(a:000)
+    let l:import_path = join(a:000, ' ')
   endif
 
-  let bin_path = go#path#CheckBinPath(go#config#ErrcheckBin())
-  if empty(bin_path)
-    return
-  endif
-
-  echon "vim-go: " | echohl Identifier | echon "errcheck analysing ..." | echohl None
+  call go#util#EchoProgress('[errcheck] analysing ...')
   redraw
 
-  let command =  go#util#Shellescape(bin_path) . ' -abspath ' . import_path
-  let out = go#tool#ExecuteInDir(command)
+  let [l:out, l:err] = go#util#Exec([go#config#ErrcheckBin(), '-abspath', l:import_path])
 
   let l:listtype = go#list#Type("GoErrCheck")
-  if go#util#ShellError() != 0
+  if l:err != 0
     let errformat = "%f:%l:%c:\ %m, %f:%l:%c\ %#%m"
 
     " Parse and populate our location list
     call go#list#ParseFormat(l:listtype, errformat, split(out, "\n"), 'Errcheck')
 
-    let errors = go#list#Get(l:listtype)
-    if empty(errors)
-      echohl Error | echomsg "GoErrCheck returned error" | echohl None
-      echo out
+    let l:errors = go#list#Get(l:listtype)
+    if empty(l:errors)
+      call go#util#EchoError(l:out)
       return
     endif
 
     if !empty(errors)
-      echohl Error | echomsg "GoErrCheck found errors" | echohl None
       call go#list#Populate(l:listtype, errors, 'Errcheck')
       call go#list#Window(l:listtype, len(errors))
       if !empty(errors)
@@ -189,9 +177,8 @@ function! go#lint#Errcheck(...) abort
     endif
   else
     call go#list#Clean(l:listtype)
-    echon "vim-go: " | echohl Function | echon "[errcheck] PASS" | echohl None
+    call go#util#EchoSuccess('[errcheck] PASS')
   endif
-
 endfunction
 
 function! go#lint#ToggleMetaLinterAutoSave() abort

--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -107,10 +107,11 @@ function! go#package#FromPath(arg) abort
 endfunction
 
 function! go#package#CompleteMembers(package, member) abort
-  silent! let content = go#util#System('godoc ' . a:package)
-  if go#util#ShellError() || !len(content)
+  let [l:content, l:err] = go#util#Exec(['godoc', a:package])
+  if l:err || !len(content)
     return []
   endif
+
   let lines = filter(split(content, "\n"),"v:val !~ '^\\s\\+$'")
   try
     let mx1 = '^\s\+\(\S+\)\s\+=\s\+.*'

--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -62,8 +62,8 @@ function! go#package#ImportPath() abort
     return s:import_paths[dir]
   endif
 
-  let out = go#tool#ExecuteInDir("go list")
-  if go#util#ShellError() != 0
+  let [l:out, l:err] = go#tool#ExecuteInDir(['go', 'list'])
+  if l:err != 0
     return -1
   endif
 

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -146,7 +146,8 @@ endfunction
 function! go#path#CheckBinPath(binpath) abort
   " remove whitespaces if user applied something like 'goimports   '
   let binpath = substitute(a:binpath, '^\s*\(.\{-}\)\s*$', '\1', '')
-  " save off original path
+
+  " save original path
   let old_path = $PATH
 
   " check if we have an appropriate bin_path

--- a/autoload/go/play.vim
+++ b/autoload/go/play.vim
@@ -8,15 +8,16 @@ function! go#play#Share(count, line1, line2) abort
   let share_file = tempname()
   call writefile(split(content, "\n"), share_file, "b")
 
-  let command = "curl -s -X POST https://play.golang.org/share --data-binary '@".share_file."'"
-  let snippet_id = go#util#System(command)
+  let l:cmd = ['curl', '-s', '-X', 'POST', 'https://play.golang.org/share',
+        \ '--data-binary', '@' . l:share_file]
+  let [l:snippet_id, l:err] = go#util#Exec(l:cmd)
 
   " we can remove the temp file because it's now posted.
   call delete(share_file)
 
-  if go#util#ShellError() != 0
-    echo 'A error has occurred. Run this command to see what the problem is:'
-    echo command
+  if l:err != 0
+    echom 'A error has occurred. Run this command to see what the problem is:'
+    echom go#util#Shelljoin(l:cmd)
     return
   endif
 

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -25,12 +25,6 @@ function! go#rename#Rename(bang, ...) abort
   let fname = expand('%:p')
   let pos = go#util#OffsetCursor()
   let offset = printf('%s:#%d', fname, pos)
-
-  " no need to escape for job call
-  let bin_path = go#util#has_job() ? bin_path : shellescape(bin_path)
-  let offset = go#util#has_job() ? offset : shellescape(offset)
-  let to_identifier = go#util#has_job() ? to_identifier : shellescape(to_identifier)
-
   let cmd = [bin_path, "-offset", offset, "-to", to_identifier, '-tags', go#config#BuildTags()]
 
   if go#util#has_job()

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -42,11 +42,8 @@ function! go#rename#Rename(bang, ...) abort
     return
   endif
 
-  let command = join(cmd, " ")
-  let out = go#tool#ExecuteInDir(command)
-
-  let splitted = split(out, '\n')
-  call s:parse_errors(go#util#ShellError(), a:bang, splitted)
+  let [l:out, l:err] = go#tool#ExecuteInDir(l:cmd)
+  call s:parse_errors(l:err, a:bang, split(l:out, '\n'))
 endfunction
 
 function s:rename_job(args)

--- a/autoload/go/tags.vim
+++ b/autoload/go/tags.vim
@@ -31,24 +31,22 @@ function! go#tags#run(start, end, offset, mode, fname, test_mode, ...) abort
     let args["modified"] = 1
   endif
 
-  let result = s:create_cmd(args)
+  let l:result = s:create_cmd(args)
   if has_key(result, 'err')
     call go#util#EchoError(result.err)
     return -1
   endif
 
-  let command = join(result.cmd, " ")
-
   if &modified
     let filename = expand("%:p:gs!\\!/!")
     let content  = join(go#util#GetLines(), "\n")
     let in = filename . "\n" . strlen(content) . "\n" . content
-    let out = go#util#System(command, in)
+    let [l:out, l:err] = go#util#Exec(l:result.cmd, in)
   else
-    let out = go#util#System(command)
+    let [l:out, l:err] = go#util#Exec(l:result.cmd)
   endif
 
-  if go#util#ShellError() != 0
+  if l:err != 0
     call go#util#EchoError(out)
     return
   endif
@@ -115,7 +113,6 @@ func s:create_cmd(args) abort
   if empty(bin_path)
     return {'err': "gomodifytags does not exist"}
   endif
-  let bin_path = go#util#Shellescape(bin_path)
 
   let l:start = a:args.start
   let l:end = a:args.end
@@ -127,7 +124,7 @@ func s:create_cmd(args) abort
   " start constructing the command
   let cmd = [bin_path]
   call extend(cmd, ["-format", "json"])
-  call extend(cmd, ["-file", go#util#Shellescape(a:args.fname)])
+  call extend(cmd, ["-file", a:args.fname])
   call extend(cmd, ["-transform", l:modifytags_transform])
 
   if has_key(a:args, "modified")

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -61,10 +61,9 @@ function! go#test#Test(bang, compile, ...) abort
   call go#cmd#autowrite()
   redraw
 
-  let args = go#util#Shelllist(args, 1)
-  let command = "go " . join(args, ' ')
+  let l:cmd = ['go'] + l:args
 
-  let out = go#tool#ExecuteInDir(command)
+  let [l:out, l:err] = go#tool#ExecuteInDir(l:cmd)
   " TODO(bc): When the output is JSON, the JSON should be run through a
   " filter to produce lines that are more easily described by errorformat.
 
@@ -74,8 +73,8 @@ function! go#test#Test(bang, compile, ...) abort
   let dir = getcwd()
   execute cd fnameescape(expand("%:p:h"))
 
-  if go#util#ShellError() != 0
-    call go#list#ParseFormat(l:listtype, s:errorformat(), split(out, '\n'), command)
+  if l:err != 0
+    call go#list#ParseFormat(l:listtype, s:errorformat(), split(out, '\n'), l:cmd)
     let errors = go#list#Get(l:listtype)
     call go#list#Window(l:listtype, len(errors))
     if !empty(errors) && !a:bang

--- a/autoload/go/textobj.vim
+++ b/autoload/go/textobj.vim
@@ -105,7 +105,7 @@ function! go#textobj#FunctionLocation(direction, cnt) abort
     let l:cmd += ['-parse-comments']
   endif
 
-  let [l:out, l:err] = go#util#Exec(command)
+  let [l:out, l:err] = go#util#Exec(l:cmd)
   if l:err
     call go#util#EchoError(out)
     return

--- a/autoload/go/textobj.vim
+++ b/autoload/go/textobj.vim
@@ -7,30 +7,26 @@
 
 " Select a function in visual mode.
 function! go#textobj#Function(mode) abort
-  let offset = go#util#OffsetCursor()
-
-  let fname = shellescape(expand("%:p"))
+  let l:fname = expand("%:p")
   if &modified
-    " Write current unsaved buffer to a temp file and use the modified content
     let l:tmpname = tempname()
     call writefile(go#util#GetLines(), l:tmpname)
-    let fname = l:tmpname
+    let l:fname = l:tmpname
   endif
 
-  let bin_path = go#path#CheckBinPath('motion')
-  if empty(bin_path)
-    return
-  endif
-
-  let command = printf("%s -format vim -file %s -offset %s", bin_path, fname, offset)
-  let command .= " -mode enclosing"
+  let l:cmd = ['motion',
+        \ '-format', 'vim',
+        \ '-file', l:fname,
+        \ '-offset', go#util#OffsetCursor(),
+        \ '-mode', 'enclosing',
+        \ ]
 
   if go#config#TextobjIncludeFunctionDoc()
-    let command .= " -parse-comments"
+    let l:cmd += ['-parse-comments']
   endif
 
-  let out = go#util#System(command)
-  if go#util#ShellError() != 0
+  let [l:out, l:err] = go#util#Exec(l:cmd)
+  if l:err
     call go#util#EchoError(out)
     return
   endif
@@ -89,36 +85,28 @@ endfunction
 
 " Get the location of the previous or next function.
 function! go#textobj#FunctionLocation(direction, cnt) abort
-  let offset = go#util#OffsetCursor()
-
-  let fname = shellescape(expand("%:p"))
+  let l:fname = expand("%:p")
   if &modified
     " Write current unsaved buffer to a temp file and use the modified content
     let l:tmpname = tempname()
     call writefile(go#util#GetLines(), l:tmpname)
-    let fname = l:tmpname
+    let l:fname = l:tmpname
   endif
 
-  let bin_path = go#path#CheckBinPath('motion')
-  if empty(bin_path)
-    return
-  endif
-
-  let command = printf("%s -format vim -file %s -offset %s", bin_path, fname, offset)
-  let command .= ' -shift ' . a:cnt
-
-  if a:direction == 'next'
-    let command .= ' -mode next'
-  else " 'prev'
-    let command .= ' -mode prev'
-  endif
+  let l:cmd = ['motion',
+        \ '-format', 'vim',
+        \ '-file', l:fname,
+        \ '-offset', go#util#OffsetCursor(),
+        \ '-shift', a:cnt,
+        \ '-mode', a:direction,
+        \ ]
 
   if go#config#TextobjIncludeFunctionDoc()
-    let command .= " -parse-comments"
+    let l:cmd += ['-parse-comments']
   endif
 
-  let out = go#util#System(command)
-  if go#util#ShellError() != 0
+  let [l:out, l:err] = go#util#Exec(command)
+  if l:err
     call go#util#EchoError(out)
     return
   endif

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -159,16 +159,8 @@ function! go#tool#FilterValids(items) abort
 endfunction
 
 function! go#tool#ExecuteInDir(cmd) abort
-  " Verify that the directory actually exists. If the directory does not
-  " exist, then assume that the a:cmd should not be executed. Callers expect
-  " to check v:shell_error (via go#util#ShellError()), so execute a command
-  " that will return an error as if a:cmd was run and exited with an error.
-  " This helps avoid errors when working with plugins that use virtual files
-  " that don't actually exist on the file system (e.g. vim-fugitive's
-  " GitDiff).
   if !isdirectory(expand("%:p:h"))
-    let [out, err] = go#util#Exec(["false"])
-    return ''
+    return ['', 1]
   endif
 
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
@@ -204,15 +196,16 @@ function! go#tool#OpenBrowser(url) abort
         return
     endif
 
-    if cmd =~ '^!'
-        let cmd = substitute(cmd, '%URL%', '\=escape(shellescape(a:url),"#")', 'g')
-        silent! exec cmd
+    " if setting starts with a !.
+    if l:cmd =~ '^!'
+        let l:cmd = substitute(l:cmd, '%URL%', '\=escape(shellescape(a:url), "#")', 'g')
+        silent! exec l:cmd
     elseif cmd =~ '^:[A-Z]'
-        let cmd = substitute(cmd, '%URL%', '\=escape(a:url,"#")', 'g')
-        exec cmd
+        let l:cmd = substitute(l:cmd, '%URL%', '\=escape(a:url,"#")', 'g')
+        exec l:cmd
     else
-        let cmd = substitute(cmd, '%URL%', '\=shellescape(a:url)', 'g')
-        call go#util#System(cmd)
+        let l:cmd = substitute(l:cmd, '%URL%', '\=shellescape(a:url)', 'g')
+        call go#util#System(l:cmd)
     endif
 endfunction
 

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -36,7 +36,7 @@ function! go#tool#Files(...) abort
     endif
   endfor
 
-  let [l:out, l:err] = go#tool#ExecuteInDir(['go', 'list', '-f', l:combined)
+  let [l:out, l:err] = go#tool#ExecuteInDir(['go', 'list', '-f', l:combined])
   return split(l:out, '\n')
 endfunction
 
@@ -64,8 +64,12 @@ function! go#tool#Imports() abort
   endif
 
   for package_path in split(out, '\n')
-    let [l:out, l:err] = go#tool#ExecuteInDir(['go', 'list' '-f', '{{.Name}}', l:package_path])
-    let package_name = substitute(, '\n$', '', '')
+    let [l:out, l:err] = go#tool#ExecuteInDir(['go', 'list', '-f', '{{.Name}}', l:package_path])
+    if l:err != 0
+      echo out
+      return imports
+    endif
+    let package_name = substitute(l:out, '\n$', '', '')
     let imports[package_name] = package_path
   endfor
 

--- a/autoload/go/tool_test.vim
+++ b/autoload/go/tool_test.vim
@@ -1,8 +1,8 @@
 func! Test_ExecuteInDir() abort
   let l:tmp = gotest#write_file('a/a.go', ['package a'])
   try
-    let l:out = go#tool#ExecuteInDir("pwd")
-    call assert_equal(l:tmp . "/src/a\n", l:out)
+    let l:out = go#tool#ExecuteInDir(['pwd'])
+    call assert_equal([l:tmp . "/src/a\n", 0], l:out)
   finally
     call delete(l:tmp, 'rf')
   endtry
@@ -13,8 +13,8 @@ func! Test_ExecuteInDir_nodir() abort
   exe ':e ' . l:tmp . '/new-dir/a'
 
   try
-    let l:out = go#tool#ExecuteInDir("pwd")
-    call assert_equal('', l:out)
+    let l:out = go#tool#ExecuteInDir(['pwd'])
+    call assert_equal(['', 1], l:out)
   finally
     call delete(l:tmp, 'rf')
   endtry

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -156,10 +156,15 @@ function! go#util#Exec(cmd, ...) abort
     return ['', 1]
   endif
 
-  " CheckBinPath will show a warning for us.
-  let l:bin = go#path#CheckBinPath(a:cmd[0])
-  if empty(l:bin)
-    return ['', 1]
+  let l:bin = a:cmd[0]
+
+  " Don't run CheckBinPath for "go" to prevent infinite recursion.
+  if a:cmd[0] != 'go'
+    " CheckBinPath will show a warning for us.
+    let l:bin = go#path#CheckBinPath(l:bin)
+    if empty(l:bin)
+      return ['', 1]
+    endif
   endif
 
   let l:cmd = go#util#Shelljoin([l:bin] + a:cmd[1:])

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -48,7 +48,7 @@ function! go#util#IsMac() abort
   return has('mac') ||
         \ has('macunix') ||
         \ has('gui_macvim') ||
-        \ go#util#System('uname') =~? '^darwin'
+        \ go#util#Exec(['uname'])[0] =~? '^darwin'
 endfunction
 
  " Checks if using:
@@ -93,25 +93,25 @@ endfunction
 " goarch returns 'go env GOARCH'. This is an internal function and shouldn't
 " be used. Instead use 'go#util#env("goarch")'
 function! go#util#goarch() abort
-  return substitute(go#util#System('go env GOARCH'), '\n', '', 'g')
+  return substitute(go#util#Exec(['go', 'env', 'GOARCH'])[0], '\n', '', 'g')
 endfunction
 
 " goos returns 'go env GOOS'. This is an internal function and shouldn't
 " be used. Instead use 'go#util#env("goos")'
 function! go#util#goos() abort
-  return substitute(go#util#System('go env GOOS'), '\n', '', 'g')
+  return substitute(go#util#Exec(['go', 'env', 'GOOS'])[0], '\n', '', 'g')
 endfunction
 
 " goroot returns 'go env GOROOT'. This is an internal function and shouldn't
 " be used. Instead use 'go#util#env("goroot")'
 function! go#util#goroot() abort
-  return substitute(go#util#System('go env GOROOT'), '\n', '', 'g')
+  return substitute(go#util#Exec(['go', 'env', 'GOROOT'])[0], '\n', '', 'g')
 endfunction
 
 " gopath returns 'go env GOPATH'. This is an internal function and shouldn't
 " be used. Instead use 'go#util#env("gopath")'
 function! go#util#gopath() abort
-  return substitute(go#util#System('go env GOPATH'), '\n', '', 'g')
+  return substitute(go#util#Exec(['go', 'env', 'GOPATH'])[0], '\n', '', 'g')
 endfunction
 
 function! go#util#osarch() abort

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -162,7 +162,12 @@ function! go#util#Exec(cmd, ...) abort
     return ['', 1]
   endif
 
-  let l:out = call('s:system', [go#util#Shelljoin([l:bin] + a:cmd[1:])] + a:000)
+  let l:cmd = go#util#Shelljoin([l:bin] + a:cmd[1:])
+  if go#util#HasDebug('shell-commands')
+    call go#util#EchoInfo('shell command: ' . l:cmd)
+  endif
+
+  let l:out = call('s:system', [l:cmd] + a:000)
   return [l:out, go#util#ShellError()]
 endfunction
 

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -93,25 +93,25 @@ endfunction
 " goarch returns 'go env GOARCH'. This is an internal function and shouldn't
 " be used. Instead use 'go#util#env("goarch")'
 function! go#util#goarch() abort
-  return substitute(go#util#Exec(['go', 'env', 'GOARCH'])[0], '\n', '', 'g')
+  return substitute(s:exec(['go', 'env', 'GOARCH'])[0], '\n', '', 'g')
 endfunction
 
 " goos returns 'go env GOOS'. This is an internal function and shouldn't
 " be used. Instead use 'go#util#env("goos")'
 function! go#util#goos() abort
-  return substitute(go#util#Exec(['go', 'env', 'GOOS'])[0], '\n', '', 'g')
+  return substitute(s:exec(['go', 'env', 'GOOS'])[0], '\n', '', 'g')
 endfunction
 
 " goroot returns 'go env GOROOT'. This is an internal function and shouldn't
 " be used. Instead use 'go#util#env("goroot")'
 function! go#util#goroot() abort
-  return substitute(go#util#Exec(['go', 'env', 'GOROOT'])[0], '\n', '', 'g')
+  return substitute(s:exec(['go', 'env', 'GOROOT'])[0], '\n', '', 'g')
 endfunction
 
 " gopath returns 'go env GOPATH'. This is an internal function and shouldn't
 " be used. Instead use 'go#util#env("gopath")'
 function! go#util#gopath() abort
-  return substitute(go#util#Exec(['go', 'env', 'GOPATH'])[0], '\n', '', 'g')
+  return substitute(s:exec(['go', 'env', 'GOPATH'])[0], '\n', '', 'g')
 endfunction
 
 function! go#util#osarch() abort
@@ -158,15 +158,17 @@ function! go#util#Exec(cmd, ...) abort
 
   let l:bin = a:cmd[0]
 
-  " Don't run CheckBinPath for "go" to prevent infinite recursion.
-  if a:cmd[0] != 'go'
-    " CheckBinPath will show a warning for us.
-    let l:bin = go#path#CheckBinPath(l:bin)
-    if empty(l:bin)
-      return ['', 1]
-    endif
+  " CheckBinPath will show a warning for us.
+  let l:bin = go#path#CheckBinPath(l:bin)
+  if empty(l:bin)
+    return ['', 1]
   endif
 
+  return call('s:exec', [a:cmd] + a:000)
+endfunction
+
+function! s:exec(cmd, ...) abort
+  let l:bin = a:cmd[0]
   let l:cmd = go#util#Shelljoin([l:bin] + a:cmd[1:])
   if go#util#HasDebug('shell-commands')
     call go#util#EchoInfo('shell command: ' . l:cmd)

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -153,13 +153,13 @@ endfunction
 function! go#util#Exec(cmd, ...) abort
   if len(a:cmd) == 0
     call go#util#EchoError("go#util#Exec() called with empty a:cmd")
-    return
+    return ['', 1]
   endif
 
   " CheckBinPath will show a warning for us.
   let l:bin = go#path#CheckBinPath(a:cmd[0])
   if empty(l:bin)
-    return ["", 1]
+    return ['', 1]
   endif
 
   let l:out = call('s:system', [go#util#Shelljoin([l:bin] + a:cmd[1:])] + a:000)

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1681,6 +1681,8 @@ A list of options to debug; useful for development and/or reporting bugs.
 
 Currently accepted values:
 
+  shell-commands     Echo all shell commands that vim-go runs (does not
+                     include async jobs).
   debugger-state     Expose debugger state in 'g:go_debug_diag'.
   debugger-commands  Echo communication between vim-go and `dlv`; requests and
                      responses are recorded in `g:go_debug_commands`.

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -124,7 +124,11 @@ function! s:GoInstallBinaries(updateBinaries, ...)
 
   for [binary, pkg] in items(l:packages)
     let l:importPath = pkg[0]
-    let l:goGetFlags = len(pkg) > 1 ? get(pkg[1], l:platform, '') : ''
+
+    let l:run_cmd = l:cmd
+    if len(l:pkg) > 1 && get(l:pkg[1], l:platform, '') isnot ''
+      let l:run_cmd += get(l:pkg[1], l:platform, '')
+    endif
 
     let binname = "go_" . binary . "_bin"
 
@@ -140,9 +144,9 @@ function! s:GoInstallBinaries(updateBinaries, ...)
         echo "vim-go: ". binary ." not found. Installing ". importPath . " to folder " . go_bin_path
       endif
 
-      let [l:out, l:err] = go#util#Exec(l:cmd + [l:goGetFlags, l:importPath)
+      let [l:out, l:err] = go#util#Exec(l:run_cmd + [l:importPath])
       if l:err
-        echom "Error installing " . importPath . ": " . out
+        echom "Error installing " . l:importPath . ": " . l:out
       endif
     endif
   endfor

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -97,16 +97,9 @@ function! s:GoInstallBinaries(updateBinaries, ...)
     set noshellslash
   endif
 
-  let cmd = "go get -v "
+  let l:cmd = ['go', 'get', '-v']
   if get(g:, "go_get_update", 1) != 0
-    let cmd .= "-u "
-  endif
-
-  let s:go_version = matchstr(go#util#System("go version"), '\d.\d.\d')
-
-  " https://github.com/golang/go/issues/10791
-  if s:go_version > "1.4.0" && s:go_version < "1.5.0"
-    let cmd .= "-f "
+    let l:cmd += ['-u']
   endif
 
   " Filter packages from arguments (if any).
@@ -147,8 +140,8 @@ function! s:GoInstallBinaries(updateBinaries, ...)
         echo "vim-go: ". binary ." not found. Installing ". importPath . " to folder " . go_bin_path
       endif
 
-      let out = go#util#System(printf('%s %s %s', cmd, l:goGetFlags, shellescape(importPath)))
-      if go#util#ShellError() != 0
+      let [l:out, l:err] = go#util#Exec(l:cmd + [l:goGetFlags, l:importPath)
+      if l:err
         echom "Error installing " . importPath . ": " . out
       endif
     endif


### PR DESCRIPTION
Fixes #1766; Fixes #1767

Using `-tags ''` is valid in pretty much all commands, but due to inconsistent ad-hoc application of shell escaping empty tags sometimes wouldn't get passed correctly.

The solution is to use `go#util#Exec()`, which handles this for us.

This will also fix issues with multiple build tags set (e.g. `let g:go_build_tags = 'aa bb'`).