### PR TITLE
Pretty print maps in JSON and YAML

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -435,6 +435,15 @@ if !reflect.DeepEqual(${1:expected}, ${2:actual}) {
 }
 endsnippet
 
+# print a map in JSON format
+snippet pj "print a map in JSON format"
+b, err := json.MarshalIndent(${1:val}, "", "  ")
+if err != nil {
+	fmt.Println("error:", err)
+}
+fmt.Print(string(b))
+endsnippet
+
 global !p
 
 import re

--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -444,6 +444,15 @@ if err != nil {
 fmt.Print(string(b))
 endsnippet
 
+# print a map in YAML format
+snippet py "print a map in YAML format"
+b, err := yaml.Marshal(&${1:val})
+if err != nil {
+	fmt.Println("error:", err)
+}
+fmt.Print(string(b))
+endsnippet
+
 global !p
 
 import re


### PR DESCRIPTION
This marshals and prints a `map` in indented JSON or YAML format. 
Implements UltiSnips only.