### PR TITLE
use go doc instead of godoc

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -314,10 +314,6 @@ function! go#config#DeclsMode() abort
   return get(g:, "go_decls_mode", "")
 endfunction
 
-function! go#config#DocCommand() abort
-  return get(g:, "go_doc_command", ["godoc"])
-endfunction
-
 function! go#config#FmtCommand() abort
   return get(g:, "go_fmt_command", "gofmt")
 endfunction

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -59,9 +59,8 @@ function! go#doc#Open(newmode, mode, ...) abort
       return
     endif
 
-    let [l:out, l:err] = go#util#Exec(go#config#DocCommand() + a:000)
-  " Without argument: run gogetdoc on cursor position.
-  else
+    let [l:out, l:err] = go#util#Exec(['go', 'doc'] + a:000)
+  else " Without argument: run gogetdoc on cursor position.
     let [l:out, l:err] = s:gogetdoc(0)
     if out == -1
       return

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1364,14 +1364,6 @@ mappings of |:GoDef|. By default it's disabled. >
 
   let g:go_def_reuse_buffer = 0
 <
-                                                          *'g:go_doc_command'*
-
-Command to use for |:GoDoc|; only used when invoked with a package name. The
-`gogetdoc` command is always used when |:GoDoc| is used on the identifier
-under the cursor (i.e. without argument or from |K|). >
-
-  let g:go_doc_command = ["godoc"]
-<
                                                              *'g:go_bin_path'*
 
 Use this option to change default path for vim-go tools when using


### PR DESCRIPTION
`godoc`'s CLI support is deprecated and expected to be removed in Go
1.12; `go doc` is the future; adopt it now.

Fixes #2069