### PR TITLE
fix guru output handling in Neovim

### DIFF
--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -127,7 +127,7 @@ function! s:job_start(cmd, start_options) abort
   " use a shell for input redirection if needed
   let cmd = a:cmd
   if has_key(a:start_options, 'in_io') && a:start_options.in_io ==# 'file' && !empty(a:start_options.in_name)
-    let cmd = ['/bin/sh', '-c', join(a:cmd, ' ') . ' <' . a:start_options.in_name]
+    let cmd = ['/bin/sh', '-c', go#util#Shelljoin(a:cmd) . ' <' . a:start_options.in_name]
   endif
 
   return jobstart(cmd, opts)

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -113,12 +113,43 @@ function! s:job_start(cmd, start_options) abort
   endif
 
   let opts = {'stdout_buffered': v:true, 'stderr_buffered': v:true}
+
+  let stdout_buf = ""
   function opts.on_stdout(job_id, data, event) closure
-    call a:start_options.callback(a:job_id, join(a:data, "\n"))
+    let l:data = a:data
+    let l:data[0] = stdout_buf . l:data[0]
+    let stdout_buf = ""
+
+    if l:data[-1] != ""
+      let stdout_buf = l:data[-1]
+    endif
+
+    let l:data = l:data[:-2]
+    if len(l:data) == 0
+      return
+    endif
+
+    call a:start_options.callback(a:job_id, join(l:data, "\n"))
   endfunction
+
+  let stderr_buf = ""
   function opts.on_stderr(job_id, data, event) closure
-    call a:start_options.callback(a:job_id, join(a:data, "\n"))
+    let l:data = a:data
+    let l:data[0] = stderr_buf . l:data[0]
+    let stderr_buf = ""
+
+    if l:data[-1] != ""
+      let stderr_buf = l:data[-1]
+    endif
+
+    let l:data = l:data[:-2]
+    if len(l:data) == 0
+      return
+    endif
+
+    call a:start_options.callback(a:job_id, join(l:data, "\n"))
   endfunction
+
   function opts.on_exit(job_id, exit_code, event) closure
     call a:start_options.exit_cb(a:job_id, a:exit_code)
     call a:start_options.close_cb(a:job_id)


### PR DESCRIPTION
Output from a Neovim job may come in batches and splits on newlines.
When the output ends with a newline, the last element in the data passed
to the stdout and stderr callbacks will be the empty string. When it's
not the empty string, then last element is an incomplete line, and the
next call will contain the rest of the line in the first element of its
data.

Join shell arguments correctly when Neovim calls guru.

Fixes #1836