### PR TITLE
Fix missing extension for Windows

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -134,9 +134,14 @@ function! s:GoInstallBinaries(updateBinaries, ...)
 
     let bin_setting_name = "go_" . binary . "_bin"
 
-    let bin = binary
     if exists("g:{bin_setting_name}")
       let bin = g:{bin_setting_name}
+    else
+      if go#util#IsWin()
+        let bin = binary . '.exe'
+      else
+        let bin = binary
+      endif
     endif
 
     if !executable(bin) || a:updateBinaries == 1


### PR DESCRIPTION
The binaries installed via `:GoUpdateBinaries` cannot be executable on Windows since the binaries do not have an extension.

This pull-request adds the ".exe" extension to the binary file name.