### PR TITLE
fix Neovim output handling

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -85,7 +85,7 @@ function! s:async_info(echo, showstatus)
     if &encoding != 'utf-8'
       let i = 0
       while i < len(a:messages)
-        let a:messages[i] = iconv(a:messages[i], 'utf-i', &encoding)
+        let a:messages[i] = iconv(a:messages[i], 'utf-8', &encoding)
         let i += 1
       endwhile
     endif

--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -293,11 +293,10 @@ function! go#job#Start(cmd, options)
     unlet l:options._start
   endif
 
-
   if has('nvim')
     let l:input = []
-    if has_key(l:options, 'in_io') && l:options.in_io ==# 'file' && !empty(l:options.in_name)
-      let l:input = readfile(l:options.in_name, 1)
+    if has_key(a:options, 'in_io') && a:options.in_io ==# 'file' && !empty(a:options.in_name)
+      let l:input = readfile(a:options.in_name, "b")
     endif
 
     let job = jobstart(a:cmd, l:options)

--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -331,49 +331,77 @@ function! s:neooptions(options)
         continue
       endif
 
+      " dealing with the channel lines of Neovim sucks. The docs (:help
+      " channel-lines) say:
+      " stream event handlers may receive partial (incomplete) lines. For a
+      " given invocation of on_stdout etc, `a:data` is not guaranteed to end
+      " with a newline.
+      "   - `abcdefg` may arrive as `['abc']`, `['defg']`.
+      "   - `abc\nefg` may arrive as `['abc', '']`, `['efg']` or `['abc']`,
+      "     `['','efg']`, or even `['ab']`, `['c','efg']`.
       if key == 'callback'
         let l:options['callback'] = a:options['callback']
 
         if !has_key(a:options, 'out_cb')
-          let l:options['stdout_buffered'] = v:true
-
           function! s:callback2on_stdout(ch, data, event) dict
-            let l:data = a:data
-            let l:data[0] = self.stdout_buf . l:data[0]
-            let self.stdout_buf = ""
+            " a single empty string means EOF was reached.
+            if len(a:data) == 1 && a:data[0] == ''
+              " when there's nothing buffered, return early so that an
+              " erroneous message will not be added.
+              if self.stdout_buf == ''
+                return
+              endif
 
-            if l:data[-1] != ""
+              let l:data = [self.stdout_buf]
+              let self.stdout_buf = ''
+            else
+              let l:data = copy(a:data)
+              let l:data[0] = self.stdout_buf . l:data[0]
+
+              " The last element may be a partial line; save it for next time.
               let self.stdout_buf = l:data[-1]
+
+              let l:data = l:data[:-2]
+
+              if len(l:data) == 0
+                return
+              endif
             endif
 
-            let l:data = l:data[:-2]
-            if len(l:data) == 0
-              return
-            endif
-
-            call self.callback(a:ch, join(l:data, "\n"))
+            for l:msg in l:data
+              call self.callback(a:ch, l:msg)
+            endfor
           endfunction
           let l:options['on_stdout'] = function('s:callback2on_stdout', [], l:options)
         endif
 
         if !has_key(a:options, 'err_cb')
-          let l:options['stderr_buffered'] = v:true
-
           function! s:callback2on_stderr(ch, data, event) dict
-            let l:data = a:data
-            let l:data[0] = self.stderr_buf . l:data[0]
-            let self.stderr_buf = ""
+            " a single empty string means EOF was reached.
+            if len(a:data) == 1 && a:data[0] == ''
+              " when there's nothing buffered, return early so that an
+              " erroneous message will not be added.
+              if self.stderr_buf == ''
+                return
+              endif
+              let l:data = [self.stderr_buf]
+              let self.stderr_buf = ''
+            else
+              let l:data = copy(a:data)
+              let l:data[0] = self.stderr_buf . l:data[0]
 
-            if l:data[-1] != ""
+              " The last element may be a partial line; save it for next time.
               let self.stderr_buf = l:data[-1]
