### PR TITLE
Package name must come after subcommand

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -551,8 +551,8 @@ function! go#debug#Start(is_test, ...) abort
 
     let l:cmd = [
           \ dlv,
-          \ l:pkgname,
           \ (a:is_test ? 'test' : 'debug'),
+          \ l:pkgname,
           \ '--output', tempname(),
           \ '--headless',
           \ '--api-version', '2',


### PR DESCRIPTION
Package name must come after subcommand (test/debug), dlv could not start when package name comes before subcommand