### PR TITLE
Debugger: optional highlighting

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -420,6 +420,10 @@ function! go#config#HighlightVariableDeclarations() abort
   return get(g:, 'go_highlight_variable_declarations', 0)
 endfunction
 
+function! go#config#DebugDefaultHighlighting() abort
+  return get(g:, 'go_debug_default_highlighting', 1)
+endfunction
+
 function! go#config#FoldEnable(...) abort
   if a:0 > 0
     return index(go#config#FoldEnable(), a:1) > -1

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1902,7 +1902,7 @@ The `gohtmltmpl` filetype is automatically set for `*.tmpl` files; the
                                                     *gomod* *ft-gomod-syntax*
 go.mod file syntax~
 
-The `gomod` 'filetype' provides syntax highlighting for Go's module file 
+The `gomod` 'filetype' provides syntax highlighting for Go's module file
 `go.mod`
 
 
@@ -2110,6 +2110,22 @@ Server address `dlv` will listen on; must be in `hostname:port` format.
 Defaults to `127.0.0.1:8181`:
 >
   let g:go_debug_address = '127.0.0.1:8181'
+
+
+                                           *'g:go_debug_default_highlighting'*
+
+Provides the option to override debugger highlighting
+
+Default:
+
+>
+  let g:go_debug_default_highlighting = 1
+  hi GoDebugBreakpoint term=standout
+    \ ctermbg=117 ctermfg=0
+    \ guibg=#BAD4F5 guifg=Black
+  hi GoDebugCurrent term=reverse
+    \ ctermbg=12 ctermfg=7
+    \ guibg=DarkBlue guifg=White
 <
 
 ==============================================================================

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -374,8 +374,10 @@ function! s:hi()
   hi def      goCoverageUncover    ctermfg=red guifg=#F92672
 
   " :GoDebug commands
-  hi GoDebugBreakpoint term=standout ctermbg=117 ctermfg=0 guibg=#BAD4F5  guifg=Black
-  hi GoDebugCurrent    term=reverse  ctermbg=12  ctermfg=7 guibg=DarkBlue guifg=White
+  if go#config#DebugDefaultHighlighting()
+    hi GoDebugBreakpoint term=standout ctermbg=117 ctermfg=0 guibg=#BAD4F5  guifg=Black
+    hi GoDebugCurrent term=reverse  ctermbg=12  ctermfg=7 guibg=DarkBlue guifg=White
+  endif
 endfunction
 
 augroup vim-go-hi


### PR DESCRIPTION
The default highlighting of `GoDebugCurrent` makes the current line unreadable with my color scheme.
Overriding it in my `init.vim` or `ftplugin/go.vim` did not work.

PR introduces an option to skip the highlighting in `syntax/go.vim`, so one can specify their preferred colors in their configuration via `let g:go_debug_default_highlighting = 0`.