### PR TITLE
add guru describe information in balloon

### DIFF
--- a/autoload/go/auto.vim
+++ b/autoload/go/auto.vim
@@ -12,7 +12,7 @@ function! go#auto#template_autocreate()
 endfunction
 
 function! go#auto#echo_go_info()
-  if !get(g:, "go_echo_go_info", 1)
+  if !go#config#EchoGoInfo()
     return
   endif
 

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -207,8 +207,8 @@ function! s:info_filter(echo, result) abort
 endfunction
 
 function! s:info_complete(echo, result) abort
-  if a:echo && !empty(a:result)
-    echo "vim-go: " | echohl Function | echon a:result | echohl None
+  if a:echo
+    call go#util#ShowInfo(a:result)
   endif
 
   return a:result

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -282,8 +282,8 @@ function! go#debug#Stop() abort
   silent! exe bufwinnr(bufnr('__GODEBUG_OUTPUT__')) 'wincmd c'
 
   if has('balloon_eval')
-    set noballooneval
-    set balloonexpr=
+    let &noballooneval=s:ballooneval
+    let &balloonexpr=s:balloonexpr
   endif
 
   augroup vim-go-debug
@@ -466,6 +466,9 @@ function! s:start_cb() abort
   nnoremap <silent> <Plug>(go-debug-print)      :<C-u>call go#debug#Print(expand('<cword>'))<CR>
 
   if has('balloon_eval')
+    let s:balloonexpr=&balloonexpr
+    let s:ballooneval=&ballooneval
+
     set balloonexpr=go#debug#BalloonExpr()
     set ballooneval
   endif

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -18,6 +18,7 @@ function! s:guru_cmd(args) range abort
   let format = a:args.format
   let needs_scope = a:args.needs_scope
   let selected = a:args.selected
+  let postype = get(a:args, 'postype', 'cursor')
 
   let result = {}
 
@@ -61,12 +62,16 @@ function! s:guru_cmd(args) range abort
     call extend(cmd, ["-scope", l:scope])
   endif
 
