### PR TITLE
revert the change to use mdempsky/gocode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,13 +37,6 @@ BUG FIXES:
 
 BACKWARDS INCOMPATIBILITIES:
 
-* This is not a breaking changes but we list it in case there are some issues
-  that come up after upgrading to the new release with autocompletion. We no
-  longer rely on using `nsf/gocode` and switched to the new fork
-  `mdempsky/gocode`. Please let us know if you see any `gocode`
-  (autocompletion) related issues after upgrading.
-  [[GH-1814]](https://github.com/fatih/vim-go/pull/1814)
-
 ## 1.17 - (March 27, 2018)
 
 FEATURES:

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -34,7 +34,7 @@ let s:packages = {
       \ 'dlv':           ['github.com/derekparker/delve/cmd/dlv'],
       \ 'errcheck':      ['github.com/kisielk/errcheck'],
       \ 'fillstruct':    ['github.com/davidrjenni/reftools/cmd/fillstruct'],
-      \ 'gocode':        ['github.com/mdempsky/gocode', {'windows': ['-ldflags', '-H=windowsgui']}],
+      \ 'gocode':        ['github.com/nsf/gocode', {'windows': ['-ldflags', '-H=windowsgui']}],
       \ 'godef':         ['github.com/rogpeppe/godef'],
       \ 'gogetdoc':      ['github.com/zmb3/gogetdoc'],
       \ 'goimports':     ['golang.org/x/tools/cmd/goimports'],


### PR DESCRIPTION
mdempsky/gocode is not a drop-in replacement for nsf/gocode. Let's revert this for now until we can figure out how to deal with its differences.

https://github.com/mdempsky/gocode/commit/e117c263fb7092eedd7cab24f41d90a9d76bd23a shows that there's _a lot_ of differences. Notably, the options that nsf/gocode supports are not supported with mdempksy/gocode.

Fixes #1817 again