### PR TITLE
Add minimum vim version requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This plugin adds Go language support for Vim, with the following main features:
 
 ## Install
 
+You will need at least version of Vim 7.4.1689 to use this package.
+
 The [**latest stable release**](https://github.com/fatih/vim-go/releases/latest) is the
 recommended version to use. If you choose to use the master branch instead,
 please do so with caution; it is a _development_ branch.

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -76,6 +76,16 @@ tools developed by the Go community to provide a seamless Vim experience.
 ==============================================================================
 INSTALL                                                           *go-install*
 
+You will need at least version of Vim 7.4.1689 to use this package. On OSX, if
+you are still using your system version of vim, you can use homebrew to keep
+your version of Vim up to do date with the following terminal commands:
+
+>
+  brew install vim --with-override-system-vi
+  # if you use macvim you'll need to uninstall then reinstall with an override
+  brew install macvim --with-override-system-vim
+<
+
 The latest stable release, https://github.com/fatih/vim-go/releases/latest, is
 the recommended version to use. If you choose to use the master branch
 instead, please do so with caution; it is a _development_ branch.


### PR DESCRIPTION
Two updates related to the minimum Vim version for this plugin:

* Added note in the [install](https://github.com/fatih/vim-go/blob/master/README.md#install) section of the README
* Added section in `/docs/vim-go.txt` for updating your default vim version