### PR TITLE
gocode: Change repo from nsf/gocode to mdempsky/gocode

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -34,7 +34,7 @@ let s:packages = {
       \ 'dlv':           ['github.com/derekparker/delve/cmd/dlv'],
       \ 'errcheck':      ['github.com/kisielk/errcheck'],
       \ 'fillstruct':    ['github.com/davidrjenni/reftools/cmd/fillstruct'],
-      \ 'gocode':        ['github.com/nsf/gocode', {'windows': '-ldflags -H=windowsgui'}],
+      \ 'gocode':        ['github.com/mdempsky/gocode', {'windows': '-ldflags -H=windowsgui'}],
       \ 'godef':         ['github.com/rogpeppe/godef'],
       \ 'gogetdoc':      ['github.com/zmb3/gogetdoc'],
       \ 'goimports':     ['golang.org/x/tools/cmd/goimports'],


### PR DESCRIPTION
Hi,

I noticed that recently nsf/gocode is no longer maintained (please see [notice at the top of README](https://github.com/nsf/gocode#an-autocompletion-daemon-for-the-go-programming-language)). And now [mdempsky/gocode](https://github.com/mdempsky/gocode) is an official active repository of gocode.

So I think vim-go should use the new repository for now. This PR only changes the repository URL in vim-go repository.

Please note that it's not straightforward to change the URL because the new repo only supports Go 1.10+. What do you think, @fatih?