### PR TITLE
Improve go.mod filetype detection

### DIFF
--- a/ftdetect/gofiletype.vim
+++ b/ftdetect/gofiletype.vim
@@ -31,9 +31,23 @@ au BufReadPost *.s call s:gofiletype_post()
 
 au BufRead,BufNewFile *.tmpl set filetype=gohtmltmpl
 
-" make sure we explicitly look for a `go.mod` and the `module` starts from the
-" beginning
-au BufNewFile,BufRead go.mod
-	\ if getline(1) =~ '^module.*' | set filetype=gomod |  endif
+" Set the filetype if the first non-comment and non-blank line starts with
+" 'module <path>'.
+au BufNewFile,BufRead go.mod call s:gomod()
+
+fun! s:gomod()
+  for l:i in range(1, line('$'))
+    let l:l = getline(l:i)
+    if l:l ==# '' || l:l[:1] ==# '//'
+      continue
+    endif
+
+    if l:l =~# '^module .\+'
+      set filetype=gomod
+    endif
+
+    break
+  endfor
+endfun
 
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
Comments are allowed in the go.mod file, so previously:

	// Document stuff!

	module foo/bar

	require "other/pkg"

Would not get detected properly.

Also tweak regexp slightly: `module` must be followed by a space and at
least one character.