### PR TITLE
Fix gohtmltmpl syntax to show everywhere

### DIFF
--- a/syntax/gohtmltmpl.vim
+++ b/syntax/gohtmltmpl.vim
@@ -10,6 +10,8 @@ runtime! syntax/gotexttmpl.vim
 runtime! syntax/html.vim
 unlet b:current_syntax
 
+syn cluster htmlPreproc add=gotplAction,goTplComment
+
 let b:current_syntax = "gohtmltmpl"
 
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
This change enable highlighting of `{{…}}` everywhere within html, for example in tags:
```html
<input type=checkbox {{ if .Check }}checked{{ end }} value="{{ .Value }}">
```