### PR TITLE
Go spec snippets

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -189,47 +189,220 @@ snippet ta "type assertion"
 ${1:x}, ok := ${2:y}.(${3:type})
 endsnippet
 
-# anonymous function
-snippet anon "fn := func() { ... }"
-${1:fn} := func() {
-	${2:${VISUAL}}
+# Statements
+## panic
+snippet pn "panic()"
+panic("${0:msg}")
+endsnippet
+
+## Send Statements
+snippet send "send value onto channel"
+${1:ch} <- ${2:${VISUAL}}
+endsnippet
+
+## IncDec statements
+snippet inc "increment variable"
+${1:${VISUAL:x}} += ${2:1}
+endsnippet
+
+snippet dec "increment variable"
+${1:${VISUAL:x}} -= ${2:1}
+endsnippet
+
+## Assignment Statements
+snippet = "sets variable equal to operand"
+${1} = ${2}
+endsnippet
+
+snippet =t "tuple assignment"
+${1:x}, ${2:y} = ${3:${VISUAL}}
+endsnippet
+
+snippet =b "set blank"
+_ = ${1:${VISUAL}}
+endsnippet
+
+snippet =bte "blank error in tuple return"
+${1:x}, _ = ${2:${VISUAL}}
+endsnippet
+
+snippet =x "swap variables"
+${1:a}, ${2:b} = $2, $1
+endsnippet
+
+## If Statements
+snippet if "if ... { ... }"
+if ${1:condition} {
+	${0:${VISUAL}}
+}
+endsnippet
+
+snippet If "if statement"
+if ${1:x} ${2:=} ${3:y} {
+	${4:action}
 }
 ${0}
 endsnippet
 
-# append
-snippet ap "append(slice, value)"
-append(${1:slice}, ${0:value})
+snippet ife "if statement with expression"
+if ${1:x} := ${2:f()}; $1 ${3: > y} {
+	${4:action}
+}
+${0}
 endsnippet
 
-# append assignment
-snippet ap= "a = append(a, value)"
-${1:slice} = append($1, ${0:value})
+# else snippet
+snippet else
+else {
+	${0:${VISUAL}}
+}
 endsnippet
 
-# break
-snippet br "break"
-break
+## Switch Statements
+snippet switch "bare switch statement"
+switch {
+case ${1:condition}:
+	${2:action}	
+}
+${0}
+endsnippet 
+
+snippet switchv "switch on a variable"
+switch ${1:x} {
+default:
+	${2:action}
+case ${3:y}:
+	${4:action}
+}
+${0}
 endsnippet
 
-# case
-snippet case "case ...:"
+snippet switchi "switch on variable with initializer"
+switch ${1:x} := ${2:fn()}; $1 {
+case ${3:x}:
+	${4:action}
+}
+${0}
+endsnippet
+
+snippet tswitch "type switch"
+switch ${1:x} := ${2:y}.(type) {
+case ${3:z}:
+	${4:action}
+}
+${0}
+endsnippet
+
+snippet case "case entry"
 case ${1:value}:
 	${0:${VISUAL}}
 endsnippet
 
-# continue
-snippet cn "continue"
-continue
-endsnippet
-
-# default case
-snippet default "default: ..."
+snippet cde "case default entry"
 default:
 	${0:${VISUAL}}
 endsnippet
 
-# defer
+## For statements
+snippet for "for ... { ... }"
+for ${1} {
+	${2:${VISUAL:action}}
+}
+${0}
+endsnippet
+
+# for integer loop
+snippet fori "for 0..N-1 { ... }"
+for ${1:i} := 0; $1 < ${2:N}; $1++ {
+	${3:${VISUAL:action}}
+}
+${0}
+endsnippet
+
+snippet forc "for with a condition"
+for ${1:x} ${2:=} ${3:x} {
+	${4:${VISUAL:action}}
+}
+${0}
+endsnippet
+
+snippet forcc "for with a for clause"
+for ${1:i} := ${2:0}; ${3:$1} ${4:<} ${5:y}; ${6:i++} { 
+	${7:${VISUAL:action}}
+}
+${0}
+endsnippet
+
+snippet forr "for with a range statement"
+for ${1:i}, ${2:x} := range ${3:y} {
+	${4:${VISUAL:action}}
+}
+${0}
+endsnippet
+
+snippet Forr "for k, v := range items { ... }"
+for ${2:k}, ${3:v} := range ${1} {
+	${4:${VISUAL:action}}
+}
+${0}
+endsnippet
+
+## Go statements
+snippet g "go statement"
+go ${1:x}
+endsnippet
+
+snippet go "go someFunc(...)"
+go ${1:funcName}(${0})
+endsnippet
+
+snippet gof "go func() { ... }()"
+go func() {
+	${1:${VISUAL}}
+}()
+${0}
+endsnippet
+
+## Select statements
+snippet select "select statement"
+select {
+case ${1:x} ${2::=} ${3:<-}${4:c}:
+	${5:action}
+}
+${0}
+endsnippet
+
+snippet scase "select case entry"
+case ${1:x} ${2:<-} ${3:y}:
+	${4:action}
+endsnippet
+
+## Return statements
+snippet rt "return"
+return ${0:${VISUAL}}
+endsnippet
+
+## Break statements
+snippet br "break"
+break
+endsnippet
+
+## Continue statements
+snippet cn "continue"
+continue
+endsnippet
+
+## Goto statements
+snippet gt "goto"
+goto ${1:x}
+endsnippet
+
+## Fallthrough Statements
+snippet ft "fallthrough"
+fallthrough
+endsnippet
+
+## Defer statements
 snippet df "defer someFunction()"
 defer ${1:func}(${2})
 ${0}
@@ -248,6 +421,24 @@ defer func() {
 		${0:${VISUAL}}
 	}
 }()
