### PR TITLE
Improve debugger

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -206,7 +206,7 @@ endfunction
 
 function! go#config#DebugCommands() abort
   " make sure g:go_debug_commands is set so that it can be added to easily.
-  let g:go_debug_commands = get(g:, 'go_debug_commands', {})
+  let g:go_debug_commands = get(g:, 'go_debug_commands', [])
   return g:go_debug_commands
 endfunction
 

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -96,7 +96,7 @@ function! s:call_jsonrpc(method, ...) abort
         call chansend(l:ch, req_json)
 
         if go#util#HasDebug('debugger-commands')
-          let g:go_debug_commands = add(g:go_debug_commands, {
+          let g:go_debug_commands = add(go#config#DebugCommands(), {
                 \ 'request':  req_json,
                 \ 'response': Cb,
           \ })
@@ -108,7 +108,7 @@ function! s:call_jsonrpc(method, ...) abort
       call ch_sendraw(l:ch, req_json)
 
       if go#util#HasDebug('debugger-commands')
-        let g:go_debug_commands = add(g:go_debug_commands, {
+        let g:go_debug_commands = add(go#config#DebugCommands(), {
               \ 'request':  req_json,
               \ 'response': Cb,
         \ })
@@ -135,7 +135,7 @@ function! s:call_jsonrpc(method, ...) abort
     endif
 
     if go#util#HasDebug('debugger-commands')
-      let g:go_debug_commands = add(g:go_debug_commands, {
+      let g:go_debug_commands = add(go#config#DebugCommands(), {
             \ 'request':  req_json,
             \ 'response': resp_json,
       \ })

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -581,13 +581,6 @@ function! go#debug#Start(is_test, ...) abort
     call go#config#SetDebugDiag(s:state)
   endif
 
-  " cd in to test directory; this is also what running "go test" does.
-  if a:is_test
-    lcd %:p:h
-  endif
-
-  let s:state.is_test = a:is_test
-
   let dlv = go#path#CheckBinPath("dlv")
   if empty(dlv)
     return
@@ -603,6 +596,20 @@ function! go#debug#Start(is_test, ...) abort
     else
       let l:pkgname = go#package#FromPath(getcwd())
     endif
+
+    if l:pkgname is -1
+      call go#util#EchoError('could not determine package name')
+      return
+    endif
+
+    " cd in to test directory; this is also what running "go test" does.
+    if a:is_test
+      " TODO(bc): Either remove this if it's ok to do so or else record it and
+      " reset cwd after the job completes.
+      lcd %:p:h
+    endif
+
+    let s:state.is_test = a:is_test
 
     let l:args = []
     if len(a:000) > 1

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -589,9 +589,8 @@ function! go#debug#Start(is_test, ...) abort
   try
     if len(a:000) > 0
       let l:pkgname = a:1
-      " Expand .; otherwise this won't work from a tmp dir.
       if l:pkgname[0] == '.'
-        let l:pkgname = go#package#FromPath(getcwd()) . l:pkgname[1:]
+        let l:pkgname = go#package#FromPath(l:pkgname)
       endif
     else
       let l:pkgname = go#package#FromPath(getcwd())

--- a/autoload/go/debug_test.vim
+++ b/autoload/go/debug_test.vim
@@ -1,0 +1,54 @@
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+function! Test_GoDebugStart_Empty() abort
+  call s:debug()
+endfunction
+
+function! Test_GoDebugStart_RelativePackage() abort
+  call s:debug('./debugmain')
+endfunction
+
+function! Test_GoDebugStart_Package() abort
+  call s:debug('debugmain')
+endfunction
+
+function! s:debug(...) abort
+  if !go#util#has_job()
+    return
+  endif
+
+  try
+    let l:tmp = gotest#load_fixture('debugmain/debugmain.go')
+
+    call go#debug#Breakpoint(6)
+
+    call assert_false(exists(':GoDebugStop'))
+
+    if a:0 == 0
+      let l:cd = exists('*haslocaldir') && haslocaldir() ? 'lcd' : 'cd'
+      execute l:cd . ' debugmain'
+      call go#debug#Start(0)
+    else
+      call go#debug#Start(0, a:1)
+    endif
+
+    let l:start = reltime()
+    while !exists(':GoDebugStop') && reltimefloat(reltime(l:start)) < 10
+      sleep 100m
+    endwhile
+
+    call go#debug#Stop()
+
+    call assert_false(exists(':GoDebugStop'))
+  finally
+    call delete(l:tmp, 'rf')
+  endtry
+endfunction
+
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -92,7 +92,6 @@ function! go#job#Options(args)
     let state.errorformat = a:args.errorformat
   endif
 
-  " do nothing in state.complete by default.
   function state.complete(job, exit_status, data)
     if has_key(self, 'custom_complete')
       let l:winid = win_getid(winnr())

--- a/autoload/go/test-fixtures/debugmain/debugmain.go
+++ b/autoload/go/test-fixtures/debugmain/debugmain.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("vim-go")
+}

--- a/scripts/docker-test
+++ b/scripts/docker-test
@@ -8,6 +8,8 @@ vimgodir=$(cd -P "$(dirname "$0")/.." > /dev/null && pwd)
 cd "$vimgodir"
 
 docker build --tag vim-go-test .
-docker run --rm vim-go-test
+# seccomp=confined is required for dlv to run in a container, hence it's
+# required for vim-go's debug tests.
+docker run --rm --security-opt="seccomp=unconfined" vim-go-test
 
 # vim:ts=2:sts=2:sw=2:et

--- a/scripts/runtest.vim
+++ b/scripts/runtest.vim
@@ -36,7 +36,8 @@ source %
 " cd into the folder of the test file.
 let s:cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
 let s:testfile = expand('%:t')
-execute s:cd . expand('%:p:h')
+let s:dir = expand('%:p:h')
+execute s:cd . s:dir
 
 " Export root path to vim-go dir.
 let g:vim_go_root = fnamemodify(getcwd(), ':p')
@@ -69,6 +70,8 @@ for s:test in sort(s:tests)
 
   " Restore GOPATH after each test.
   let $GOPATH = s:gopath
+  " Restore the working directory after each test.
+  execute s:cd . s:dir
 
   let s:elapsed_time = substitute(reltimestr(reltime(s:started)), '^\s*\(.\{-}\)\s*$', '\1', '')
   let s:done += 1


### PR DESCRIPTION
##### reset current directory after each test

##### use go list to get import path via go#package#FromPath

##### fix uses of g:go_debug_commands
* use go#config#DebugCommands() when reading the value so that it
  doesn't have to be set before the read.
* return an empty list instead of an empty dictionary for its default
  value.


##### Shutdown and detach from delve correctly
Use a single connection to delve to simplify detaching properly. The
previous implementation was making a connection to delve for each
request and was never closing any of them. Instead, create a single
connection to delve and reuse it for each rpc call. This allows vim-go
to not have to pass `--accept-multiclient`, which in turn shutsdown
delve when detach is called.

As part of this work, `call_jsonrpc` was refactored to not deal with
callbacks explicitly. Because Neovim requires a callback to get data
from a socket, the `on_data` callback was moved into `out_cb` and
improved to deal with the edge cases that Neovim has with regard to
partial messages.


##### delay changing working directory for dlv test
Delay changing the working directory for debugging tests only if the
package to be debugged could be determined.

Return early and show an error if the package could not be determined.


##### add debug tests
Add debug tests to ensure that :GoDebugStart and :GoDebugStop work as
expected with no arguments, a relative package and package specified
with its full import path

The test package source file is in a package named debugmain instead of
following the usual pattern (e.g. debug), because delve seems to choke
pretty hard on when the package being debugged is named debug...
