### PR TITLE
use modified buffer as input to gocode-gomod

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -6,15 +6,6 @@ function! s:gocodeCommand(cmd, args) abort
   let l:gocode_bin = "gocode"
   let l:gomod = go#util#gomod()
   if filereadable(l:gomod)
-    " Save the file when in module mode so that go list can read the
-    " imports. If the user doesn't have autowrite or autorwriteall enabled,
-    " they'll need to write the file manually to get reliable results.
-    " See https://github.com/fatih/vim-go/pull/1988#issuecomment-428576989.
-    "
-    " TODO(bc): don't save the file when in module mode once
-    " golang.org/x/tools/go/packages has support for an overlay and it's used
-    " by gocode.
-    call go#cmd#autowrite()
     let l:gocode_bin = "gocode-gomod"
   endif
 


### PR DESCRIPTION
Saving a modified buffer to disk is no longer necessary for
autocompletion with github.com/stamblerre/gocode;
golang.org/x/tools/go/packages now supports overlays, and support for
them was merged to github.com/stamblerre/gocode recently.