### PR TITLE
gocode: switch to https://github.com/mdempsky/gocode

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -43,31 +43,7 @@ function! s:sync_gocode(cmd, args, input) abort
   return l:result
 endfunction
 
-let s:optionsEnabled = 0
-function! s:gocodeEnableOptions() abort
-  if s:optionsEnabled
-    return
-  endif
-
-  let l:bin_path = go#path#CheckBinPath("gocode")
-  if empty(l:bin_path)
-    return
-  endif
-
-  let s:optionsEnabled = 1
-
-  call go#util#Exec(['gocode', 'set', 'propose-builtins', s:toBool(go#config#GocodeProposeBuiltins())])
-  call go#util#Exec(['gocode', 'set', 'autobuild', s:toBool(go#config#GocodeAutobuild())])
-  call go#util#Exec(['gocode', 'set', 'unimported-packages', s:toBool(go#config#GocodeUnimportedPackages())])
-endfunction
-
-function! s:toBool(val) abort
-  if a:val | return 'true' | else | return 'false' | endif
-endfunction
-
 function! s:gocodeAutocomplete() abort
-  call s:gocodeEnableOptions()
-
   " use the offset as is, because the cursor position is the position for
   " which autocomplete candidates are needed.
   return s:sync_gocode('autocomplete',

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -135,21 +135,9 @@ function! go#config#SetGuruScope(scope) abort
   endif
 endfunction
 
-function! go#config#GocodeUnimportedPackages() abort
-  return get(g:, 'go_gocode_unimported_packages', 0)
-endfunction
-
 let s:sock_type = (has('win32') || has('win64')) ? 'tcp' : 'unix'
 function! go#config#GocodeSocketType() abort
   return get(g:, 'go_gocode_socket_type', s:sock_type)
-endfunction
-
-function! go#config#GocodeProposeBuiltins() abort
-  return get(g:, 'go_gocode_propose_builtins', 1)
-endfunction
-
-function! go#config#GocodeAutobuild() abort
-  return get(g:, 'go_gocode_autobuild', 1)
 endfunction
 
 function! go#config#EchoCommandInfo() abort

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1544,28 +1544,6 @@ same.
         \ '? go#util#pascalcase(expand("<cword>"))' .
         \ ': go#util#camelcase(expand("<cword>"))'
 <
-                                                     *'g:go_gocode_autobuild'*
-
-Specifies whether `gocode` should automatically build out-of-date packages
-when their source fields are modified, in order to obtain the freshest
-autocomplete results for them.  By default it is enabled.
->
-  let g:go_gocode_autobuild = 1
-<
-                                              *'g:go_gocode_propose_builtins'*
-
-Specifies whether `gocode` should add built-in types, functions and constants
-to an autocompletion proposals. By default it is enabled.
->
-  let g:go_gocode_propose_builtins = 1
-<
-                                           *'g:go_gocode_unimported_packages'*
-
-Specifies whether `gocode` should include suggestions from unimported
-packages. By default it is disabled.
->
-  let g:go_gocode_unimported_packages = 0
-<
 
                                                    *'g:go_gocode_socket_type'*
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -34,7 +34,7 @@ let s:packages = {
       \ 'dlv':           ['github.com/derekparker/delve/cmd/dlv'],
       \ 'errcheck':      ['github.com/kisielk/errcheck'],
       \ 'fillstruct':    ['github.com/davidrjenni/reftools/cmd/fillstruct'],
-      \ 'gocode':        ['github.com/nsf/gocode', {'windows': ['-ldflags', '-H=windowsgui']}],
+      \ 'gocode':        ['github.com/mdempsky/gocode', {'windows': ['-ldflags', '-H=windowsgui']}],
       \ 'godef':         ['github.com/rogpeppe/godef'],
       \ 'gogetdoc':      ['github.com/zmb3/gogetdoc'],
       \ 'goimports':     ['golang.org/x/tools/cmd/goimports'],


### PR DESCRIPTION
nsf/gocode is not working well with Go 1.10. I just encountered it myself again. The author of original gocode also states and recommends the mdempsky/gocode fork over nsf/gocode: https://github.com/nsf/gocode#an-autocompletion-daemon-for-the-go-programming-language

We actually [moved once](https://github.com/fatih/vim-go/pull/1814), but because we didn't removed the obsolote settings, we weren't prepared for issues that were [reported](https://github.com/fatih/vim-go/issues/1817), and hence [reverted it back](https://github.com/fatih/vim-go/pull/1823)

This PR also removes all settings. The reason is that the new gocode doesn't support settings anymore. The author decided not the support it.

* For `autobuild`, this was removed because the author believe it's not
worth tackling it inside `gocode`: https://github.com/mdempsky/gocode/issues/13
* For `propose builtins`, this is actually still supported but disabled in
the source code, we need to add it back again in the future:
https://github.com/mdempsky/gocode/commit/787cfae70965d528523902b4c12e85692e17336b
* For `unimported packages`: this was just removed and I couldn't find
upcoming plans for it

Going forward this package seems to be more stable and is a better bet. Most important, as I stated nfs/gocode is not 1.10 compatible and the author has no intentions to fix it.