### PR TITLE
match gomod versions correctly

### DIFF
--- a/autoload/go/highlight_test.vim
+++ b/autoload/go/highlight_test.vim
@@ -1,0 +1,95 @@
+function! Test_gomodVersion_highlight() abort
+  try
+    syntax on
+
+    let l:dir= gotest#write_file('gomodtest/go.mod', [
+          \ 'module github.com/fatih/vim-go',
+          \ '',
+          \ '\x1frequire (',
+          \ '\tversion/simple v1.0.0',
+          \ '\tversion/pseudo/premajor v1.0.0-20060102150405-0123456789abcdef',
+          \ '\tversion/pseudo/prerelease v1.0.0-prerelease.0.20060102150405-0123456789abcdef',
+          \ '\tversion/pseudo/prepatch v1.0.1-0.20060102150405-0123456789abcdef',
+          \ '\tversion/simple/incompatible v2.0.0+incompatible',
+          \ '\tversion/pseudo/premajor/incompatible v2.0.0-20060102150405-0123456789abcdef+incompatible',
+          \ '\tversion/pseudo/prerelease/incompatible v2.0.0-prerelease.0.20060102150405-0123456789abcdef+incompatible',
+          \ '\tversion/pseudo/prepatch/incompatible v2.0.1-0.20060102150405-0123456789abcdef+incompatible',
+          \ ')'])
+
+    let l:lineno = 4
+    let l:lineclose = line('$')
+    while l:lineno < l:lineclose
+      let l:line = getline(l:lineno)
+      let l:col = col([l:lineno, '$']) - 1
+      let l:idx = len(l:line) - 1
+      let l:from = stridx(l:line, ' ') + 1
+
+      while l:idx >= l:from
+        call cursor(l:lineno, l:col)
+        let l:synname = synIDattr(synID(l:lineno, l:col, 1), 'name')
+        let l:errlen = len(v:errors)
+
+        call assert_equal('gomodVersion', l:synname, 'version on line ' . l:lineno)
+
+        " continue at the next line if there was an error at this column;
+        " there's no need to test each column once an error is detected.
+        if l:errlen < len(v:errors)
+          break
+        endif
+
+        let l:col -= 1
+        let l:idx -= 1
+      endwhile
+      let l:lineno += 1
+    endwhile
+  finally
+    call delete(l:dir, 'rf')
+  endtry
+endfunc
+
+function! Test_gomodVersion_incompatible_highlight() abort
+  try
+    syntax on
+
+    let l:dir= gotest#write_file('gomodtest/go.mod', [
+          \ 'module github.com/fatih/vim-go',
+          \ '',
+          \ '\x1frequire (',
+          \ '\tversion/invalid/incompatible v1.0.0+incompatible',
+          \ '\tversion/invalid/premajor/incompatible v1.0.0-20060102150405-0123456789abcdef+incompatible',
+          \ '\tversion/invalid/prerelease/incompatible v1.0.0-prerelease.0.20060102150405-0123456789abcdef+incompatible',
+          \ '\tversion/invalid/prepatch/incompatible v1.0.1-0.20060102150405-0123456789abcdef+incompatible',
+          \ ')'])
+
+    let l:lineno = 4
+    let l:lineclose = line('$')
+    while l:lineno < l:lineclose
+      let l:line = getline(l:lineno)
+      let l:col = col([l:lineno, '$']) - 1
+      let l:idx = len(l:line) - 1
+      let l:from = stridx(l:line, '+')
+
+      while l:idx >= l:from
+        call cursor(l:lineno, l:col)
+        let l:synname = synIDattr(synID(l:lineno, l:col, 1), 'name')
+        let l:errlen = len(v:errors)
+
+        call assert_notequal('gomodVersion', l:synname, 'version on line ' . l:lineno)
+
+        " continue at the next line if there was an error at this column;
+        " there's no need to test each column once an error is detected.
+        if l:errlen < len(v:errors)
+          break
+        endif
+
+        let l:col -= 1
+        let l:idx -= 1
+      endwhile
+      let l:lineno += 1
+    endwhile
+  finally
+    call delete(l:dir, 'rf')
+  endtry
+endfunc
+
+" vim: sw=2 ts=2 et

--- a/syntax/gomod.vim
+++ b/syntax/gomod.vim
@@ -37,10 +37,26 @@ syntax match gomodReplaceOperator "\v\=\>"
 highlight default link gomodReplaceOperator Operator
 
 
-" highlight semver, note that this is very simple. But it works for now
-syntax match gomodVersion "v\d\+\.\d\+\.\d\+"
-syntax match gomodVersion "v\d\+\.\d\+\.\d\+-\S*"
-syntax match gomodVersion "v\d\+\.\d\+\.\d\++incompatible"
+" highlight versions:
+"  * vX.Y.Z
+"  * vX.0.0-yyyyymmddhhmmss-abcdefabcdef
+"  * vX.Y.Z-pre.0.yyyymmddhhmmss-abcdefabcdef
+"  * vX.Y.(Z+1)-0.yyyymmddhhss-abcdefabcdef
+"  * +incompatible suffix when X > 1
+" match vX.Y.Z and their prereleases
+syntax match gomodVersion "v\d\+\.\d\+\.\d\+\%(-\%(\w\+\.\)\+0\.\d\{14}-\x\+\)\?"
+" match target when most recent version before the target is X.Y.Z
+syntax match gomodVersion "v\d\+\.\d\+\.[1-9]\{1}\d*\%(-0\.\%(\d\{14}-\x\+\)\)\?"
+" match target without a major version before the commit (e.g.  vX.0.0-yyyymmddhhmmss-abcdefabcdef)
+syntax match gomodVersion "v\d\+\.0\.0-\d\{14\}-\x\+"
+
+" match vX.Y.Z and their prereleases for X>1
+syntax match gomodVersion "v[2-9]\{1}\d\?\.\d\+\.\d\+\%(-\%(\w\+\.\)\+0\.\d\{14\}-\x\+\)\?\%(+incompatible\>\)\?"
+" match target when most recent version before the target is X.Y.Z for X>1
+syntax match gomodVersion "v[2-9]\{1}\d\?\.\d\+\.[1-9]\{1}\d*\%(-0\.\%(\d\{14\}-\x\+\)\)\?\%(+incompatible\>\)\?"
+" match target without a major version before the commit (e.g.  vX.0.0-yyyymmddhhmmss-abcdefabcdef) for X>1
+syntax match gomodVersion "v[2-9]\{1}\d\?\.0\.0-\d\{14\}-\x\+\%(+incompatible\>\)\?"
+
 highlight default link gomodVersion Identifier
 
 let b:current_syntax = "gomod"


### PR DESCRIPTION
* don't match +incompatible when major version is < 2.
* match pseudo versions correctly.