### PR TITLE
adjust dlv flags for its new logging option

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -556,7 +556,7 @@ function! go#debug#Start(is_test, ...) abort
           \ '--output', tempname(),
           \ '--headless',
           \ '--api-version', '2',
-          \ '--log', 'debugger',
+          \ '--log', '--log-output', 'debugger,rpc',
           \ '--listen', go#config#DebugAddress(),
           \ '--accept-multiclient',
     \]


### PR DESCRIPTION
Delve recently added `--log-output`
(https://github.com/derekparker/delve/pull/1230); adjust the dlv options
accordingly.