### PR TITLE
gocode: Restore support for unimported packages

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -33,6 +33,10 @@ function! s:gocodeCommand(cmd, args) abort
     let cmd = extend(cmd, ['-source'])
   endif
 
+  if go#config#GocodeUnimportedPackages()
+    let cmd = extend(cmd, ['-unimported-packages'])
+  endif
+
   let cmd = extend(cmd, [a:cmd])
   let cmd = extend(cmd, a:args)
 

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -135,6 +135,10 @@ function! go#config#SetGuruScope(scope) abort
   endif
 endfunction
 
+function! go#config#GocodeUnimportedPackages() abort
+  return get(g:, 'go_gocode_unimported_packages', 0)
+endfunction
+
 let s:sock_type = (has('win32') || has('win64')) ? 'tcp' : 'unix'
 function! go#config#GocodeSocketType() abort
   return get(g:, 'go_gocode_socket_type', s:sock_type)

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1611,6 +1611,14 @@ package and packages that have been installed will proposed.
 >
   let g:go_gocode_propose_source = 1
 <
+                                           *'g:go_gocode_unimported_packages'*
+
+Specifies whether `gocode` should include suggestions from unimported
+packages. By default it is disabled.
+>
+  let g:go_gocode_unimported_packages = 0
+<
+
                                                    *'g:go_gocode_socket_type'*
 
 Specifies whether `gocode` should use a different socket type. By default


### PR DESCRIPTION
`g:go_gocode_unimported_packages` option was removed by #1853.
However, unimproted packages feature has been re-implemented to `github.com/mdempsky/gocode`, so we can restore the option to enable that feature.