### PR TITLE
Respect user debug highlight group customization

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -894,8 +894,13 @@ sign define godebugbreakpoint text=> texthl=GoDebugBreakpoint
 sign define godebugcurline text== linehl=GoDebugCurrent texthl=GoDebugCurrent
 
 fun! s:hi()
-  hi GoDebugBreakpoint term=standout ctermbg=117 ctermfg=0 guibg=#BAD4F5  guifg=Black
-  hi GoDebugCurrent    term=reverse  ctermbg=12  ctermfg=7 guibg=DarkBlue guifg=White
+
+  if execute("hi GoDebugBreakpoint", "silent!") =~ "xxx cleared"
+    hi GoDebugBreakpoint term=standout ctermbg=117 ctermfg=0 guibg=#BAD4F5  guifg=Black
+  endif
+  if execute("hi GoDebugCurrent", "silent!") =~ "xxx cleared"
+    hi GoDebugCurrent    term=reverse  ctermbg=12  ctermfg=7 guibg=DarkBlue guifg=White
+  endif
 endfun
 augroup vim-go-breakpoint
   autocmd!


### PR DESCRIPTION
As mentioned in #1839, If the user sets GoDebugCurrent or
GoDebugBreakpoint, we should respect their customization and not
override them.

The problem is that we're defining it in autoload, so it gets evaluated
after user customizations have been applied. I suspect the right thing
to do is to move the definition of the groups & signs to the syntax
file, but I'm going to assume things were done the way they were for a
good reason, and not propose that change (I'm no vim-expert).

It's not obvious how we can check for this, so I've chosen to execute
"hi GoDebugBreakpoint" and look for a string that appears to be present
when it was not already set.