### PR TITLE
Fix flags for GoUpdateBinaries

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -125,7 +125,7 @@ function! s:GoInstallBinaries(updateBinaries, ...)
   for [binary, pkg] in items(l:packages)
     let l:importPath = pkg[0]
 
-    let l:run_cmd = l:cmd
+    let l:run_cmd = copy(l:cmd)
     if len(l:pkg) > 1 && get(l:pkg[1], l:platform, '') isnot ''
       let l:run_cmd += [get(l:pkg[1], l:platform, '')]
     endif

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -34,7 +34,7 @@ let s:packages = {
       \ 'dlv':           ['github.com/derekparker/delve/cmd/dlv'],
       \ 'errcheck':      ['github.com/kisielk/errcheck'],
       \ 'fillstruct':    ['github.com/davidrjenni/reftools/cmd/fillstruct'],
-      \ 'gocode':        ['github.com/mdempsky/gocode', {'windows': '-ldflags -H=windowsgui'}],
+      \ 'gocode':        ['github.com/mdempsky/gocode', {'windows': ['-ldflags', '-H=windowsgui']}],
       \ 'godef':         ['github.com/rogpeppe/godef'],
       \ 'gogetdoc':      ['github.com/zmb3/gogetdoc'],
       \ 'goimports':     ['golang.org/x/tools/cmd/goimports'],
@@ -127,7 +127,7 @@ function! s:GoInstallBinaries(updateBinaries, ...)
 
     let l:run_cmd = copy(l:cmd)
     if len(l:pkg) > 1 && get(l:pkg[1], l:platform, '') isnot ''
-      let l:run_cmd += [get(l:pkg[1], l:platform, '')]
+      let l:run_cmd += get(l:pkg[1], l:platform, '')
     endif
 
     let binname = "go_" . binary . "_bin"


### PR DESCRIPTION
This commits fixes errors of `GoUpdateBinaries` command on Windows.

Before these commits, the following errors occurred when `GoUpdateBinaries` was executed.

```
vim-go: Updating gogetdoc. Reinstalling github.com/zmb3/gogetdoc to folder C:\Users\blyoa\go\bin\
vim-go: Updating guru. Reinstalling golang.org/x/tools/cmd/guru to folder C:\Users\blyoa\go\bin\
vim-go: Updating golint. Reinstalling github.com/golang/lint/golint to folder C:\Users\blyoa\go\bin\
vim-go: Updating fillstruct. Reinstalling github.com/davidrjenni/reftools/cmd/fillstruct to folder C:\Users\blyoa\go\bin\
vim-go: Updating godef. Reinstalling github.com/rogpeppe/godef to folder C:\Users\blyoa\go\bin\
vim-go: Updating motion. Reinstalling github.com/fatih/motion to folder C:\Users\blyoa\go\bin\
vim-go: Updating errcheck. Reinstalling github.com/kisielk/errcheck to folder C:\Users\blyoa\go\bin\
vim-go: Updating dlv. Reinstalling github.com/derekparker/delve/cmd/dlv to folder C:\Users\blyoa\go\bin\
vim-go: Updating gocode. Reinstalling github.com/mdempsky/gocode to folder C:\Users\blyoa\go\bin\
Error installing github.com/mdempsky/gocode: flag provided but not defined: -ldflags -H^@usage: get [-d] [-f] [-fix] [-insecure] [-t] [-u] [-v] [build flags] [packages]^@Run 'go help get' for details.^@
vim-go: Updating gotags. Reinstalling github.com/jstemmer/gotags to folder C:\Users\blyoa\go\bin\
Error installing github.com/jstemmer/gotags: flag provided but not defined: -ldflags -H^@usage: get [-d] [-f] [-fix] [-insecure] [-t] [-u] [-v] [build flags] [packages]^@Run 'go help get' for details.^@
vim-go: Updating impl. Reinstalling github.com/josharian/impl to folder C:\Users\blyoa\go\bin\
Error installing github.com/josharian/impl: flag provided but not defined: -ldflags -H^@usage: get [-d] [-f] [-fix] [-insecure] [-t] [-u] [-v] [build flags] [packages]^@Run 'go help get' for details.^@
vim-go: Updating goimports. Reinstalling golang.org/x/tools/cmd/goimports to folder C:\Users\blyoa\go\bin\
Error installing golang.org/x/tools/cmd/goimports: flag provided but not defined: -ldflags -H^@usage: get [-d] [-f] [-fix] [-insecure] [-t] [-u] [-v] [build flags] [packages]^@Run 'go help get' for details.^@
vim-go: Updating gomodifytags. Reinstalling github.com/fatih/gomodifytags to folder C:\Users\blyoa\go\bin\
Error installing github.com/fatih/gomodifytags: flag provided but not defined: -ldflags -H^@usage: get [-d] [-f] [-fix] [-insecure] [-t] [-u] [-v] [build flags] [packages]^@Run 'go help get' for details.^@
vim-go: Updating keyify. Reinstalling github.com/dominikh/go-tools/cmd/keyify to folder C:\Users\blyoa\go\bin\
Error installing github.com/dominikh/go-tools/cmd/keyify: flag provided but not defined: -ldflags -H^@usage: get [-d] [-f] [-fix] [-insecure] [-t] [-u] [-v] [build flags] [packages]^@Run 'go help get' for details.^@
vim-go: Updating gorename. Reinstalling golang.org/x/tools/cmd/gorename to folder C:\Users\blyoa\go\bin\
Error installing golang.org/x/tools/cmd/gorename: flag provided but not defined: -ldflags -H^@usage: get [-d] [-f] [-fix] [-insecure] [-t] [-u] [-v] [build flags] [packages]^@Run 'go help get' for details.^@
vim-go: Updating asmfmt. Reinstalling github.com/klauspost/asmfmt/cmd/asmfmt to folder C:\Users\blyoa\go\bin\
Error installing github.com/klauspost/asmfmt/cmd/asmfmt: flag provided but not defined: -ldflags -H^@usage: get [-d] [-f] [-fix] [-insecure] [-t] [-u] [-v] [build flags] [packages]^@Run 'go help get' for details.^@
vim-go: Updating gometalinter. Reinstalling github.com/alecthomas/gometalinter to folder C:\Users\blyoa\go\bin\
Error installing github.com/alecthomas/gometalinter: flag provided but not defined: -ldflags -H^@usage: get [-d] [-f] [-fix] [-insecure] [-t] [-u] [-v] [build flags] [packages]^@Run 'go help get' for details.^@
```