### PR TITLE
gocode: add support for experimental gocode

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -1,5 +1,11 @@
 function! s:gocodeCommand(cmd, args) abort
-  let bin_path = go#path#CheckBinPath("gocode")
+  let l:gocode_bin = "gocode"
+  let l:gomod = go#util#gomod()
+  if filereadable(l:gomod)
+    let l:gocode_bin = "gocode-gomod"
+  endif
+
+  let bin_path = go#path#CheckBinPath(l:gocode_bin)
   if empty(bin_path)
     return []
   endif

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -2,6 +2,15 @@ function! s:gocodeCommand(cmd, args) abort
   let l:gocode_bin = "gocode"
   let l:gomod = go#util#gomod()
   if filereadable(l:gomod)
+    " Save the file when in module mode so that go list can read the
+    " imports. If the user doesn't have autowrite or autorwriteall enabled,
+    " they'll need to write the file manually to get reliable results.
+    " See https://github.com/fatih/vim-go/pull/1988#issuecomment-428576989.
+    "
+    " TODO(bc): don't save the file when in module mode once
+    " golang.org/x/tools/go/packages has support for an overlay and it's used
+    " by gocode.
+    call go#cmd#autowrite()
     let l:gocode_bin = "gocode-gomod"
   endif
 

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -127,6 +127,13 @@ function! go#util#gopath() abort
   return substitute(s:exec(['go', 'env', 'GOPATH'])[0], '\n', '', 'g')
 endfunction
 
+" gomod returns 'go env GOMOD'. gomod changes depending on the folder. Don't
+" use go#util#env as it caches the value.
+function! go#util#gomod() abort
+  return substitute(s:exec(['go', 'env', 'GOMOD'])[0], '\n', '', 'g')
+endfunction
+
+
 function! go#util#osarch() abort
   return go#util#env("goos") . '_' . go#util#env("goarch")
 endfunction

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -47,6 +47,7 @@ let s:packages = {
       \ 'errcheck':      ['github.com/kisielk/errcheck'],
       \ 'fillstruct':    ['github.com/davidrjenni/reftools/cmd/fillstruct'],
       \ 'gocode':        ['github.com/mdempsky/gocode', {'windows': ['-ldflags', '-H=windowsgui']}],
+      \ 'gocode-gomod':  ['github.com/stamblerre/gocode'],
       \ 'godef':         ['github.com/rogpeppe/godef'],
       \ 'gogetdoc':      ['github.com/zmb3/gogetdoc'],
       \ 'goimports':     ['golang.org/x/tools/cmd/goimports'],


### PR DESCRIPTION
WIP. Somehow `gocode-gomod` only returns %20 of the time the candidates. To test it you can use `gomodifytags` repo. First pen gocode-gomod in debug mode to see that it doesn't return any candidates:

```
gocode-gomod exit
gocode-gomode -s -debug
```

Clone gomodifytags and play around:

```
git clone https://github.com/fatih/gomodifytags
cd gomodifytags
vim main.go
// try to complete flag. exported identifiers
```

This doesn't work always, not sure why.

For more information see: https://github.com/Microsoft/vscode-go/pull/1932