### PR TITLE
Debugger: compatibility with neovim

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -150,7 +150,7 @@ endfunction
 " Update the location of the current breakpoint or line we're halted on based on
 " response from dlv.
 function! s:update_breakpoint(res) abort
-  if type(a:res) ==# v:t_none
+  if type(a:res) ==# type(v:null)
     return
   endif
 


### PR DESCRIPTION
`v:t_none` is undefined in neovim.

After starting the debugger and each execution of `:GoDebugNext` or `:GoDebugStep`, I receive following output:
```
Error detected while processing function 28[1]..<SNR>135_stack_cb[13]..<SNR>135_update_breakpoint:                                                                                                                                      
line    1:
E121: Undefined variable: v:t_none
Press ENTER or type command to continue
Error detected while processing function 28[1]..<SNR>135_stack_cb[13]..<SNR>135_update_breakpoint:
line    1:
E15: Invalid expression: type(a:res) ==# v:t_none
```

Fix introduces `type(v:null)` which seems to work with both, vim8 and neovim.