+
+              let l:data = l:data[:-2]
+              if len(l:data) == 0
+                return
+              endif
             endif
 
-            let l:data = l:data[:-2]
-            if len(l:data) == 0
-              return
-            endif
-
-            call self.callback(a:ch, join(l:data, "\n"))
+            for l:msg in l:data
+              call self.callback(a:ch, l:msg)
+            endfor
           endfunction
           let l:options['on_stderr'] = function('s:callback2on_stderr', [], l:options)
         endif
@@ -383,22 +411,32 @@ function! s:neooptions(options)
 
       if key == 'out_cb'
         let l:options['out_cb'] = a:options['out_cb']
-        let l:options['stdout_buffered'] = v:true
         function! s:on_stdout(ch, data, event) dict
-          let l:data = a:data
-          let l:data[0] = self.stdout_buf . l:data[0]
-          let self.stdout_buf = ""
+          " a single empty string means EOF was reached.
+          if len(a:data) == 1 && a:data[0] == ''
+            " when there's nothing buffered, return early so that an
+            " erroneous message will not be added.
+            if self.stdout_buf == ''
+              return
+            endif
+            let l:data = [self.stdout_buf]
+            let self.stdout_buf = ''
+          else
+            let l:data = copy(a:data)
+            let l:data[0] = self.stdout_buf . l:data[0]
 
-          if l:data[-1] != ""
+            " The last element may be a partial line; save it for next time.
             let self.stdout_buf = l:data[-1]
+
+            let l:data = l:data[:-2]
+            if len(l:data) == 0
+              return
+            endif
           endif
 
-          let l:data = l:data[:-2]
-          if len(l:data) == 0
-            return
-          endif
-
-          call self.out_cb(a:ch, join(l:data, "\n"))
+            for l:msg in l:data
+              call self.out_cb(a:ch, l:msg)
+            endfor
         endfunction
         let l:options['on_stdout'] = function('s:on_stdout', [], l:options)
 
@@ -407,22 +445,32 @@ function! s:neooptions(options)
 
       if key == 'err_cb'
         let l:options['err_cb'] = a:options['err_cb']
-        let l:options['stderr_buffered'] = v:true
         function! s:on_stderr(ch, data, event) dict
-          let l:data = a:data
-          let l:data[0] = self.stderr_buf . l:data[0]
-          let self.stderr_buf = ""
+          " a single empty string means EOF was reached.
+          if len(a:data) == 1 && a:data[0] == ''
+            " when there's nothing buffered, return early so that an
+            " erroneous message will not be added.
+            if self.stderr_buf == ''
+              return
+            endif
+            let l:data = [self.stderr_buf]
+            let self.stderr_buf = ''
+          else
+            let l:data = copy(a:data)
+            let l:data[0] = self.stderr_buf . l:data[0]
 
-          if l:data[-1] != ""
+            " The last element may be a partial line; save it for next time.
             let self.stderr_buf = l:data[-1]
+
+            let l:data = l:data[:-2]
+            if len(l:data) == 0
+              return
+            endif
           endif
 
-          let l:data = l:data[:-2]
-          if len(l:data) == 0
-            return
-          endif
-
-          call self.err_cb(a:ch, join(l:data, "\n"))
+          for l:msg in l:data
+            call self.err_cb(a:ch, l:msg)
+          endfor
         endfunction
         let l:options['on_stderr'] = function('s:on_stderr', [], l:options)
 


### PR DESCRIPTION
#### fix typo: spell utf-8 correctly

#### handle stdin io correctly in Neovim

s:neooptions drops any options that are not related to the callbacks; so
use a:options instead of l:options when determining whether to send a
file's contents to the job's stdin.

#### fix issues with handling Neovim channels

Call the job callback for _each_ line of output instead of once with a
single message that's joined the lines of of output to conform to the
expecations of the callback.

Handle the EOF message correctly by sending any buffered messages to the
callbacks.

Fixes #1966 