-  let pos = printf("#%s", go#util#OffsetCursor())
-  if selected != -1
-    " means we have a range, get it
-    let pos1 = go#util#Offset(line("'<"), col("'<"))
-    let pos2 = go#util#Offset(line("'>"), col("'>"))
-    let pos = printf("#%s,#%s", pos1, pos2)
+  if postype == 'balloon'
+    let pos = printf("#%s", go#util#Offset(v:beval_lnum, v:beval_col))
+  else
+    let pos = printf("#%s", go#util#OffsetCursor())
+    if selected != -1
+      " means we have a range, get it
+      let pos1 = go#util#Offset(line("'<"), col("'<"))
+      let pos2 = go#util#Offset(line("'>"), col("'>"))
+      let pos = printf("#%s,#%s", pos1, pos2)
+    endif
   endif
 
   let l:filename = fnamemodify(expand("%"), ':p:gs?\\?/?') . ':' . pos
@@ -588,6 +593,141 @@ function! go#guru#Scope(...) abort
   else
     call go#util#EchoSuccess("current guru scope: ". join(scope, ","))
   endif
+endfunction
+
+function! go#guru#DescribeBalloon() abort
+  " don't even try if async isn't available.
+  if !go#util#has_job()
+    return
+  endif
+
+  " json_encode() and friends are introduced with this patch (7.4.1304)
+  " vim: https://groups.google.com/d/msg/vim_dev/vLupTNhQhZ8/cDGIk0JEDgAJ
+  " nvim: https://github.com/neovim/neovim/pull/4131
+  if !exists("*json_decode")
+    call go#util#EchoError("requires 'json_decode'. Update your Vim/Neovim version.")
+    return
+  endif
+
+  function! s:describe_balloon(exit_val, output, mode)
+    if a:exit_val != 0
+      return
+    endif
+
+    if a:output[0] !=# '{'
+      return
+    endif
+
+    if empty(a:output) || type(a:output) != type("")
+      return
+    endif
+
+    let l:result = json_decode(a:output)
+    if type(l:result) != type({})
+      call go#util#EchoError(printf('malformed output from guru: %s', a:output))
+      return
+    endif
+
+    let l:info = []
+    if has_key(l:result, 'desc')
+      if l:result['desc'] != 'identifier'
+        let l:info = add(l:info, l:result['desc'])
+      endif
+    endif
+
+    if has_key(l:result, 'detail')
+      let l:detail = l:result['detail']
+
+      " guru gives different information based on the detail mode. Let try to
+      " extract the most useful information
+
+      if l:detail == 'value'
+        if !has_key(l:result, 'value')
+          call go#util#EchoError('value key is missing. Please open a bug report on vim-go repo.')
+          return
+        endif
+
+        let l:val = l:result['value']
+        if !has_key(l:val, 'type')
+          call go#util#EchoError('type key is missing (value.type). Please open a bug report on vim-go repo.')
+          return
+        endif
+
+        let l:info = add(l:info, printf('type: %s', l:val['type']))
+        if has_key(l:val, 'value')
+          let l:info = add(l:info, printf('value: %s', l:val['value']))
+        endif
+      elseif l:detail == 'type'
+        if !has_key(l:result, 'type')
+          call go#util#EchoError('type key is missing. Please open a bug report on vim-go repo.')
+          return
+        endif
+
+        let l:type = l:result['type']
+        if !has_key(l:type, 'type')
+          call go#util#EchoError('type key is missing (type.type). Please open a bug report on vim-go repo.')
+          return
+        endif
+
+        let l:info = add(l:info, printf('type: %s', l:type['type']))
+
+        if has_key(l:type, 'methods')
+          let l:info = add(l:info, 'methods:')
+          for l:m in l:type.methods
+            let l:info = add(l:info, printf("\t%s", l:m['name']))
+          endfor
+        endif
+      elseif l:detail == 'package'
+        if !has_key(l:result, 'package')
+          call go#util#EchoError('package key is missing. Please open a bug report on vim-go repo.')
+          return
+        endif
+
+        let l:package = result['package']
+        if !has_key(l:package, 'path')
+          call go#util#EchoError('path key is missing (package.path). Please open a bug report on vim-go repo.')
+          return
+        endif
+
+        let l:info = add(l:info, printf('package: %s', l:package["path"]))
+      elseif l:detail == 'unknown'
+        " the description is already included in l:info, and there's no other
+        " information on unknowns.
+      else
+        call go#util#EchoError(printf('unknown detail mode (%s) found. Please open a bug report on vim-go repo', l:detail))
+        return
+      endif
+    endif
+
+    if has('balloon_eval')
+      call balloon_show(join(l:info, "\n"))
+      return
+    endif
+
+    call balloon_show(l:info)
+  endfunction
+
+
+  " change the active window to the window where the cursor is.
+  let l:winid = win_getid(winnr())
+  call win_gotoid(v:beval_winid)
+
+  let l:args = {
+        \ 'mode': 'describe',
+        \ 'format': 'json',
+        \ 'selected': -1,
+        \ 'needs_scope': 0,
+        \ 'custom_parse': function('s:describe_balloon'),
+        \ 'disable_progress': 1,
+        \ 'postype': 'balloon',
+        \ }
+
+  call s:async_guru(args)
+
+  " make the starting window active again
+  call win_gotoid(l:winid)
+
+  return ''
 endfunction
 
 " restore Vi compatibility settings

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -316,7 +316,7 @@ function! go#guru#DescribeInfo(showstatus) abort
       return
     endif
 
-    echo "vim-go: " | echohl Function | echon info | echohl None
+    call go#util#ShowInfo(info)
   endfunction
 
   let args = {

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -287,7 +287,7 @@ function! go#guru#DescribeInfo(showstatus) abort
         return
       endif
 
-      let info  = val["type"]
+      let info = val["type"]
     elseif detail == "type"
       if !has_key(result, 'type')
         call go#util#EchoError("type key is missing. Please open a bug report on vim-go repo.")
@@ -300,7 +300,7 @@ function! go#guru#DescribeInfo(showstatus) abort
         return
       endif
 
-      let info  = type["type"]
+      let info = type["type"]
     elseif detail == "package"
       if !has_key(result, 'package')
         call go#util#EchoError("package key is missing. Please open a bug report on vim-go repo.")

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -111,6 +111,10 @@ function! go#tool#Exists(importpath) abort
     return 0
 endfunction
 
+function! go#tool#DescribeBalloon()
+  return go#guru#DescribeBalloon()
+endfunction
+
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -547,6 +547,14 @@ function! go#util#FilterValids(items) abort
   return filtered
 endfunction
 
+function! go#util#ShowInfo(info)
+  if empty(a:info)
+    return
+  endif
+
+  echo "vim-go: " | echohl Function | echon a:info | echohl None
+endfunction
+
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1176,6 +1176,12 @@ cleaned for each package after `60` seconds. This can be changed with the
 Returns the description of the identifer under the cursor. Can be used to plug
 into the statusline.
 
+
+                                                   *go#tool#DescribeBalloon()*
+
+Suitable to be used as an expression to show the evaluation balloon. See `help
+balloonexpr`.
+
 ==============================================================================
 SETTINGS                                                        *go-settings*
 


### PR DESCRIPTION
Teach vim-go how to display balloons with information from guru describe.

During development, I had to experiment a bit with the best way to hook this up. During those experiments I made a few other topical changes:
* DRY out the `:GoInfo` display code so there's only one place that has to change if we modify it again instead of having to remember to do it for both modes.
* Use the config functions in `plugin/go.vim` instead of referencing the config values explicitly.
* Remove some extra spaces.

A few things to note for any testers:
* the balloons work well with iTerm, but not in tmux. It's not clear if there's anyway to get them to work in tmux.
* Neovim does not support balloons.
* I explicitly added an early return when jobs are not available to avoid the performance problems that synchronous calls to populate the balloon would cause...

Fixes #1963

