### PR TITLE
snippet: Add table testing boilerplate snippet

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -363,6 +363,28 @@ func Test${1:Function}(t *testing.T) {
 }
 endsnippet
 
+# test table snippet
+snippet tt
+var tests = []struct {
+	name string
+	expected string
+	given string
+}{
+	{"${1}", "${2}", "${3}",},
+}
+for _, tt := range tests {
+	tt := tt
+	t.Run(tt.name, func(t *testing.T){
+		actual := ${0:${VISUAL}}(tt.given)
+		if actual != tt.expected {
+				t.Errorf("$0(%s): expected %s, actual %s", tt.given, tt.expected, actual)
+		}
+
+	})
+}
+endsnippet
+
+
 snippet hf "http.HandlerFunc" !b
 func ${1:handler}(w http.ResponseWriter, r *http.Request) {
 	${0:fmt.Fprintf(w, "hello world")}

--- a/gosnippets/minisnip/_go_tt
+++ b/gosnippets/minisnip/_go_tt
@@ -1,0 +1,17 @@
+var tests = []struct {
+	name string
+	expected string
+	given string
+}{
+	{"", "", "",},
+}
+for _, tt := range tests {
+	tt := tt
+	t.Run(tt.name, func(t *testing.T){
+		actual := {{++}}(tt.given)
+		if actual != tt.expected {
+				t.Errorf("{{+~\~1+}}(%s): expected %s, actual %s", tt.given, tt.expected, actual)
+		}
+
+	})
+}

--- a/gosnippets/snippets/go.snip
+++ b/gosnippets/snippets/go.snip
@@ -315,6 +315,25 @@ abbr func TestXYZ(t *testing.T) { ... }
 	func Test${1:Function}(t *testing.T) {
 		${0}
 	}
+# test table snippet
+snippet tt
+abbr var test = {...}{...} for {t.Run(){...}}
+    var tests = []struct {
+        name string
+        expected string
+        given string
+    }{
+        {"${2}", "${3}", "${4}",},
+    }
+    for _, tt := range tests {
+        tt := tt
+        t.Run(tt.name, func(t *testing.T){
+            actual := ${1:Function}(tt.given)
+            if actual != tt.expected {
+                t.Errorf("given(%s): expected %s, actual %s", tt.given, tt.expected, actual)
+            }
+        })
+    }
 # test server
 snippet tsrv
 abbr ts := httptest.NewServer(...)


### PR DESCRIPTION
The snippet only considers string input / output, and it needs to be modified for each test case, but it provides a clean, parallel testing compatible table testing boilerplate code.

Let me know if you have suggestions about tab stops or snippet name.