### PR TITLE
snippets: add trun -> t.Run()

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -363,6 +363,13 @@ func Test${1:Function}(t *testing.T) {
 }
 endsnippet
 
+# subtest
+snippet trun "t.Run(..., func(t *testing.T) { ... })"
+t.Run("${1:name}", func(t *testing.T) {
+	${0:${VISUAL}}
+})
+endsnippet
+
 snippet hf "http.HandlerFunc" !b
 func ${1:handler}(w http.ResponseWriter, r *http.Request) {
 	${0:fmt.Fprintf(w, "hello world")}

--- a/gosnippets/snippets/go.snip
+++ b/gosnippets/snippets/go.snip
@@ -315,6 +315,14 @@ abbr func TestXYZ(t *testing.T) { ... }
 	func Test${1:Function}(t *testing.T) {
 		${0}
 	}
+
+# subtest
+snippet trun
+abbr t.Run(..., func(t *testing.T) { ... })
+	t.Run("${1:name}", func(t *testing.T) {
+		${0}
+	})
+
 # test server
 snippet tsrv
 abbr ts := httptest.NewServer(...)


### PR DESCRIPTION
I tried an embarrasing number of guesses to find the snippet for 
```
t.Run("asdf", func(t *testing.T) {
})
```
before looking up the source and realizing it's missing.

This adds it!

Tested on ultisnips master.
Not tested on snipmate.