### PR TITLE
put test output within its RUN and PASS/FAIL lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This plugin adds Go language support for Vim, with the following main features:
 
 ## Install
 
-vim-go requires at least Vim 7.4.1689 or Neovim 0.2.2.
+vim-go requires at least Vim 7.4.2009 or Neovim 0.2.2.
 
 The [**latest stable release**](https://github.com/fatih/vim-go/releases/latest) is the
 recommended version to use. If you choose to use the master branch instead,

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -76,7 +76,7 @@ tools developed by the Go community to provide a seamless Vim experience.
 ==============================================================================
 INSTALL                                                           *go-install*
 
-vim-go requires at least Vim 7.4.1689 or Neovim 0.2.2. On macOS, if you are
+vim-go requires at least Vim 7.4.2009 or Neovim 0.2.2. On macOS, if you are
 still using your system version of vim, you can use homebrew to keep your
 version of Vim up-to-date with the following terminal command:
 >

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -4,23 +4,24 @@ if exists("g:go_loaded_install")
 endif
 let g:go_loaded_install = 1
 
-" Not using the has('patch-7.4.1689') syntax because that wasn't added until
+" Not using the has('patch-7.4.2009') syntax because that wasn't added until
 " 7.4.237, and we want to be sure this works for everyone (this is also why
 " we're not using utils#EchoError()).
 "
-" Version 7.4.1689 was chosen because that's what the most recent Ubuntu LTS
-" release (16.04) uses.
+" Version 7.4.2009 was chosen because that's greater than what the most recent Ubuntu LTS
+" release (16.04) uses and has a couple of features we need (e.g. execute()
+" and :message clear).
 if
       \ go#config#VersionWarning() != 0 &&
-      \ (v:version < 704 || (v:version == 704 && !has('patch1689')))
+      \ (v:version < 704 || (v:version == 704 && !has('patch2009')))
       \ && !has('nvim')
   echohl Error
-  echom "vim-go requires Vim 7.4.1689 or Neovim, but you're using an older version."
+  echom "vim-go requires Vim 7.4.2009 or Neovim, but you're using an older version."
   echom "Please update your Vim for the best vim-go experience."
   echom "If you really want to continue you can set this to make the error go away:"
   echom "    let g:go_version_warning = 0"
   echom "Note that some features may error out or behave incorrectly."
-  echom "Please do not report bugs unless you're using Vim 7.4.1689 or newer."
+  echom "Please do not report bugs unless you're using Vim 7.4.2009 or newer."
   echohl None
 
   " Make sure people see this.

--- a/scripts/install-vim
+++ b/scripts/install-vim
@@ -16,8 +16,7 @@ vim=${1:-}
 
 case "$vim" in
   "vim-7.4")
-    # This is what the most recent Ubuntu LTS (16.04) ships with.
-    tag="v7.4.1689"
+    tag="v7.4.2009"
     giturl="https://github.com/vim/vim"
     ;;
 


### PR DESCRIPTION
Put test output within its RUN and PASS/FAIL lines so that it's easier to identify which test is providing the output.

For instance, the  `Test_Vet` in `lint_test.vim` outputs `vim-go: [vet] FAIL`. Previously, this output would be output _after_ the test results:
```
=== RUN  Test_Vet
--- PASS Test_Vet (0.628221s)
vim-go: calling vet...
vim-go: [vet] FAIL
ok   lint_test.vim              2.651954s / 4 tests
```

But now, the output will be shown _within_ the test run:
```
=== RUN  Test_Vet
vim-go: calling vet...
vim-go: [vet] FAIL
--- PASS Test_Vet (0.618306s)
ok   lint_test.vim              2.598650s / 4 tests
```