### PR TITLE
Use guibg instead of ctermbg if user is using neovim 

### DIFF
--- a/autoload/go/statusline.vim
+++ b/autoload/go/statusline.vim
@@ -53,22 +53,12 @@ function! go#statusline#Show() abort
 
   " only update highlight if status has changed.
   if status_text != s:last_status
-    if (has("nvim"))
-      if status.state =~ "success" || status.state =~ "finished" || status.state =~ "pass"
-        hi goStatusLineColor cterm=bold guibg=#5fd700 guifg=#005f00
-      elseif status.state =~ "started" || status.state =~ "analysing" || status.state =~ "compiling"
-        hi goStatusLineColor cterm=bold guibg=#ff8700 guifg=#870000
-      elseif status.state =~ "failed"
-        hi goStatusLineColor cterm=bold guibg=#ff0000 guifg=#5f0000
-      endif
-    else
-      if status.state =~ "success" || status.state =~ "finished" || status.state =~ "pass"
-        hi goStatusLineColor cterm=bold ctermbg=76 ctermfg=22
-      elseif status.state =~ "started" || status.state =~ "analysing" || status.state =~ "compiling"
-        hi goStatusLineColor cterm=bold ctermbg=208 ctermfg=88
-      elseif status.state =~ "failed"
-        hi goStatusLineColor cterm=bold ctermbg=196 ctermfg=52
-      endif
+    if status.state =~ "success" || status.state =~ "finished" || status.state =~ "pass"
+      hi goStatusLineColor cterm=bold ctermbg=76 ctermfg=22 guibg=#5fd700 guifg=#005f00
+    elseif status.state =~ "started" || status.state =~ "analysing" || status.state =~ "compiling"
+      hi goStatusLineColor cterm=bold ctermbg=208 ctermfg=88 guibg=#ff8700 guifg=#870000
+    elseif status.state =~ "failed"
+      hi goStatusLineColor cterm=bold ctermbg=196 ctermfg=52 guibg=#ff0000 guifg=#5f0000
     endif
   endif
 

--- a/autoload/go/statusline.vim
+++ b/autoload/go/statusline.vim
@@ -53,12 +53,22 @@ function! go#statusline#Show() abort
 
   " only update highlight if status has changed.
   if status_text != s:last_status
-    if status.state =~ "success" || status.state =~ "finished" || status.state =~ "pass"
-      hi goStatusLineColor cterm=bold ctermbg=76 ctermfg=22
-    elseif status.state =~ "started" || status.state =~ "analysing" || status.state =~ "compiling"
-      hi goStatusLineColor cterm=bold ctermbg=208 ctermfg=88
-    elseif status.state =~ "failed"
-      hi goStatusLineColor cterm=bold ctermbg=196 ctermfg=52
+    if (has("nvim"))
+      if status.state =~ "success" || status.state =~ "finished" || status.state =~ "pass"
+        hi goStatusLineColor cterm=bold guibg=#5fd700 guifg=#005f00
+      elseif status.state =~ "started" || status.state =~ "analysing" || status.state =~ "compiling"
+        hi goStatusLineColor cterm=bold guibg=#ff8700 guifg=#870000
+      elseif status.state =~ "failed"
+        hi goStatusLineColor cterm=bold guibg=#ff0000 guifg=#5f0000
+      endif
+    else
+      if status.state =~ "success" || status.state =~ "finished" || status.state =~ "pass"
+        hi goStatusLineColor cterm=bold ctermbg=76 ctermfg=22
+      elseif status.state =~ "started" || status.state =~ "analysing" || status.state =~ "compiling"
+        hi goStatusLineColor cterm=bold ctermbg=208 ctermfg=88
+      elseif status.state =~ "failed"
+        hi goStatusLineColor cterm=bold ctermbg=196 ctermfg=52
+      endif
     endif
   endif
 


### PR DESCRIPTION
If it is neovim, goStatusLineColor must be using guibg and guifg to reflect correct colors. I am not expert in vim script. Hence please let me know if we can refactor this code.