### PR TITLE
Improve performance of package comment regex

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -351,11 +351,11 @@ if go#config#HighlightBuildConstraints() || go#config#FoldEnable('package_commen
   " matched as comments to avoid looking like working build constraints.
   " The he, me, and re options let the "package" itself be highlighted by
   " the usual rules.
-  exe 'syn region  goPackageComment    start=/\v(\/\/.*\n)+\s*package/'
+  exe 'syn region  goPackageComment    start=/\v%^(\s*\n)*(\/\/.*\n)+\s*package/'
         \ . ' end=/\v\n\s*package/he=e-7,me=e-7,re=e-7'
         \ . ' contains=@goCommentGroup,@Spell'
         \ . (go#config#FoldEnable('package_comment') ? ' fold' : '')
-  exe 'syn region  goPackageComment    start=/\v\/\*.*\n(.*\n)*\s*\*\/\npackage/'
+  exe 'syn region  goPackageComment    start=/\v%^(\s*\n)*\/\*.*\n(.*\n)*\s*\*\/\npackage/'
         \ . ' end=/\v\*\/\n\s*package/he=e-7,me=e-7,re=e-7'
         \ . ' contains=@goCommentGroup,@Spell'
         \ . (go#config#FoldEnable('package_comment') ? ' fold' : '')

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -351,11 +351,11 @@ if go#config#HighlightBuildConstraints() || go#config#FoldEnable('package_commen
   " matched as comments to avoid looking like working build constraints.
   " The he, me, and re options let the "package" itself be highlighted by
   " the usual rules.
-  exe 'syn region  goPackageComment    start=/\v%^(\s*\n)*(\/\/.*\n)+\s*package/'
+  exe 'syn region  goPackageComment    start=/\v(\/\/.*\n)+\s*package/'
         \ . ' end=/\v\n\s*package/he=e-7,me=e-7,re=e-7'
         \ . ' contains=@goCommentGroup,@Spell'
         \ . (go#config#FoldEnable('package_comment') ? ' fold' : '')
-  exe 'syn region  goPackageComment    start=/\v%^(\s*\n)*\/\*.*\n(.*\n)*\s*\*\/\npackage/'
+  exe 'syn region  goPackageComment    start=/\v^\s*\/\*.*\n(.*\n)*\s*\*\/\npackage/'
         \ . ' end=/\v\*\/\n\s*package/he=e-7,me=e-7,re=e-7'
         \ . ' contains=@goCommentGroup,@Spell'
         \ . (go#config#FoldEnable('package_comment') ? ' fold' : '')


### PR DESCRIPTION
By anchoring to the start of the document (since that's the only place
a package comment will appear), the number of false matches is greatly
reduced in some files.

Fixes #1747