### PR TITLE
Handle test compilation errors

### DIFF
--- a/autoload/go/test-fixtures/test/src/testcompilerror/testcompilerror_test.go
+++ b/autoload/go/test-fixtures/test/src/testcompilerror/testcompilerror_test.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func TestSomething(t *testing.T) {
+	r := struct{}{}
+	ioutil.ReadAll(r)
+}

--- a/autoload/go/test-fixtures/test/src/veterror/veterror.go
+++ b/autoload/go/test-fixtures/test/src/veterror/veterror.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Errorf("%v")
+}

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -303,6 +303,9 @@ function! s:errorformat() abort
   " match compiler errors
   let format = "%f:%l:%c: %m"
 
+  " match vet errors
+  let format .= ",%f:%l: %m"
+
   " ignore `go test -v` output for starting tests
   let format .= ",%-G=== RUN   %.%#"
   " ignore `go test -v` output for passing tests

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -300,14 +300,8 @@ function! s:errorformat() abort
   " (e.g. \%(\)).
   let indent = '%\\%(    %\\)%#'
 
-  " match compiler errors
-  let format = "%f:%l:%c: %m"
-
-  " match vet errors
-  let format .= ",%f:%l: %m"
-
   " ignore `go test -v` output for starting tests
-  let format .= ",%-G=== RUN   %.%#"
+  let format = "%-G=== RUN   %.%#"
   " ignore `go test -v` output for passing tests
   let format .= ",%-G" . indent . "--- PASS: %.%#"
 
@@ -418,6 +412,20 @@ function! s:errorformat() abort
   " panic stacktraces.
   let format .= ",%-CFAIL%\\t%.%#"
   "let format .= ",FAIL%\\t%.%#"
+
+  " match compiler errors
+  " These are very smilar to errors from test output, but lack leading tabs
+  " for the first line of an error, and subsequent lines only have one tab
+  " instead of two.
+  let format .= ",%A%f:%l:%c: %m"
+  let format .= ",%A%f:%l: %m"
+  " It would be nice if this weren't necessary, but panic lines from tests are
+  " prefixed with a single leading tab, making them very similar to 2nd and
+  " later lines of a multi-line compiler error. Swallow it so that it doesn't
+  " cause a quickfix entry since the next entry can add a quickfix entry for
+  " 2nd and later lines of a multi-line compiler error.
+  let format .= ",%-C%\\tpanic: %.%#"
+  let format .= ",%G%\\t%m"
 
   " Match and ignore everything else in multi-line messages.
   let format .= ",%-C%.%#"

--- a/autoload/go/test_test.vim
+++ b/autoload/go/test_test.vim
@@ -74,9 +74,18 @@ endfunc
 
 func! Test_GoTestVet() abort
   let expected = [
-        \ {'lnum': 6, 'bufnr': 14, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'Errorf format %v reads arg #1, but call has only 0 args'},
+        \ {'lnum': 6, 'bufnr': 16, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'Errorf format %v reads arg #1, but call has only 0 args'},
       \ ]
   call s:test('veterror/veterror.go', expected)
+endfunc
+
+func! Test_GoTestTestCompilerError() abort
+  let expected = [
+        \ {'lnum': 10, 'bufnr': 11, 'col': 16, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'cannot use r (type struct {}) as type io.Reader in argument to ioutil.ReadAll:'},
+        \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'struct {} does not implement io.Reader (missing Read method)'}
+      \ ]
+
+  call s:test('testcompilerror/testcompilerror_test.go', expected)
 endfunc
 
 func! s:test(file, expected, ...) abort

--- a/autoload/go/test_test.vim
+++ b/autoload/go/test_test.vim
@@ -72,6 +72,13 @@ func! Test_GoTestShowName() abort
   unlet g:go_test_show_name
 endfunc
 
+func! Test_GoTestVet() abort
+  let expected = [
+        \ {'lnum': 6, 'bufnr': 14, 'col': 0, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'Errorf format %v reads arg #1, but call has only 0 args'},
+      \ ]
+  call s:test('veterror/veterror.go', expected)
+endfunc
+
 func! s:test(file, expected, ...) abort
   if has('nvim')
     " nvim mostly shows test errors correctly, but the the expected errors are


### PR DESCRIPTION
Handle vet errors (usually only have a filename and line number, with not column number available) as well as multi-line compiler errors.

Fixes #1802 
