### PR TITLE
add go_gocode_enabled option

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -128,7 +128,7 @@ Depending on your installation method, you may have to generate the plugin's
 |:helptags| manually (e.g. `:helptags ALL`).
 
 Autocompletion is enabled by default via 'omnifunc', which you can trigger
-with |i_CTRL-X_CTRL-O| (`<C-x><C-o>`).
+with |i_CTRL-X_CTRL-O| (`<C-x><C-o>`). See |'g:go_gocode_enabled'| to disable it.
 
 Supported Go plugins~                                         *vim-go-plugins*
 
@@ -1607,6 +1607,14 @@ same.
   let g:go_gorename_prefill = 'expand("<cword>") =~# "^[A-Z]"' .
         \ '? go#util#pascalcase(expand("<cword>"))' .
         \ ': go#util#camelcase(expand("<cword>"))'
+<
+                                              *'g:go_gocode_enabled'*
+
+Use this option to enable/disable `gocode` autocompletion support.
+Disabling it allows you to use completion via other service, like LSP.
+Default is enabled.
+>
+  let g:go_gocode_enabled = 1
 <
                                               *'g:go_gocode_propose_builtins'*
 

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -24,8 +24,10 @@ setlocal noexpandtab
 
 compiler go
 
-" Set gocode completion
-setlocal omnifunc=go#complete#Complete
+if get(g:, "go_gocode_enabled", 1)
+  " Set gocode completion
+  setlocal omnifunc=go#complete#Complete
+endif
 
 if get(g:, "go_doc_keywordprg_enabled", 1)
   " keywordprg doesn't allow to use vim commands, override it


### PR DESCRIPTION
I love vim-go and use it with development every day. Current I'm trying go language server for auto-completion and lint diagnostic etc. After I disabled vim-go from my workflow, I really missing commands like GoTest/GoImport, so I add `g:go_gocode_enabled` option to disable gocode completion. And now I can talk to language server for code completion/lint, and keep other vim-go useful stuff.

This small feature may be a very personal requirement. If it doesn't meet vim-go's goal, just discard it.

Thanks again for the great plugin!