### PR TITLE
Fix async job errors

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -284,15 +284,6 @@ endfunction
 " ---------------------
 
 function! s:cmd_job(args) abort
-  let status_dir = expand('%:p:h')
-  let started_at = reltime()
-
-  call go#statusline#Update(status_dir, {
-        \ 'desc': "current status",
-        \ 'type': a:args.cmd[1],
-        \ 'state': "started",
-        \})
-
   " autowrite is not enabled for jobs
   call go#cmd#autowrite()
 

--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -238,7 +238,7 @@ function! go#job#Options(args)
 
     if empty(errors)
       " failed to parse errors, output the original content
-      call go#util#EchoError(self.messages + [self.dir])
+      call go#util#EchoError([self.dir] + self.messages)
       call win_gotoid(l:winid)
       return
     endif


### PR DESCRIPTION
* Echo errors when they cannot be parsed. Put the directory at the
beginning of the echoed messages to give context to the messages that
follow. The user may still need to call `:messages` to see the full list of errors....

* Remove redundant setting of statusline

Fixes #1942