### PR TITLE
Make $PATH take precedence over go_bin_path

### DIFF
--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -155,7 +155,7 @@ function! go#path#CheckBinPath(binpath) abort
   if !empty(go_bin_path)
     " append our GOBIN and GOPATH paths and be sure they can be found there...
     " let us search in our GOBIN and GOPATH paths
-    let $PATH = go_bin_path . go#util#PathListSep() . $PATH
+    let $PATH = $PATH . go#util#PathListSep() . go_bin_path
   endif
 
   " if it's in PATH just return it


### PR DESCRIPTION
We're using wrapper scripts at the front of $PATH to ensure that everyone is using a particular version of gofmt/goimports. I was surprised that these weren't picked up by vim-go. This change makes vim-go respect the user's preferences by using $PATH first and only falling back to go_bin_path if the requested binaries aren't in $PATH at all.