### PR TITLE
do not indent second line of raw string

### DIFF
--- a/autoload/go/indent_test.vim
+++ b/autoload/go/indent_test.vim
@@ -1,0 +1,22 @@
+func! Test_indent_raw_string() abort
+  try
+    let l:dir= gotest#write_file('indent/indent.go', [
+          \ 'package main',
+          \ '',
+          \ 'import "fmt"',
+          \ '',
+          \ 'func main() {',
+          \	"\t\x1fconst msg = `",
+          \ '`',
+          \ '\tfmt.Println(msg)',
+          \ '}'])
+
+    silent execute "normal o" . "not indented\<Esc>"
+    let l:indent = indent(line('.'))
+    call assert_equal(0, l:indent)
+  finally
+    call delete(l:dir, 'rf')
+  endtry
+endfunc
+
+" vim: sw=2 ts=2 et

--- a/indent/go.vim
+++ b/indent/go.vim
@@ -38,6 +38,10 @@ function! GoIndent(lnum)
 
   let ind = previ
 
+  if prevl =~ ' = `[^`]*$'
+    " previous line started a multi-line raw string
+    return 0
+  endif
   if prevl =~ '[({]\s*$'
     " previous line opened a block
     let ind += shiftwidth()

--- a/indent/go.vim
+++ b/indent/go.vim
@@ -24,17 +24,6 @@ if exists("*GoIndent")
   finish
 endif
 
-" use shiftwidth function only if it's available
-if exists('*shiftwidth')
-  func s:sw()
-    return shiftwidth()
-  endfunc
-else
-  func s:sw()
-    return &sw
-  endfunc
-endif
-
 function! GoIndent(lnum)
   let prevlnum = prevnonblank(a:lnum-1)
   if prevlnum == 0
@@ -51,17 +40,17 @@ function! GoIndent(lnum)
 
   if prevl =~ '[({]\s*$'
     " previous line opened a block
-    let ind += s:sw()
+    let ind += shiftwidth()
   endif
   if prevl =~# '^\s*\(case .*\|default\):$'
     " previous line is part of a switch statement
-    let ind += s:sw()
+    let ind += shiftwidth()
   endif
   " TODO: handle if the previous line is a label.
 
   if thisl =~ '^\s*[)}]'
     " this line closed a block
-    let ind -= s:sw()
+    let ind -= shiftwidth()
   endif
 
   " Colons are tricky.
@@ -69,7 +58,7 @@ function! GoIndent(lnum)
   " We ignore trying to deal with jump labels because (a) they're rare, and
   " (b) they're hard to disambiguate from a composite literal key.
   if thisl =~# '^\s*\(case .*\|default\):$'
-    let ind -= s:sw()
+    let ind -= shiftwidth()
   endif
 
   return ind


### PR DESCRIPTION
Do not match the indentation of code that assigns a multi-line raw string within the raw string (i.e. the second line of a raw string should not match the indentation of the line of code that assigns the raw string to a variable).

Fixes #1800