### PR TITLE
Fix highlighting version on gomod

### DIFF
--- a/syntax/gomod.vim
+++ b/syntax/gomod.vim
@@ -39,7 +39,8 @@ highlight default link gomodReplaceOperator Operator
 
 " highlight semver, note that this is very simple. But it works for now
 syntax match gomodVersion "v\d\+\.\d\+\.\d\+"
-syntax match gomodVersion "v\d\+\.\d\+\.\d\+-.*"
+syntax match gomodVersion "v\d\+\.\d\+\.\d\+-\S*"
+syntax match gomodVersion "v\d\+\.\d\+\.\d\++incompatible"
 highlight default link gomodVersion Identifier
 
 let b:current_syntax = "gomod"


### PR DESCRIPTION
Hi,

I started using Go modules with Go 1.11. And I found some highlights are not correct as follows:

- Version may have `+incompatible` suffix. I'm not sure that other words than 'incompatible' are used as suffix. For safety, I hard-coded `+incompatible` in the highlight definition.
- Comment after version is highlighted as part of version

I took screenshot of my `go.mod` before/after this fix.

- Before

<img width="689" alt="before" src="https://user-images.githubusercontent.com/823277/45927816-2d2f8280-bf74-11e8-84c9-98aca4d5b473.png">

- After

<img width="689" alt="after" src="https://user-images.githubusercontent.com/823277/45927818-37ea1780-bf74-11e8-948a-134fbec649c2.png">
