### PR TITLE
preserve shellcmdflag and normalize for /bin/sh

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -137,12 +137,13 @@ endfunction
 " so that we always use a standard POSIX-compatible Bourne shell (and not e.g.
 " csh, fish, etc.) See #988 and #1276.
 function! s:system(cmd, ...) abort
-  " Preserve original shell and shellredir values
+  " Preserve original shell, shellredir and shellcmdflag values
   let l:shell = &shell
   let l:shellredir = &shellredir
+  let l:shellcmdflag = &shellcmdflag
 
   if !go#util#IsWin() && executable('/bin/sh')
-      set shell=/bin/sh shellredir=>%s\ 2>&1
+      set shell=/bin/sh shellredir=>%s\ 2>&1 shellcmdflag=-c
   endif
 
   try
@@ -151,6 +152,7 @@ function! s:system(cmd, ...) abort
     " Restore original values
     let &shell = l:shell
     let &shellredir = l:shellredir
+    let &shellcmdflag = l:shellcmdflag
   endtry
 endfunction
 


### PR DESCRIPTION
Fix shell related problems when `shellcmdflag` contains flags not understood by `/bin/sh` by resetting it to a safe value and restoring it at the end.