### PR TITLE
disable other *.mod autocmds

### DIFF
--- a/ftdetect/gofiletype.vim
+++ b/ftdetect/gofiletype.vim
@@ -31,6 +31,11 @@ au BufReadPost *.s call s:gofiletype_post()
 
 au BufRead,BufNewFile *.tmpl set filetype=gohtmltmpl
 
+" remove the autocommands for modsim3, and lprolog files so that their
+" highlight groups, syntax, etc. will not be loaded. *.MOD is included, so
+" that on case insensitive file systems the module2 autocmds will not be
+" executed.
+au! BufNewFile,BufRead *.mod,*.MOD
 " Set the filetype if the first non-comment and non-blank line starts with
 " 'module <path>'.
 au BufNewFile,BufRead go.mod call s:gomod()


### PR DESCRIPTION
Disable the highlight settings and syntax groups for other *.mod files.

The one downside of this is that a user that uses vim-go and also works in Module2, LambdaProlog, and Modsim III files will need to set the filetype for those other languages via _another_ autocmd. Is there really any vim-go user that also works one of those three other languages?