### PR TITLE
Add syntax highlight to 'godoc' filetype

### DIFF
--- a/syntax/godoc.vim
+++ b/syntax/godoc.vim
@@ -1,0 +1,8 @@
+if exists('b:current_syntax')
+    finish
+endif
+
+syn include @godocGoSrc syntax/go.vim
+syn match godocGoRegion /\%^\%(\%(.\+\n\)\+\n\)\{2}/ contains=@godocGoSrc
+
+let b:current_syntax = 'godoc'


### PR DESCRIPTION
I added syntax highlighting to `godoc` filetype.

This patch highlights from head of the buffer until the second blank line as `go` filetype.

<img width="963" alt="2018-12-01 9 58 58" src="https://user-images.githubusercontent.com/823277/49322211-c40a5380-f550-11e8-8684-baeba5acdbfe.png">
