### PR TITLE
guru.vim: defer ImportPath check

### DIFF
--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -16,12 +16,6 @@ function! s:guru_cmd(args) range abort
   let selected = a:args.selected
 
   let result = {}
-  let pkg = go#package#ImportPath()
-
-  " this is important, check it!
-  if pkg == -1 && needs_scope
-    return {'err': "current directory is not inside of a valid GOPATH"}
-  endif
 
   "return with a warning if the binary doesn't exist
   let bin_path = go#path#CheckBinPath("guru")
@@ -47,6 +41,10 @@ function! s:guru_cmd(args) range abort
     " some modes require scope to be defined (such as callers). For these we
     " choose a sensible setting, which is using the current file's package
     if needs_scope
+      let pkg = go#package#ImportPath()
+      if pkg == -1
+        return {'err': "current directory is not inside of a valid GOPATH"}
+      endif
       let scopes = [pkg]
     endif
   endif


### PR DESCRIPTION
In the k8s.io/kubernetes repo, vendor/k8s.io/{api,apiservers} etc. are
symbolic links to corresponding dir staging/src/k8s.io/{api,apiservers}.

    vendor/k8s.io/apiserver -> ../../staging/src/k8s.io/apiserver

ImportPath detection for files under these staging directories will fail
because '%:p:h' does not match any items of 'go list'

For large projects like k8s, users tend to set the g:go_guru_scope
variable.  The change is mainly a workaround trying to improve
experience so that those not worked before will work now and it will not
affect existing usage.