### PR TITLE
Fix wrong binary path for go#util#Exec

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -167,13 +167,16 @@ function! go#util#Exec(cmd, ...) abort
 
   let l:bin = a:cmd[0]
 
+  " Lookup the full path, respecting settings such as 'go_bin_path'. On errors,
   " CheckBinPath will show a warning for us.
   let l:bin = go#path#CheckBinPath(l:bin)
   if empty(l:bin)
     return ['', 1]
   endif
 
-  return call('s:exec', [a:cmd] + a:000)
+  " Finally execute the command using the full, resolved path. Do not pass the
+  " unmodified command as the correct program might not exist in $PATH.
+  return call('s:exec', [[l:bin] + a:cmd[1:]] + a:000)
 endfunction
 
 function! s:exec(cmd, ...) abort


### PR DESCRIPTION
Commands such as :GoImports ended up calling "goimports" directly rather
than using the full path based on g:go_bin_path. Restore the previous
behavior of using the expanded binary path.

Fixes regression from #1771
(commit 32ae8640716530bd55062379177da51efb37dfd2,
"Fix infinite recursion when GOPATH is empty, part two").
___
Cc: @Carpetsmoker

I don't have `~/go/bin` in my `$PATH`, but I do have `let g:go_bin_path = expand('~/go/bin')` in my vimrc.
It would be nice to have a regression test for this, but `scripts/install-vim` always adds `$GOPATH/bin` to `PATH`, so I am not sure if it is feasible to do this?