### PR TITLE
Add the go_search_bin_path_first option

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -356,6 +356,10 @@ function! go#config#BinPath() abort
   return get(g:, "go_bin_path", "")
 endfunction
 
+function! go#config#SearchBinPathFirst() abort
+  return get(g:, 'go_search_bin_path_first', 1)
+endfunction
+
 function! go#config#HighlightArrayWhitespaceError() abort
   return get(g:, 'go_highlight_array_whitespace_error', 0)
 endfunction

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -142,7 +142,8 @@ function! go#path#BinPath() abort
 endfunction
 
 " CheckBinPath checks whether the given binary exists or not and returns the
-" path of the binary. It returns an empty string doesn't exists.
+" path of the binary, respecting the go_bin_path and go_search_bin_path_first
+" settings. It returns an empty string if the binary doesn't exist.
 function! go#path#CheckBinPath(binpath) abort
   " remove whitespaces if user applied something like 'goimports   '
   let binpath = substitute(a:binpath, '^\s*\(.\{-}\)\s*$', '\1', '')
@@ -155,7 +156,12 @@ function! go#path#CheckBinPath(binpath) abort
   if !empty(go_bin_path)
     " append our GOBIN and GOPATH paths and be sure they can be found there...
     " let us search in our GOBIN and GOPATH paths
-    let $PATH = go_bin_path . go#util#PathListSep() . $PATH
+    " respect the ordering specified by go_search_bin_path_first
+    if go#config#SearchBinPathFirst()
+      let $PATH = go_bin_path . go#util#PathListSep() . $PATH
+    else
+      let $PATH = $PATH . go#util#PathListSep() . go_bin_path
+    endif
   endif
 
   " if it's in PATH just return it

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1364,14 +1364,27 @@ Command to use for |:GoDoc|; only used when invoked with a package name. The
 under the cursor (i.e. without argument or from |K|). >
 
   let g:go_doc_command = ["godoc"]
-
-<                                                            *'g:go_bin_path'*
+<
+                                                             *'g:go_bin_path'*
 
 Use this option to change default path for vim-go tools when using
 |:GoInstallBinaries| and |:GoUpdateBinaries|. If not set `$GOBIN` or
 `$GOPATH/bin` is used. >
 
   let g:go_bin_path = ""
+<
+                                                *'g:go_search_bin_path_first'*
+
+This option lets |'g:go_bin_path'| (or its default value) take precedence over
+$PATH when invoking a tool command such as |:GoFmt| or |:GoImports|.
+
+Enabling this option ensures that the binaries installed via
+|:GoInstallBinaries| and |:GoUpdateBinaries| are the same ones that are
+invoked via the tool commands.
+
+By default it is enabled. >
+
+  let g:go_search_bin_path_first = 1
 <
                                                        *'g:go_snippet_engine'*
 


### PR DESCRIPTION
This allows the user to let their $PATH take precedence over go_bin_path when looking for tools if they so choose (but defaults to keeping the current behavior). For context, see #2040.