### PR TITLE
Fix GoDeclsDir for ctrlp on a directory other than '.'

### DIFF
--- a/autoload/ctrlp/decls.vim
+++ b/autoload/ctrlp/decls.vim
@@ -117,7 +117,7 @@ function! ctrlp#decls#enter() abort
     call add(s:decls, printf("%s\t%s |%s:%s:%s|\t%s",
           \ decl.ident . space,
           \ decl.keyword,
-          \ fnamemodify(decl.filename, ":t"),
+          \ fnamemodify(decl.filename, ":."),
           \ decl.line,
           \ decl.col,
           \ decl.full,


### PR DESCRIPTION
If you run `GoDeclsDir ./some/package` with vim-go using CtrlP, it show the list of declarations in the package, but when you hit enter on one of them, it just opens a new buffer with the name of the file containing the selected symbol, but it doesn't correctly open the existing file. This fixes that issue.