### PR TITLE
Add godoc option for goinfo usage

### DIFF
--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -86,6 +86,8 @@ function! go#tool#Info(showstatus) abort
     call go#complete#Info(a:showstatus)
   elseif l:mode == 'guru'
     call go#guru#DescribeInfo(a:showstatus)
+  elseif l:mode == 'godoc'
+    call go#doc#Open('new', 'split', <f-args>)
   else
     call go#util#EchoError('go_info_mode value: '. l:mode .' is not valid. Valid values are: [gocode, guru]')
   endif

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -87,7 +87,7 @@ function! go#tool#Info(showstatus) abort
   elseif l:mode == 'guru'
     call go#guru#DescribeInfo(a:showstatus)
   elseif l:mode == 'godoc'
-    call go#doc#Open('new', 'split', <f-args>)
+    call go#doc#Open('new', 'split')
   else
     call go#util#EchoError('go_info_mode value: '. l:mode .' is not valid. Valid values are: [gocode, guru]')
   endif


### PR DESCRIPTION
## Problem

- Gocode or guru only provide one line definition, sometimes we also want to read function's comment as well.

## Solution

- Use godoc for that purpose