### PR TITLE
add test for go#complete#GetInfo

### DIFF
--- a/autoload/go/complete_test.vim
+++ b/autoload/go/complete_test.vim
@@ -1,0 +1,20 @@
+func! Test_GetInfo()
+    let l:filename = 'complete/complete.go'
+    let l:tmp = gotest#load_fixture(l:filename)
+
+    call cursor(8, 3)
+
+    let g:go_info_mode = 'gocode'
+    let expected = 'func Example(s string)'
+    let actual = go#complete#GetInfo()
+    call assert_equal(expected, actual)
+
+    let g:go_info_mode = 'guru'
+    call go#config#InfoMode()
+    let actual = go#complete#GetInfo()
+    call assert_equal(expected, actual)
+
+    unlet g:go_info_mode
+endfunction
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/test-fixtures/complete/complete.go
+++ b/autoload/go/test-fixtures/complete/complete.go
@@ -1,0 +1,9 @@
+package complete
+
+type T struct {
+	V string
+}
+
+func Example(s string) {
+	Example("")
+}


### PR DESCRIPTION
Add a test for `go#complete#GetInfo`, because it has guarantees, and some users depend on it.