### PR TITLE
don't set tags on coverage when running synchronously

### DIFF
--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -58,7 +58,7 @@ function! go#coverage#Buffer(bang, ...) abort
     return
   endif
 
-  let args = [a:bang, 0, '-tags', go#config#BuildTags(), "-coverprofile", l:tmpname]
+  let args = [a:bang, 0, "-coverprofile", l:tmpname]
   if a:0
     call extend(args, a:000)
   endif


### PR DESCRIPTION
The synchronous code path for :GoCoverage deletegates to a function that
adds builds tags to the command line; adding the tags to the command to
be called causes an error.

Fixes #1784