### PR TITLE
disable proposing source by default

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -149,7 +149,7 @@ function! go#config#GocodeProposeBuiltins() abort
 endfunction
 
 function! go#config#GocodeProposeSource() abort
-  return get(g:, 'go_gocode_propose_source', 1)
+  return get(g:, 'go_gocode_propose_source', 0)
 endfunction
 
 function! go#config#EchoCommandInfo() abort

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1622,7 +1622,7 @@ Specifies whether `gocode` should use source files instead of binary packages
 for autocompletion proposals. When disabled, only identifiers from the current
 package and packages that have been installed will proposed.
 >
-  let g:go_gocode_propose_source = 1
+  let g:go_gocode_propose_source = 0
 <
                                            *'g:go_gocode_unimported_packages'*
 


### PR DESCRIPTION
Now that gocode support `-fallback-to-source`, `-source` does not need
to be the default, as it slows down gocode significantly.