### PR TITLE
tell delve how to log

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -555,7 +555,7 @@ function! go#debug#Start(is_test, ...) abort
           \ '--output', tempname(),
           \ '--headless',
           \ '--api-version', '2',
-          \ '--log',
+          \ '--log', 'debugger',
           \ '--listen', go#config#DebugAddress(),
           \ '--accept-multiclient',
     \]


### PR DESCRIPTION
Delve changed the log flag from a boolean flag to a string flag in
derekparker/delve#1166.

Fixes #1805