+endsnippet
+
+# anonymous function
+snippet anon "fn := func() { ... }"
+${1:fn} := func() {
+	${2:${VISUAL}}
+}
+${0}
+endsnippet
+
+# append
+snippet ap "append(slice, value)"
+append(${1:slice}, ${0:value})
+endsnippet
+
+# append assignment
+snippet ap= "a = append(a, value)"
+${1:slice} = append($1, ${0:value})
 endsnippet
 
 # gpl
@@ -276,20 +467,6 @@ snippet import "import ( ... )"
 import (
 	"${1:package}"
 )
-endsnippet
-
-# if condition
-snippet if "if ... { ... }"
-if ${1:condition} {
-	${0:${VISUAL}}
-}
-endsnippet
-
-# else snippet
-snippet else
-else {
-	${0:${VISUAL}}
-}
 endsnippet
 
 # if inline error
@@ -358,32 +535,6 @@ snippet yaml "\`yaml:key\`"
 \`yaml:"${1:`!v  go#util#snippetcase(matchstr(getline("."), '\w\+'))`}"\`
 endsnippet
 
-# fallthrough
-snippet ft "fallthrough"
-fallthrough
-endsnippet
-
-# for loop
-snippet for "for ... { ... }"
-for ${1} {
-	${0:${VISUAL}}
-}
-endsnippet
-
-# for integer loop
-snippet fori "for 0..N-1 { ... }"
-for ${1:i} := 0; $1 < ${2:N}; $1++ {
-	${0:${VISUAL}}
-}
-endsnippet
-
-# for range loop
-snippet forr "for k, v := range items { ... }"
-for ${2:k}, ${3:v} := range ${1} {
-	${0:${VISUAL}}
-}
-endsnippet
-
 # Fmt Printf debug
 snippet ff "fmt.Printf(...)"
 fmt.Printf("${1:${VISUAL}} = %+v\n", $1)
@@ -435,48 +586,9 @@ package ${1:main}
 ${0}
 endsnippet
 
