### PR TITLE
-fallback-to-source needs gocode to be running the cache importer

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -36,7 +36,7 @@ function! s:gocodeCommand(cmd, args) abort
   if go#config#GocodeProposeSource()
     let cmd = extend(cmd, ['-source'])
   else
-    let cmd = extend(cmd, ['-fallback-to-source'])
+    let cmd = extend(cmd, ['-fallback-to-source', '-cache'])
   endif
 
   if go#config#GocodeUnimportedPackages()


### PR DESCRIPTION

- therefore pass the -cache option to gocode command calls, so the
  client will start the server with the -cache option as well.
  Needs [this PR](https://github.com/mdempsky/gocode/pull/93) in gocode