### PR TITLE
remove unneeded nvim checks

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -31,7 +31,7 @@ function! go#cmd#Build(bang, ...) abort
         \ [".", "errors"]
 
   " Vim and Neovim async.
-  if go#util#has_job() || has('nvim')
+  if go#util#has_job()
     call s:cmd_job({
           \ 'cmd': ['go'] + args,
           \ 'bang': a:bang,

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -67,7 +67,7 @@ function! go#complete#GetInfo() abort
 endfunction
 
 function! go#complete#Info(showstatus) abort
-  if go#util#has_job(1) || has('nvim')
+  if go#util#has_job(1)
     return s:async_info(1, a:showstatus)
   else
     return s:sync_info(1)

--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -44,7 +44,7 @@ function! go#coverage#Buffer(bang, ...) abort
   let s:toggle = 1
   let l:tmpname = tempname()
 
-  if go#util#has_job() || has('nvim')
+  if go#util#has_job()
     call s:coverage_job({
           \ 'cmd': ['go', 'test', '-tags', go#config#BuildTags(), '-coverprofile', l:tmpname] + a:000,
           \ 'complete': function('s:coverage_callback', [l:tmpname]),
@@ -89,7 +89,7 @@ endfunction
 " a new HTML coverage page from that profile in a new browser
 function! go#coverage#Browser(bang, ...) abort
   let l:tmpname = tempname()
-  if go#util#has_job() || has('nvim')
+  if go#util#has_job()
     call s:coverage_job({
           \ 'cmd': ['go', 'test', '-tags', go#config#BuildTags(), '-coverprofile', l:tmpname],
           \ 'complete': function('s:coverage_browser_callback', [l:tmpname]),

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -42,7 +42,7 @@ function! go#def#Jump(mode) abort
 
     call extend(cmd, ["definition", fname . ':#' . go#util#OffsetCursor()])
 
-    if go#util#has_job() || has('nvim')
+    if go#util#has_job()
       let l:state = {}
       let l:spawn_args = {
             \ 'cmd': cmd,

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -157,7 +157,7 @@ endfunc
 
 " run_guru runs the given guru argument
 function! s:run_guru(args) abort
-  if has('nvim') || go#util#has_job()
+  if go#util#has_job()
     let res = s:async_guru(a:args)
   else
     let res = s:sync_guru(a:args)

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -42,7 +42,7 @@ function! go#lint#Gometa(autosave, ...) abort
 
     " Include only messages for the active buffer for autosave.
     let include = [printf('--include=^%s:.*$', fnamemodify(expand('%:p'), ":."))]
-    if go#util#has_job() || has('nvim')
+    if go#util#has_job()
       let include = [printf('--include=^%s:.*$', expand('%:p:t'))]
     endif
     let cmd += include
@@ -56,7 +56,7 @@ function! go#lint#Gometa(autosave, ...) abort
 
   let cmd += goargs
 
-  if go#util#has_job() || has('nvim')
+  if go#util#has_job()
     call s:lint_job({'cmd': cmd}, a:autosave)
     return
   endif

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -27,7 +27,7 @@ function! go#rename#Rename(bang, ...) abort
   let offset = printf('%s:#%d', fname, pos)
   let cmd = [bin_path, "-offset", offset, "-to", to_identifier, '-tags', go#config#BuildTags()]
 
-  if go#util#has_job() || has('nvim')
+  if go#util#has_job()
     call s:rename_job({
           \ 'cmd': cmd,
           \ 'bang': a:bang,

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -30,7 +30,7 @@ function! go#test#Test(bang, compile, ...) abort
     call go#term#new(a:bang, ["go"] + args)
   endif
 
-  if go#util#has_job() || has('nvim')
+  if go#util#has_job()
     " use vim's job functionality to call it asynchronously
     let job_options  = {
           \ 'bang': a:bang,

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -64,6 +64,10 @@ endfunction
 " The (optional) first parameter can be added to indicate the 'cwd' or 'env'
 " parameters will be used, which wasn't added until a later version.
 function! go#util#has_job(...) abort
+  if has('nvim')
+    return 1
+  endif
+
   " cwd and env parameters to job_start was added in this version.
   if a:0 > 0 && a:1 is 1
     return has('job') && has("patch-8.0.0902")


### PR DESCRIPTION
Now that vim-go's async api support Neovim, go#util#has_job can handle
checking for Neovim instead of checking it inline.