### PR TITLE
Highlight builtin functions as keywords

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -142,10 +142,9 @@ hi def link     goUnsignedInts      Type
 hi def link     goFloats            Type
 hi def link     goComplexes         Type
 
-
 " Predefined functions and values
-syn match       goBuiltins                 /\<\v(append|cap|close|complex|copy|delete|imag|len)\ze\(/
-syn match       goBuiltins                 /\<\v(make|new|panic|print|println|real|recover)\ze\(/
+syn keyword     goBuiltins                 append cap close complex copy delete imag len
+syn keyword     goBuiltins                 make new panic print println real recover
 syn keyword     goBoolean                  true false
 syn keyword     goPredefinedIdentifiers    nil iota
 


### PR DESCRIPTION
This was changed from keywords to the regexp in #605, but I think that
was a mistake.

If you do `new := "foo"` then this is perfectly valid Go, but I don't
think it's a bad think to add a reminder that you're actually overriding
a global built-in by highlighting the `new`, just as it's not a bad idea
to highlight the `new()` in `func new()` to serve as a similar reminder.

This is a common-ish mistake that most of us have probably made at least
once or twice.

The only case where this fails is in method declaration and calls:

    func () x new() {
        other.new()
    }

But this is the case with the current highlight as well, so it doesn't
make that worse.

CC @mmlb 