### PR TITLE
restore behavior of :GoInfo when g:go_info_mode='guru'

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -81,15 +81,15 @@ function! go#complete#GetInfo() abort
   return s:sync_info(0)
 endfunction
 
-function! go#complete#Info(auto) abort
+function! go#complete#Info() abort
   if go#util#has_job(1)
-    return s:async_info(a:auto)
+    return s:async_info(1)
   else
-    return s:sync_info(a:auto)
+    return s:sync_info(1)
   endif
 endfunction
 
-function! s:async_info(auto)
+function! s:async_info(echo)
   if exists("s:async_info_job")
     call job_stop(s:async_info_job)
     unlet s:async_info_job
@@ -100,7 +100,7 @@ function! s:async_info(auto)
         \ 'exit_status': 0,
         \ 'closed': 0,
         \ 'messages': [],
-        \ 'auto': a:auto
+        \ 'echo': a:echo
       \ }
 
   function! s:callback(chan, msg) dict
@@ -132,8 +132,8 @@ function! s:async_info(auto)
       return
     endif
 
-    let result = s:info_filter(self.auto, join(self.messages, "\n"))
-    call s:info_complete(self.auto, result)
+    let result = s:info_filter(self.echo, join(self.messages, "\n"))
+    call s:info_complete(self.echo, result)
   endfunction
 
   " add 1 to the offset, so that the position at the cursor will be included
@@ -171,9 +171,7 @@ function! s:gocodeFile()
   return file
 endfunction
 
-function! s:sync_info(auto)
-  " auto is true if we were called by g:go_auto_type_info's autocmd
-
+function! s:sync_info(echo)
   " add 1 to the offset, so that the position at the cursor will be included
   " in gocode's search
   let offset = go#util#OffsetCursor()+1
@@ -182,11 +180,11 @@ function! s:sync_info(auto)
         \ [expand('%:p'), offset],
         \ go#util#GetLines())
 
-  let result = s:info_filter(a:auto, result)
-  return s:info_complete(a:auto, result)
+  let result = s:info_filter(a:echo, result)
+  return s:info_complete(a:echo, result)
 endfunction
 
-function! s:info_filter(auto, result) abort
+function! s:info_filter(echo, result) abort
   if empty(a:result)
     return ""
   endif
@@ -200,7 +198,7 @@ function! s:info_filter(auto, result) abort
   if len(l:candidates) == 1
     " When gocode panics in vim mode, it returns
     "     [0, [{'word': 'PANIC', 'abbr': 'PANIC PANIC PANIC', 'info': 'PANIC PANIC PANIC'}]]
-    if a:auto && l:candidates[0].info ==# "PANIC PANIC PANIC"
+    if a:echo && l:candidates[0].info ==# "PANIC PANIC PANIC"
       return ""
     endif
 
@@ -220,8 +218,8 @@ function! s:info_filter(auto, result) abort
   return l:filtered[0].info
 endfunction
 
-function! s:info_complete(auto, result) abort
-  if a:auto && !empty(a:result)
+function! s:info_complete(echo, result) abort
+  if a:echo && !empty(a:result)
     echo "vim-go: " | echohl Function | echon a:result | echohl None
   endif
 

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -76,10 +76,10 @@ function! go#tool#Imports() abort
   return imports
 endfunction
 
-function! go#tool#Info(auto) abort
+function! go#tool#Info() abort
   let l:mode = go#config#InfoMode()
   if l:mode == 'gocode'
-    call go#complete#Info(a:auto)
+    call go#complete#Info()
   elseif l:mode == 'guru'
     call go#guru#DescribeInfo()
   else

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -26,7 +26,7 @@ command! -nargs=* -range GoRemoveTags call go#tags#Remove(<line1>, <line2>, <cou
 " -- tool
 command! -nargs=* -complete=customlist,go#tool#ValidFiles GoFiles echo go#tool#Files(<f-args>)
 command! -nargs=0 GoDeps echo go#tool#Deps()
-command! -nargs=* GoInfo call go#tool#Info(0)
+command! -nargs=0 GoInfo call go#tool#Info()
 command! -nargs=0 GoAutoTypeInfoToggle call go#complete#ToggleAutoTypeInfo()
 
 " -- cmd

--- a/ftplugin/go/mappings.vim
+++ b/ftplugin/go/mappings.vim
@@ -31,7 +31,7 @@ nnoremap <silent> <Plug>(go-coverage-browser) :<C-u>call go#coverage#Browser(!g:
 
 nnoremap <silent> <Plug>(go-files) :<C-u>call go#tool#Files()<CR>
 nnoremap <silent> <Plug>(go-deps) :<C-u>call go#tool#Deps()<CR>
-nnoremap <silent> <Plug>(go-info) :<C-u>call go#tool#Info(0)<CR>
+nnoremap <silent> <Plug>(go-info) :<C-u>call go#tool#Info()<CR>
 nnoremap <silent> <Plug>(go-import) :<C-u>call go#import#SwitchImport(1, '', expand('<cword>'), '')<CR>
 nnoremap <silent> <Plug>(go-imports) :<C-u>call go#fmt#Format(1)<CR>
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -201,7 +201,7 @@ endfunction
 function! s:auto_type_info()
   " GoInfo automatic update
   if get(g:, "go_auto_type_info", 0)
-    call go#tool#Info(1)
+    call go#tool#Info()
   endif
 endfunction
 


### PR DESCRIPTION
Make sure :GoInfo echoes the info for the identifier under the cursor
when g:go_info_mode='gocode'.

Remove the auto argument from go#complete#Info; it is not needed. In
other locations, rename auto to echo so that it is clear what effect it
has instead of acting as a signal for _how_ it was called.

Fixes #1914.