### PR TITLE
remove unnecessary messages

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -489,7 +489,6 @@ function! s:err_cb(ch, msg) abort
     return
   endif
 
-  call go#util#EchoError(a:msg)
   let s:state['message'] += [a:msg]
 endfunction
 
@@ -499,7 +498,6 @@ function! s:out_cb(ch, msg) abort
     return
   endif
 
-  call go#util#EchoProgress(a:msg)
   let s:state['message'] += [a:msg]
 
   if stridx(a:msg, go#config#DebugAddress()) != -1

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -84,7 +84,6 @@ function! s:jump_to_declaration_cb(mode, bin_name, job, exit_status, data) abort
   endif
 
   call go#def#jump_to_declaration(a:data[0], a:mode, a:bin_name)
-  call go#util#EchoSuccess(fnamemodify(a:data[0], ":t"))
 
   " capture the active window so that after the exit_cb and close_cb callbacks
   " can return to it when a:mode caused a split.

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -123,7 +123,9 @@ endfunction
 function! go#lint#Vet(bang, ...) abort
   call go#cmd#autowrite()
 
-  call go#util#EchoProgress('calling vet...')
+  if go#config#EchoCommandInfo()
+    call go#util#EchoProgress('calling vet...')
+  endif
 
   if a:0 == 0
     let [l:out, l:err] = go#util#Exec(['go', 'vet', go#package#ImportPath()])
@@ -140,7 +142,6 @@ function! go#lint#Vet(bang, ...) abort
     if !empty(errors) && !a:bang
       call go#list#JumpToFirst(l:listtype)
     endif
-    call go#util#EchoError('[vet] FAIL')
   else
     call go#list#Clean(l:listtype)
     call go#util#EchoSuccess('[vet] PASS')

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -89,7 +89,6 @@ function s:parse_errors(exit_val, bang, out)
 
   let l:listtype = go#list#Type("GoRename")
   if a:exit_val != 0
-    call go#util#EchoError("FAILED")
     let errors = go#tool#ParseErrors(a:out)
     call go#list#Populate(l:listtype, errors, 'Rename')
     call go#list#Window(l:listtype, len(errors))

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -84,7 +84,6 @@ function! go#test#Test(bang, compile, ...) abort
       " failed to parse errors, output the original content
       call go#util#EchoError(out)
     endif
-    call go#util#EchoError("[test] FAIL")
   else
     call go#list#Clean(l:listtype)
 

--- a/scripts/runtest.vim
+++ b/scripts/runtest.vim
@@ -48,7 +48,7 @@ redir @q
 redir END
 let s:tests = split(substitute(@q, 'function \(\k\+()\)', '\1', 'g'))
 
-" log any messages that we may already accumulated.
+" log any messages already accumulated.
 call s:logmessages()
 " Iterate over all tests and execute them.
 for s:test in sort(s:tests)


### PR DESCRIPTION
Remove messages from debugger that are already replicated in the logger
window. This also cleans up the test output.

Guard some progress messages with g:go_echo_comand_info.

Remove failure messages that are redudant due to the quickfix windows
that will be shown.