### PR TITLE
Add GoDeclsDirRecur command.

### DIFF
--- a/autoload/ctrlp/decls.vim
+++ b/autoload/ctrlp/decls.vim
@@ -63,7 +63,7 @@ function! ctrlp#decls#enter() abort
   let l:cmd = ['motion',
         \ '-format', 'vim',
         \ '-mode', 'decls',
-        \ '-include', go#config#DeclsIncludes(),
+        \ '-include', go#config#DeclsIncludes()
         \ ]
 
   call go#cmd#autowrite()
@@ -76,7 +76,7 @@ function! ctrlp#decls#enter() abort
     endif
 
     let cmd += ['-file', l:fname]
-  else
+  elseif s:mode == 1
     " all functions mode
     let l:dir = expand("%:p:h")
     if exists('s:target')
@@ -84,6 +84,14 @@ function! ctrlp#decls#enter() abort
     endif
 
     let cmd += ['-dir', l:dir]
+  else
+    " all functions mode
+    let l:dir = expand("%:p:h")
+    if exists('s:target')
+      let l:dir = s:target
+    endif
+
+    let cmd += ['-dir', l:dir, '-recursive']
   endif
 
   let [l:out, l:err] = go#util#Exec(l:cmd)

--- a/autoload/fzf/decls.vim
+++ b/autoload/fzf/decls.vim
@@ -74,13 +74,20 @@ function! s:source(mode,...) abort
     endif
 
     let cmd += ['-file', l:fname]
-  else
+  elseif a:mode == 1
     " all functions mode
     if a:0 && !empty(a:1)
       let s:current_dir = a:1
     endif
 
     let l:cmd += ['-dir', s:current_dir]
+  else
+    " all functions mode
+    if a:0 && !empty(a:1)
+      let s:current_dir = a:1
+    endif
+
+    let l:cmd += ['-dir', s:current_dir, '-recursive']
   endif
 
   let [l:out, l:err] = go#util#Exec(l:cmd)
@@ -112,7 +119,7 @@ function! s:source(mode,...) abort
     endfor
 
     let pos = printf("|%s:%s:%s|",
-          \ fnamemodify(decl.filename, ":t"),
+          \ fnamemodify(decl.filename, ":."),
           \ decl.line,
           \ decl.col
           \)

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -709,6 +709,13 @@ CTRL-t
     Show all function and type declarations for the current directory. If
     [dir] is given it parses the given directory.
 
+                                                            *:GoDeclsDirRecur*
+:GoDeclsDirRecur [dir]
+
+    Show all function and type declarations for the current directory and all
+    directories within it, recursively. If [dir] is given it parses the given 
+    directory.
+
                                                                  *unite-decls*
                                                                 *denite-decls*
 :Unite decls[:path]

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -86,6 +86,7 @@ command! -bang GoAlternate call go#alternate#Switch(<bang>0, '')
 " -- decls
 command! -nargs=? -complete=file GoDecls call go#decls#Decls(0, <q-args>)
 command! -nargs=? -complete=dir GoDeclsDir call go#decls#Decls(1, <q-args>)
+command! -nargs=? -complete=dir GoDeclsDirRecur call go#decls#Decls(2, <q-args>)
 
 " -- impl
 command! -nargs=* -complete=customlist,go#impl#Complete GoImpl call go#impl#Impl(<f-args>)


### PR DESCRIPTION
This PR depends on fatih/motion#5.

I really like the `:GoDeclsDir` command on vim-go. I think it's really useful to find a function or type directly, rather than a file. However, I think the limitation that it only does one package at a time is not great if you want to quickly navigate a project divided into many packages.

This PR aims to address this by adding a recursive version of this command, `:GoDeclsDirRecur`. Before this can work, my PR on motion has to be merged, so that motion itself supports the recursive option, which it currently doesn't.