### PR TITLE
Remove go-explorer from Documentation

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -148,9 +148,6 @@ The following plugins are supported for use with vim-go:
   https://github.com/SirVer/ultisnips or
   https://github.com/joereynolds/vim-minisnip
 
-* For a better documentation viewer check out:
-  https://github.com/garyburd/go-explorer
-
 * Integration with `delve` (Neovim only):
   https://github.com/jodosha/vim-godebug
 


### PR DESCRIPTION
go-explorer is removed because it is no longer in github and the link provided in the documentation is no longer valid.