### PR TITLE
Remove duplicated l:importPath

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -175,7 +175,7 @@ function! s:GoInstallBinaries(updateBinaries, ...)
 
       " and then build and install it
       let l:build_cmd = ['go', 'build', '-o', go_bin_path . go#util#PathSep() . bin, l:importPath]
-      let [l:out, l:err] = go#util#Exec(l:build_cmd + [l:importPath])
+      let [l:out, l:err] = go#util#Exec(l:build_cmd)
       if l:err
         echom "Error installing " . l:importPath . ": " . l:out
       endif


### PR DESCRIPTION
`l:importPath` has been added twice  in the following code. It should be added once.

```go
let l:build_cmd = ['go', 'build', '-o', go_bin_path . go#util#PathSep() . bin, l:importPath]
let [l:out, l:err] = go#util#Exec(l:build_cmd + [l:importPath])
```