### PR TITLE
Add goreturns

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This plugin adds Go language support for Vim, with the following main features:
 * Improved syntax highlighting and folding.
 * Debug programs with integrated `delve` support with `:GoDebugStart`.
 * Completion support via `gocode`.
-* `gofmt` or `goimports` on save keeps the cursor position and undo history.
+* `gofmt`, `goimports` or `goreturns`  on save keeps the cursor position and undo history.
 * Go to symbol/declaration with `:GoDef`.
 * Look up documentation with `:GoDoc` or `:GoDocBrowser`.
 * Easily import packages via `:GoImport`, remove them via `:GoDrop`.

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -13,7 +13,7 @@
 "  it doesn't undo changes and break undo history.  If you are here reading
 "  this and have VimL experience, please look at the function for
 "  improvements, patches are welcome :)
-function! go#fmt#Format(withGoimport) abort
+function! go#fmt#Format(fmtBinFlag) abort
   if go#config#FmtExperimental()
     " Using winsaveview to save/restore cursor state has the problem of
     " closing folds on save:
@@ -49,8 +49,10 @@ function! go#fmt#Format(withGoimport) abort
   endif
 
   let bin_name = go#config#FmtCommand()
-  if a:withGoimport == 1
+  if a:fmtBinFlag == 1
     let bin_name = "goimports"
+  elseif a:fmtBinFlag == 2
+    let bin_name = "goreturns"
   endif
 
   let current_col = col('.')
@@ -157,7 +159,7 @@ function! s:fmt_cmd(bin_name, source, target)
     let opts = has_key(opts, a:bin_name) ? opts[a:bin_name] : ""
   endif
   call extend(cmd, split(opts, " "))
-  if a:bin_name is# 'goimports'
+  if a:bin_name is# 'goimports' || a:bin_name is# 'goreturns'
     call extend(cmd, ["-srcdir", a:target])
   endif
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -43,7 +43,8 @@ tools developed by the Go community to provide a seamless Vim experience.
   * Improved syntax highlighting and folding.
   * Debug programs with integrated `delve` support with |:GoDebugStart|.
   * Completion support via `gocode`.
-  * `gofmt` or `goimports` on save keeps the cursor position and undo history.
+  * `gofmt`, `goimports` or `goreturns` on save keeps the cursor position and
+    undo history.
   * Go to symbol/declaration with |:GoDef|.
   * Look up documentation with |:GoDoc| or |:GoDocBrowser|.
   * Easily import packages via |:GoImport|, remove them via |:GoDrop|.
@@ -229,6 +230,14 @@ COMMANDS                                                         *go-commands*
     `goimports` automatically discards/add import path based on the code. Like
     |:GoFmt|, It tries to preserve cursor position and avoids replacing the
     buffer with stderr output.
+                                                                  *:GoReturns*
+:GoReturns
+
+    Filter the current Go buffer through goreturns (needs to be installed).
+    `goreturns` automatically discards/add import path and fills in Go return
+    statements with zero values to match the func return types based on the
+    code. Like |:GoFmt|, It tries to preserve cursor position and avoids
+    replacing the buffer with stderr output.
 
                                                                      *:GoPlay*
 :[range]GoPlay
@@ -958,6 +967,10 @@ annotation.
                                                                 *(go-imports)*
 
 Calls `goimports` for the current package
+
+                                                                *(go-returns)*
+
+Calls `goreturns` for the current package
 
                                                                    *(go-lint)*
 
@@ -2294,8 +2307,8 @@ Check it out: https://www.patreon.com/fatih
 CREDITS                                                         *go-credits*
 
 * Go Authors for official Vim plugins.
-* Gocode, Godef, Golint, Guru, Goimports, Errcheck projects and authors of
-  those projects.
+* Gocode, Godef, Golint, Guru, Goimports, Goreturns, Errcheck projects and
+  authors of those projects.
 * Other vim-plugins, thanks for inspiration (vim-golang, go.vim, vim-gocode,
   vim-godef).
 * vim-go contributors: https://github.com/fatih/vim-go/graphs/contributors.

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -64,6 +64,7 @@ command! -nargs=* -range -complete=customlist,go#package#Complete GoDocBrowser c
 command! -nargs=0 GoFmt call go#fmt#Format(-1)
 command! -nargs=0 GoFmtAutoSaveToggle call go#fmt#ToggleFmtAutoSave()
 command! -nargs=0 GoImports call go#fmt#Format(1)
+command! -nargs=0 GoReturns call go#fmt#Format(2)
 
 " -- asmfmt
 command! -nargs=0 GoAsmFmtAutoSaveToggle call go#asmfmt#ToggleAsmFmtAutoSave()

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -38,6 +38,7 @@ let s:packages = {
       \ 'godef':         ['github.com/rogpeppe/godef'],
       \ 'gogetdoc':      ['github.com/zmb3/gogetdoc'],
       \ 'goimports':     ['golang.org/x/tools/cmd/goimports'],
+      \ 'goreturns':     ['github.com/sqs/goreturns'],
       \ 'golint':        ['github.com/golang/lint/golint'],
       \ 'gometalinter':  ['github.com/alecthomas/gometalinter'],
       \ 'gomodifytags':  ['github.com/fatih/gomodifytags'],


### PR DESCRIPTION
I wanted to use goreturns instead of goimports, so I added it.

I think that this issue has already been resolved.
[goreturns configuration · Issue \#208 · fatih/vim\-go](https://github.com/fatih/vim-go/issues/208)

Although it is not a perfect implementation, I was able to confirm the operation for the time being. Can you positively think about it?