### PR TITLE
Respect user debug highlight group customization

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -893,14 +893,4 @@ endfunction
 sign define godebugbreakpoint text=> texthl=GoDebugBreakpoint
 sign define godebugcurline text== linehl=GoDebugCurrent texthl=GoDebugCurrent
 
-fun! s:hi()
-  hi GoDebugBreakpoint term=standout ctermbg=117 ctermfg=0 guibg=#BAD4F5  guifg=Black
-  hi GoDebugCurrent    term=reverse  ctermbg=12  ctermfg=7 guibg=DarkBlue guifg=White
-endfun
-augroup vim-go-breakpoint
-  autocmd!
-  autocmd ColorScheme * call s:hi()
-augroup end
-call s:hi()
-
 " vim: sw=2 ts=2 et

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -371,6 +371,10 @@ function! s:hi()
   " :GoCoverage commands
   hi def      goCoverageCovered    ctermfg=green guifg=#A6E22E
   hi def      goCoverageUncover    ctermfg=red guifg=#F92672
+
+  " :GoDebug commands
+  hi GoDebugBreakpoint term=standout ctermbg=117 ctermfg=0 guibg=#BAD4F5  guifg=Black
+  hi GoDebugCurrent    term=reverse  ctermbg=12  ctermfg=7 guibg=DarkBlue guifg=White
 endfunction
 
 augroup vim-go-hi


### PR DESCRIPTION
Before, this was defined as part of the debug autoload, which would only
be invoked when a user started debugging for the first time. This caused
it to override any customizations a user may have had in their own
configuration.

By migrating the highlight groups to the syntax file, users can use
standard methods to override these colors if they don't work with their
chosen colorscheme, e.g. with a line like:

```vim
autocmd custom FileType go hi! GoDebugCurrent term=underline ctermbg=237 guibg=#3c3836
```

in their `vimrc`.

This supercedes fatih/vim-go#1840 and fixes fatih/vim-go#1839.