### PR TITLE
fix ToggleSameIds that calls SameIds with no args

### DIFF
--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -517,9 +517,9 @@ function! go#guru#ClearSameIds() abort
   return 0
 endfunction
 
-function! go#guru#ToggleSameIds() abort
+function! go#guru#ToggleSameIds(showstatus) abort
   if go#guru#ClearSameIds() != 0
-    call go#guru#SameIds()
+    call go#guru#SameIds(a:showstatus)
   endif
 endfunction
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -16,7 +16,7 @@ command! -range=% GoReferrers call go#guru#Referrers(<count>)
 
 command! -range=0 GoSameIds call go#guru#SameIds(1)
 command! -range=0 GoSameIdsClear call go#guru#ClearSameIds()
-command! -range=0 GoSameIdsToggle call go#guru#ToggleSameIds()
+command! -range=0 GoSameIdsToggle call go#guru#ToggleSameIds(1)
 command! -range=0 GoSameIdsAutoToggle call go#guru#AutoToogleSameIds()
 
 " -- tags


### PR DESCRIPTION
`ToggleSameIds` is causing an error that says `Not enough arguments for function: go#guru#SameIds`.
So, I fixed it.

I'm glad if someone reviews this, thanks.