-# panic
-snippet pn "panic()"
-panic("${0:msg}")
-endsnippet
-
-# return
-snippet rt "return"
-return ${0:${VISUAL}}
-endsnippet
-
-# select
-snippet select "select { case a := <-chan: ... }"
-select {
-case ${1:v1} := <-${2:chan1}
-	${0}
-}
-endsnippet
-
-# switch
-snippet switch "switch x { ... }"
-switch ${1:var} {
-case ${2:value1}:
-	${0}
-}
-endsnippet
-
 # sprintf
 snippet sp "fmt.Sprintf(...)"
 fmt.Sprintf("%${1:s}", ${2:var})
-endsnippet
-
-# goroutine named function
-snippet go "go someFunc(...)"
-go ${1:funcName}(${0})
-endsnippet
-
-# goroutine anonymous function
-snippet gof "go func() { ... }()"
-go func() {
-	${1:${VISUAL}}
-}()
-${0}
 endsnippet
 
 # test function

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -139,6 +139,16 @@ snippet : "short variable definition"
 ${1:x} := ${2:y}
 endsnippet
 
+snippet var "var x Type [= ...]"
+var ${1:x} ${2:Type}${3: = ${0:value}}
+endsnippet
+
+snippet vars "var ( ... )"
+var (
+	${1:x} ${2:Type}${3: = ${0:value}}
+)
+endsnippet
+
 ## Function declarations
 snippet func "func Function(...) [error] { ... }"
 func ${1:name}(${2:params})${3/(.+)/ /}`!p opening_par(snip, 3)`$3`!p closing_par(snip, 3)` {
@@ -709,18 +719,6 @@ func Benchmark${1:Method}(b *testing.B) {
 		${0:${VISUAL}}
 	}
 }
-endsnippet
-
-# variable declaration
-snippet var "var x Type [= ...]"
-var ${1:x} ${2:Type}${3: = ${0:value}}
-endsnippet
-
-# variables declaration
-snippet vars "var ( ... )"
-var (
-	${1:x} ${2:Type}${3: = ${0:value}}
-)
 endsnippet
 
 # equals fails the test if exp is not equal to act.

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -449,6 +449,101 @@ snippet del "delete a map element"
 delete(${1:map}, ${2:key})
 endsnippet
 
