### PR TITLE
Define call of go#decls#Decls as go-decls-dir for further mappings 

### DIFF
--- a/ftplugin/go/mappings.vim
+++ b/ftplugin/go/mappings.vim
@@ -50,6 +50,9 @@ nnoremap <silent> <Plug>(go-sameids-toggle) :<C-u>call go#guru#ToggleSameIds()<C
 
 nnoremap <silent> <Plug>(go-rename) :<C-u>call go#rename#Rename(!g:go_jump_to_error)<CR>
 
+nnoremap <silent> <Plug>(go-decls) :<C-u>call go#decls#Decls(0, '')<CR>
+nnoremap <silent> <Plug>(go-decls-dir) :<C-u>call go#decls#Decls(1, '')<CR>
+
 nnoremap <silent> <Plug>(go-def) :<C-u>call go#def#Jump('')<CR>
 nnoremap <silent> <Plug>(go-def-vertical) :<C-u>call go#def#Jump("vsplit")<CR>
 nnoremap <silent> <Plug>(go-def-split) :<C-u>call go#def#Jump("split")<CR>


### PR DESCRIPTION
 I'd like to call `:GoDeclsDir` via hotkey as follows:
```vim
autocmd FileType go nmap <Leader>l <Plug>(go-decls-dir)
``` 
It appears the command needs to be defined in the mappings before its usage. This PR adds that definition.
