### PR TITLE
Fix guru execution to use g:go_bin_path

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -26,7 +26,7 @@ function! go#def#Jump(mode) abort
     endif
 
   elseif bin_name == 'guru'
-    let cmd = [bin_name, '-tags', go#config#BuildTags()]
+    let cmd = [go#path#CheckBinPath(bin_name), '-tags', go#config#BuildTags()]
     let stdin_content = ""
 
     if &modified


### PR DESCRIPTION
PR #1866 was incomplete: `go#def#Jump()` calls `guru` asyncronously, and
not through `go#util#Exec()`, and so `:GoDef` fails if `guru` isn't
found in `$PATH`.