+# Errors
+snippet errn "Error return " !b
+if err != nil {
+	return ${1:err}
+}
+${0}
+endsnippet
+
+snippet err "if err != nil; return" 
+if err != nil {
+	return ${1:err}
+}
+${0}
+endsnippet
+
+snippet errn, "Error return with two return values" !b
+if err != nil {
+	return ${1:nil}, ${2:err}
+}
+${0}
+endsnippet
+
+snippet err, "Error return with two return values" !b
+if err != nil {
+	return ${1:nil}, ${2:err}
+}
+${0}
+endsnippet
+
+snippet errf "if err != nil; return formatted"
+if err != nil {
+	return fmt.Errorf(${1:err})
+}
+${0}
+endsnippet
+
+snippet errh  "if err != nil; handle and return"
+if err != nil {
+	${1:action}
+	return ${1:err}
+}
+${0}
+endsnippet
+
+snippet errhf "if err != nil; handle and return formatted"
+if err != nil {
+	${1:action}
+	return fmt.Errorf(${1:err})
+}
+${0}
+endsnippet
+
+snippet errl "if err != nil; log and return"
+if err != nil {
+	log.Println(${1:err})
+	return ${2:err}
+}
+${0}
+endsnippet
+
+snippet errlf "if err != nil; log and return"
+if err != nil {
+	log.Printf(${1:err})
+	return ${2:err}
+}
+${0}
+endsnippet
+
+snippet errlF "Error with log.Fatal(err)" !b
+if err != nil {
+	log.Fatal(err)
+}
+${0}
+endsnippet
+
+snippet ife "If with inline erro"
+if err := ${1:condition}; err != nil {
+	${0:${VISUAL}}
+}
+endsnippet
+
+snippet errp "Error panic" !b
+if err != nil {
+	panic(${1})
+}
+${0}
+endsnippet
+
+snippet errt "Error test fatal " !b
+if err != nil {
+	t.Fatal(err)
+}
+${0}
+endsnippet
+
 # anonymous function
 snippet anon "fn := func() { ... }"
 ${1:fn} := func() {
@@ -483,62 +578,6 @@ snippet import "import ( ... )"
 import (
 	"${1:package}"
 )
-endsnippet
-
-# if inline error
-snippet ife "If with inline erro"
-if err := ${1:condition}; err != nil {
-	${0:${VISUAL}}
-}
-endsnippet
-
-# error snippet
-snippet errn "Error return " !b
-if err != nil {
-	return err
-}
-${0}
-endsnippet
-
-# error log snippet
-snippet errl "Error with log.Fatal(err)" !b
-if err != nil {
-	log.Fatal(err)
-}
-${0}
-endsnippet
-
-# error multiple return
-snippet errn, "Error return with two return values" !b
-if err != nil {
-	return ${1:nil}, ${2:err}
-}
-${0}
-endsnippet
-
-# error panic
-snippet errp "Error panic" !b
-if err != nil {
-	panic(${1})
-}
-${0}
-endsnippet
-
-# error test
-snippet errt "Error test fatal " !b
-if err != nil {
-	t.Fatal(err)
-}
-${0}
-endsnippet
-
-# error handle
-snippet errh "Error handle and return" !b
-if err != nil {
-	${1}
-	return
-}
-${0}
 endsnippet
 
 # json field tag

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -639,7 +639,8 @@ if err != nil {
 }
 endsnippet
 
-# anonymous function
+# Misc.
+
 # gpl
 snippet gpl
 /*

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -85,9 +85,75 @@ snippet schan "send only channel"
 chan<- ${1:type}
 endsnippet
 
-# shorthand variable declaration
-snippet : "v := value"
-${1} := ${0}
+# Declarations and scope
+
+## Constant declarations
+snippet con "constant declaration"
+const ${1:NAME} ${2:Type} = ${0:0}
+endsnippet
+
+snippet cons "aggregate constants declaration"
+const (
+	${1:NAME} ${2:Type} = ${3:value}
+	${0}
+)
+endsnippet
+
+snippet cone "constant declaration entry"
+${1:name} ${2:type} = ${3:value}
+endsnippet
+
+## Iota
+snippet iota "const with iota"
+const (
+	${1:NAME} ${2:Type} = iota
+	${0}
+)
+endsnippet
+
+## Type declarations
+snippet typea "type alias declaration"
+type (
+	${1:alias} = ${2:type}
+)
+${0}
+endsnippet
+
+snippet typeae "type alias entry"
+${1:alias} = ${2:type}
+endsnippet
+
+snippet typed "type definition declaration"
+type (
+	${1:identifier} ${2:type}
+)
+${0}
+endsnippet
+
+snippet typede "type definition entry"
+${1:identifier} ${2:type}
+endsnippet 
+
+## Variable declarations
+snippet : "short variable definition"
+${1:x} := ${2:y}
+endsnippet
+
+## Function declarations
+snippet func "func Function(...) [error] { ... }"
+func ${1:name}(${2:params})${3/(.+)/ /}`!p opening_par(snip, 3)`$3`!p closing_par(snip, 3)` {
+	${0:${VISUAL}}
+}
+${0}
+endsnippet
+
+
+## Method Declarations
+snippet meth "func (self Type) Method(...) [error] { ... }"
+func (${1:receiver} ${2:type}) ${3:name}(${4:params})${5/(.+)/ /}`!p opening_par(snip, 5)`$5`!p closing_par(snip, 5)` {
+	${0:${VISUAL}}
+}
+${0}
 endsnippet
 
 # anonymous function
@@ -117,27 +183,6 @@ endsnippet
 snippet case "case ...:"
 case ${1:value}:
 	${0:${VISUAL}}
-endsnippet
-
-# constant
-snippet con "const XXX Type = ..."
-const ${1:NAME} ${2:Type} = ${0:0}
-endsnippet
-
-# constants
-snippet cons "const ( ... )"
-const (
-	${1:NAME} ${2:Type} = ${3:value}
-	${0}
-)
-endsnippet
-
-# constants with iota
-snippet iota "const ( ... = iota )"
-const (
-	${1:NAME} ${2:Type} = iota
-	${0}
-)
 endsnippet
 
 # continue
@@ -306,13 +351,6 @@ for ${2:k}, ${3:v} := range ${1} {
 }
 endsnippet
 
-# function
-snippet func "func Function(...) [error] { ... }"
-func ${1:name}(${2:params})${3/(.+)/ /}`!p opening_par(snip, 3)`$3`!p closing_par(snip, 3)` {
-	${0:${VISUAL}}
-}
-endsnippet
-
 # Fmt Printf debug
 snippet ff "fmt.Printf(...)"
 fmt.Printf("${1:${VISUAL}} = %+v\n", $1)
@@ -346,13 +384,6 @@ endsnippet
 # main()
 snippet main "func main() { ... }"
 func main() {
-	${0:${VISUAL}}
-}
-endsnippet
-
-# method
-snippet meth "func (self Type) Method(...) [error] { ... }"
-func (${1:receiver} ${2:type}) ${3:name}(${4:params})${5/(.+)/ /}`!p opening_par(snip, 5)`$5`!p closing_par(snip, 5)` {
 	${0:${VISUAL}}
 }
 endsnippet

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -2,6 +2,89 @@
 
 priority -10
 
+# Types
+snippet type "aggregate type definition"
+type (
+	${1:A} ${2:type}
+)
+endsnippet
+
+## Boolean types
+snippet t "true"
+true
+endsnippet
+
+snippet f "false"
+false
+endsnippet
+
+## Array types
+snippet a "array type"
+[${1:}]${2:type}
+endsnippet
+
+snippet al "array literal"
+[${1:}]${2:type}{${3:values}}
+endsnippet
+
+## Slice types
+snippet s "slice type"
+[]${1:type}
+endsnippet
+
+snippet sl "slice literal"
+[]${1:type}{${2:values}}
+endsnippet
+
+## Struct types
+snippet st "struct type" 
+struct {
+	${1:field} ${2:type}
+}
+${0}
+endsnippet
+
+snippet std "struct type with definition"
+type ${1:Type} struct {
+	${1:field} ${2:type}
+}
+${0}
+endsnippet
+
+snippet ste "struct entry"
+${1:field} ${2:type}
+endsnippet
+
+## Function types
+snippet fn "function type"
+func(${1:arguments}) ${2:returned}
+endsnippet
+
+## Interface types
+snippet interface "interface I { ... }"
+type ${1:Interface} interface {
+	${2:/* TODO: add methods */}
+}
+endsnippet
+
+## Map types
+snippet map "map type"
+map[${1:type}]${2:type}
+endsnippet
+
+## Channel types
+snippet chan "channel type"
+chan ${1:type}
+endsnippet
+
+snippet rchan "recieve only channel"
+<-chan ${1:type}
+endsnippet
+
+snippet schan "send only channel"
+chan<- ${1:type}
+endsnippet
+
 # shorthand variable declaration
 snippet : "v := value"
 ${1} := ${0}
