### PR TITLE
restore nvim's support for running go test in a terminal

### DIFF
--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -34,6 +34,10 @@ function! go#test#Test(bang, compile, ...) abort
     endif
   endif
 
+  if has('nvim') && go#config#TermEnabled()
+    call go#term#new(a:bang, ["go"] + args)
+  endif
+
   if go#util#has_job() || has('nvim')
     " use vim's job functionality to call it asynchronously
     let job_options  = {


### PR DESCRIPTION
Support for running tests in a terminal in Neovim was accidentally dropped in #1864.