### PR TITLE
Restore &cpo even when finishing early

### DIFF
--- a/ftplugin/go/tagbar.vim
+++ b/ftplugin/go/tagbar.vim
@@ -1,7 +1,3 @@
-" don't spam the user when Vim is started in Vi compatibility mode
-let s:cpo_save = &cpo
-set cpo&vim
-
 " Check if tagbar is installed under plugins or is directly under rtp
 " this covers pathogen + Vundle/Bundle
 "
@@ -12,6 +8,10 @@ if !executable('ctags')
 elseif globpath(&rtp, 'plugin/tagbar.vim') == ""
   finish
 endif
+
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
 
 if !exists("g:go_gotags_bin")
   let g:go_gotags_bin = "gotags"

--- a/indent/go.vim
+++ b/indent/go.vim
@@ -13,10 +13,6 @@ if exists("b:did_indent")
 endif
 let b:did_indent = 1
 
-" don't spam the user when Vim is started in Vi compatibility mode
-let s:cpo_save = &cpo
-set cpo&vim
-
 " C indentation is too far off useful, mainly due to Go's := operator.
 " Let's just define our own.
 setlocal nolisp
@@ -27,6 +23,10 @@ setlocal indentkeys+=<:>,0=},0=)
 if exists("*GoIndent")
   finish
 endif
+
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
 
 function! GoIndent(lnum) abort
   let prevlnum = prevnonblank(a:lnum-1)

--- a/indent/gohtmltmpl.vim
+++ b/indent/gohtmltmpl.vim
@@ -2,10 +2,6 @@ if exists("b:did_indent")
   finish
 endif
 
-" don't spam the user when Vim is started in Vi compatibility mode
-let s:cpo_save = &cpo
-set cpo&vim
-
 runtime! indent/html.vim
 
 " Indent Golang HTML templates
@@ -16,6 +12,10 @@ setlocal indentkeys+==else,=end
 if exists("*GetGoHTMLTmplIndent")
   finish
 endif
+
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
 
 function! GetGoHTMLTmplIndent(lnum)
   " Get HTML indent


### PR DESCRIPTION
If a script calls `finish`, the restoration of `&cpo`, which is at the
end of the script, never gets called.

As a follow-up to #2055, this change moves the place where `&cpo` is
preserved until after the places where `finish` is called.  I believe
this is safe, since those places are near the beginning of their
respective scripts, and there's nothing earlier that's dependent on the
default setting of `&cpo`.