@@ -28,11 +111,6 @@ endsnippet
 # break
 snippet br "break"
 break
-endsnippet
-
-# channel
-snippet ch "chan Type"
-chan ${0:int}
 endsnippet
 
 # case
@@ -120,13 +198,6 @@ snippet import "import ( ... )"
 import (
 	"${1:package}"
 )
-endsnippet
-
-# full interface snippet
-snippet interface "interface I { ... }"
-type ${1:Interface} interface {
-	${2:/* TODO: add methods */}
-}
 endsnippet
 
 # if condition
@@ -272,11 +343,6 @@ snippet make "make(Type, size)"
 make(${1:[]string}, ${2:0})${0}
 endsnippet
 
-# map
-snippet map "map[Type]Type"
-map[${1:string}]${0:int}
-endsnippet
-
 # main()
 snippet main "func main() { ... }"
 func main() {
@@ -320,13 +386,6 @@ snippet select "select { case a := <-chan: ... }"
 select {
 case ${1:v1} := <-${2:chan1}
 	${0}
-}
-endsnippet
-
-# struct
-snippet st "type T struct { ... }"
-type ${1:Type} struct {
-${0}
 }
 endsnippet
 

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -544,6 +544,47 @@ if err != nil {
 ${0}
 endsnippet
 
+# Printing and Logging
+snippet ffd "fmt.Printf(...) dynamically for debugging"
+fmt.Printf("${1:${VISUAL}} = %+v\n", $1)
+endsnippet
+
+snippet pf "fmt.Printf"
+fmt.Printf(${1:args})
+endsnippet
+
+snippet pl "fmt.Println"
+fmt.Println(${1:args})
+endsnippet
+
+snippet fn "fmt.Println(...)"
+fmt.Println("${1:${VISUAL}}")
+endsnippet
+
+snippet lfd "log.Printf(...) dynamically for debugging"
+log.Printf("${1:${VISUAL}} = %+v\n", $1)
+endsnippet
+
+snippet lf "log.Printf"
+log.Printf(${1:args})
+endsnippet
+
+snippet ln "log.Println(...)"
+log.Println("${1:${VISUAL:args}}")
+endsnippet
+
+snippet ll "log.Println(...)"
+log.Println("${1:${VISUAL:args}}")
+endsnippet
+
+snippet fe "fmt.Errorf(...)"
+fmt.Errorf("${1:${VISUAL}}")
+endsnippet
+
+snippet sp "fmt.Sprintf(...)"
+fmt.Sprintf("%${1:s}", ${2:var})
+endsnippet
+
 # anonymous function
 snippet anon "fn := func() { ... }"
 ${1:fn} := func() {
@@ -590,31 +631,6 @@ snippet yaml "\`yaml:key\`"
 \`yaml:"${1:`!v  go#util#snippetcase(matchstr(getline("."), '\w\+'))`}"\`
 endsnippet
 
-# Fmt Printf debug
-snippet ff "fmt.Printf(...)"
-fmt.Printf("${1:${VISUAL}} = %+v\n", $1)
-endsnippet
-
-# Fmt Println debug
-snippet fn "fmt.Println(...)"
-fmt.Println("${1:${VISUAL}}")
-endsnippet
-
-# Fmt Errorf debug
-snippet fe "fmt.Errorf(...)"
-fmt.Errorf("${1:${VISUAL}}")
-endsnippet
-
-# log printf
-snippet lf "log.Printf(...)"
-log.Printf("${1:${VISUAL}} = %+v\n", $1)
-endsnippet
-
-# log println
-snippet ln "log.Println(...)"
-log.Println("${1:${VISUAL}}")
-endsnippet
-
 # main()
 snippet main "func main() { ... }"
 func main() {
@@ -634,11 +650,6 @@ snippet package "package ..."
 // Package $1 provides ${2:...}
 package ${1:main}
 ${0}
-endsnippet
-
-# sprintf
-snippet sp "fmt.Sprintf(...)"
-fmt.Sprintf("%${1:s}", ${2:var})
 endsnippet
 
 # test function

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -147,13 +147,46 @@ func ${1:name}(${2:params})${3/(.+)/ /}`!p opening_par(snip, 3)`$3`!p closing_pa
 ${0}
 endsnippet
 
-
 ## Method Declarations
 snippet meth "func (self Type) Method(...) [error] { ... }"
 func (${1:receiver} ${2:type}) ${3:name}(${4:params})${5/(.+)/ /}`!p opening_par(snip, 5)`$5`!p closing_par(snip, 5)` {
 	${0:${VISUAL}}
 }
 ${0}
+endsnippet
+
+# Expressions
+
+## composite literals
+snippet cmpl "composite literal expression"
+${1:x} := ${2:type}{${3}}
+endsnippet
+
+snippet cmplp "composite literal pointer expression"
+${1:x} := &${2:type}{${3}}
+endsnippet 
+
+## function litearls
+snippet funcl "composite literal function (anonymous function)"
+func(${1:args}) ${2:returned} {
+	${4:action}
+}
+${0}
+endsnippet 
+
+## simple slice expression
+snippet ss "simple slice expression"
+${1:x}[${2:low} : ${3:high}]
+endsnippet
+
+## full slice expression
+snippet fs "full slice expression"
+${1:x}[${2:low} : ${3:high} : ${4:max}]
+endsnippet
+
+## type assertion
+snippet ta "type assertion"
+${1:x}, ok := ${2:y}.(${3:type})
 endsnippet
 
 # anonymous function

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -608,6 +608,37 @@ snippet sp "fmt.Sprintf(...)"
 fmt.Sprintf("%${1:s}", ${2:var})
 endsnippet
 
+# Testing
+snippet test "func TestXYZ(t *testing.T) { ... }"
+func Test${1:Function}(t *testing.T) {
+	${0:${VISUAL}}
+}
+endsnippet
+
+### quick test server
+snippet tsrv "httptest.NewServer"
+ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, ${1:`response`})
+}))
+defer ts.Close()
+
+${0:someUrl} = ts.URL
+endsnippet
+
+### test error handling
+snippet ter "if err != nil { t.Errorf(...) }"
+if err != nil {
+	t.Errorf("${0:message}")
+}
+endsnippet
+
+### test fatal error
+snippet terf "if err != nil { t.Fatalf(...) }"
+if err != nil {
+	t.Fatalf("${0:message}")
+}
+endsnippet
+
 # anonymous function
 # gpl
 snippet gpl
@@ -661,13 +692,6 @@ package ${1:main}
 ${0}
 endsnippet
 
-# test function
-snippet test "func TestXYZ(t *testing.T) { ... }"
-func Test${1:Function}(t *testing.T) {
-	${0:${VISUAL}}
-}
-endsnippet
-
 snippet hf "http.HandlerFunc" !b
 func ${1:handler}(w http.ResponseWriter, r *http.Request) {
 	${0:fmt.Fprintf(w, "hello world")}
@@ -678,30 +702,6 @@ snippet hhf "mux.HandleFunc" !b
 ${1:http}.HandleFunc("${2:/}", func(w http.ResponseWriter, r *http.Request) {
 	${0:fmt.Fprintf(w, "hello world")}
 })
-endsnippet
-
-# quick test server
-snippet tsrv "httptest.NewServer"
-ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintln(w, ${1:`response`})
-}))
-defer ts.Close()
-
-${0:someUrl} = ts.URL
-endsnippet
-
-# test error handling
-snippet ter "if err != nil { t.Errorf(...) }"
-if err != nil {
-	t.Errorf("${0:message}")
-}
-endsnippet
-
-# test fatal error
-snippet terf "if err != nil { t.Fatalf(...) }"
-if err != nil {
-	t.Fatalf("${0:message}")
-}
 endsnippet
 
 snippet example "func ExampleXYZ() { ... }"

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -174,6 +174,14 @@ func(${1:args}) ${2:returned} {
 ${0}
 endsnippet 
 
+snippet anon "fn := func() { ... }"
+${1:fn} := func(${2:}) {
+	${3:${VISUAL}}
+}
+${0}
+endsnippet
+
+
 ## simple slice expression
 snippet ss "simple slice expression"
 ${1:x}[${2:low} : ${3:high}]
@@ -586,13 +594,6 @@ fmt.Sprintf("%${1:s}", ${2:var})
 endsnippet
 
 # anonymous function
-snippet anon "fn := func() { ... }"
-${1:fn} := func() {
-	${2:${VISUAL}}
-}
-${0}
-endsnippet
-
 # gpl
 snippet gpl
 /*

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -269,7 +269,12 @@ if ${1:x} := ${2:f()}; $1 ${3: > y} {
 ${0}
 endsnippet
 
-# else snippet
+snippet ok "if !ok { ... }"
+if !ok {
+	${0:${VISUAL}}
+}
+endsnippet
+
 snippet else
 else {
 	${0:${VISUAL}}
@@ -645,13 +650,6 @@ endsnippet
 # main()
 snippet main "func main() { ... }"
 func main() {
-	${0:${VISUAL}}
-}
-endsnippet
-
-# ok
-snippet ok "if !ok { ... }"
-if !ok {
 	${0:${VISUAL}}
 }
 endsnippet

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -562,7 +562,14 @@ endsnippet
 
 snippet errt "Error test fatal " !b
 if err != nil {
-	t.Fatal(err)
+	t.Fatal(${1:err})
+}
+${0}
+endsnippet
+
+snippet errtf "Error test fatal " !b
+if err != nil {
+	t.Fatalf(${1:err})
 }
 ${0}
 endsnippet

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -511,7 +511,7 @@ endsnippet
 snippet errh  "if err != nil; handle and return"
 if err != nil {
 	${1:action}
-	return ${1:err}
+	return ${2:err}
 }
 ${0}
 endsnippet
@@ -519,7 +519,7 @@ endsnippet
 snippet errhf "if err != nil; handle and return formatted"
 if err != nil {
 	${1:action}
-	return fmt.Errorf(${1:err})
+	return fmt.Errorf(${2:err})
 }
 ${0}
 endsnippet

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -423,22 +423,38 @@ defer func() {
 }()
 endsnippet
 
+# Built-in functions
+snippet c "close"
+close(${1:args})
+endsnippet
+
+snippet mk "make"
+make(${1:args})
+endsnippet
+
+# make
+snippet make "make(Type, size)"
+make(${1:[]string}, ${2:0})${0}
+endsnippet
+
+snippet ap "append(slice, value)"
+append(${1:slice}, ${0:value})
+endsnippet
+
+snippet ap= "a = append(a, value)"
+${1:slice} = append($1, ${0:value})
+endsnippet
+
+snippet del "delete a map element"
+delete(${1:map}, ${2:key})
+endsnippet
+
 # anonymous function
 snippet anon "fn := func() { ... }"
 ${1:fn} := func() {
 	${2:${VISUAL}}
 }
 ${0}
-endsnippet
-
-# append
-snippet ap "append(slice, value)"
-append(${1:slice}, ${0:value})
-endsnippet
-
-# append assignment
-snippet ap= "a = append(a, value)"
-${1:slice} = append($1, ${0:value})
 endsnippet
 
 # gpl
@@ -558,11 +574,6 @@ endsnippet
 # log println
 snippet ln "log.Println(...)"
 log.Println("${1:${VISUAL}}")
-endsnippet
-
-# make
-snippet make "make(Type, size)"
-make(${1:[]string}, ${2:0})${0}
 endsnippet
 
 # main()


### PR DESCRIPTION
PR begins to create compossible snippets using the Go spec as reference. Idea is to have snippets be able to be nested when creating structure like Switches. For sample

```
switch<tab> creates

switch {
  case "somecase":
    someaction()
}
```
When inside this switch case doing the following creates another case statement

```
switch {
  case "somecase":
    someaction()
  case<tab>
}
```

There's still some snippets that need to be defined but the majority of the Go spec is accounted for.

One nasty issue is that SuperTab begins to evaluate gocode completion when inside brackets. So unfortunately this was not possible for me to do:

```
al\<tab\>

[]Bool{t\<tab\>, t\<tab\>}
```

We would expect t to expand to "true" however supertab kicks in with omni complete. Maybe this can be fixed by changing my trigger key for Utlisnips - not sure.