### PR TITLE
Allow for custom template directory to be set

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -67,6 +67,10 @@ function! go#config#TemplateFile() abort
   return get(g:, 'go_template_file', "hello_world.go")
 endfunction
 
+function! go#config#TemplateTestSuffix() abort
+  return get(g:, 'go_template_test_suffix', 0)
+endfunction
+
 function! go#config#StatuslineDuration() abort
   return get(g:, 'go_statusline_duration', 60000)
 endfunction

--- a/autoload/go/template.vim
+++ b/autoload/go/template.vim
@@ -24,7 +24,13 @@ function! go#template#create() abort
       else
         let l:template_file = go#config#TemplateFile()
       endif
-      let l:template_path = go#util#Join(l:root_dir, "templates", l:template_file)
+
+      " If template_file is an absolute path, use it as-is. This is to support
+      " overrides pointing to templates outside of the vim-go plugin dir
+      if fnamemodify(l:template_file, ':p') != l:template_file
+        let l:template_path = go#util#Join(l:root_dir, "templates", l:template_file)
+      endif
+
       silent exe 'keepalt 0r ' . fnameescape(l:template_path)
     endif
   else

--- a/autoload/go/template.vim
+++ b/autoload/go/template.vim
@@ -9,6 +9,7 @@ function! go#template#create() abort
   let l:root_dir = fnamemodify(s:current_file, ':h:h:h')
 
   let l:package_name = go#tool#PackageName()
+  let l:filename = expand('%:t')
 
   " if we can't figure out any package name (i.e. no Go files in the directory)
   " from the directory create the template or use the directory as the name.
@@ -18,7 +19,6 @@ function! go#template#create() abort
       let l:content = printf("package %s", l:path)
       call append(0, l:content)
     else
-      let l:filename = expand('%:t')
       if l:filename =~ "_test.go$"
         let l:template_file = go#config#TemplateTestFile()
       else
@@ -34,7 +34,12 @@ function! go#template#create() abort
       silent exe 'keepalt 0r ' . fnameescape(l:template_path)
     endif
   else
-    let l:content = printf("package %s", l:package_name)
+    let l:go_test_suffix = go#config#TemplateTestSuffix()
+    if l:filename =~ "_test.go$" && l:go_test_suffix == 1
+      let l:content = printf("package %s_test", l:package_name)
+    else
+      let l:content = printf("package %s", l:package_name)
+    endif
     call append(0, l:content)
   endif
   " checking that the last line is empty shouldn't be necessary, but for some

--- a/autoload/go/template_test.vim
+++ b/autoload/go/template_test.vim
@@ -43,6 +43,20 @@ func! Test_TemplateCreate_UsePkg() abort
   endtry
 endfunc
 
+func! Test_TemplateCreate_TestSuffix() abort
+  try
+    let l:tmp = gotest#write_file('foo/empty.txt', [''])
+    
+    let g:go_template_test_suffix = 1
+    edit foo/bar_test.go
+
+    call gotest#assert_buffer(0, ['package foo_test'])
+  finally
+    unlet g:go_template_test_suffix
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
 func! Test_TemplateCreate_PackageExists() abort
   try
     let l:tmp = gotest#write_file('quux/quux.go', ['package foo'])

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1643,7 +1643,8 @@ Specifies whether `gocode` should use a different socket type. By default
 When a new Go file is created, vim-go automatically fills the buffer content
 with a Go code template. By default, the templates under the `templates`
 folder are used.  This can be changed with the |'g:go_template_file'| and
-|'g:go_template_test_file'| settings.
+|'g:go_template_test_file'| settings to either use a different file in the
+same `templates` folder, or to use a file stored elsewhere.
 
 If the new file is created in an already prepopulated package (with other Go
 files), in this case a Go code template with only the Go package declaration
@@ -1658,17 +1659,23 @@ By default it is enabled.
 <
                                                         *'g:go_template_file'*
 
-Specifies the file under the `templates` folder that is used if a new Go file
-is created. Checkout |'g:go_template_autocreate'| for more info. By default
-the `hello_world.go` file is used.
+Specifies either the file under the `templates` folder that is used if a new
+Go file is created. Checkout |'go:go_template_autocreate'| for more info. By
+default the `hello_world.go` file is used.
+
+This variable can be set to an absolute path, so the template files don't have
+to be stored inside the vim-go directory structure. Useful when you want to
+use different templates for different projects.
 >
   let g:go_template_file = "hello_world.go"
 <
                                                    *'g:go_template_test_file'*
 
-Specifies the file under the `templates` folder that is used if a new Go test
-file is created. Checkout |'g:go_template_autocreate'| for more info. By
-default the `hello_world_test.go` file is used.
+Like with |'g:go_template_file'|, this specifies the file to use for test
+tempaltes. The template file should be under the `templates` folder,
+alternatively absolute paths can be used, too. Checkout
+|'g:go_template_autocreate'| for more info. By default, the
+`hello_world_test.go` file is used.
 >
   let g:go_template_test_file = "hello_world_test.go"
 <

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1649,6 +1649,8 @@ same `templates` folder, or to use a file stored elsewhere.
 If the new file is created in an already prepopulated package (with other Go
 files), in this case a Go code template with only the Go package declaration
 (which is automatically determined according to the current package) is added.
+If the new file here is a test file, the package name can be suffixed with the
+`_test` suffix by enabling |'g:go_template_test_suffix'|.
 
 To always use the package name instead of the template, enable the
 |'g:go_template_use_pkg'| setting.
@@ -1669,6 +1671,19 @@ use different templates for different projects.
 >
   let g:go_template_file = "hello_world.go"
 <
+                                                 *'g:go_template_test_suffix'*
+
+Specifies whether or not the package name for new test files should be
+suffixed with `_test`. If you're working in the package `foo`, and decide to
+add a test (`:new foo_test.go`), the default behaviour is to open a new buffer
+with `package foo`  at the top. Setting this config to one, the first line of
+the test file will be set to `package foo_test` instead.
+
+By default, this is disabled.
+>
+  let g:go_template_test_suffix = 0
+<
+                                                     *'g:go_template_use_pkg'*
                                                    *'g:go_template_test_file'*
 
 Like with |'g:go_template_file'|, this specifies the file to use for test

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1660,7 +1660,7 @@ By default it is enabled.
                                                         *'g:go_template_file'*
 
 Specifies either the file under the `templates` folder that is used if a new
-Go file is created. Checkout |'go:go_template_autocreate'| for more info. By
+Go file is created. Checkout |'g:go_template_autocreate'| for more info. By
 default the `hello_world.go` file is used.
 
 This variable can be set to an absolute path, so the template files don't have

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1671,6 +1671,16 @@ use different templates for different projects.
 >
   let g:go_template_file = "hello_world.go"
 <
+                                                   *'g:go_template_test_file'*
+
+Like with |'g:go_template_file'|, this specifies the file to use for test
+tempaltes. The template file should be under the `templates` folder,
+alternatively absolute paths can be used, too. Checkout
+|'g:go_template_autocreate'| for more info. By default, the
+`hello_world_test.go` file is used.
+>
+  let g:go_template_test_file = "hello_world_test.go"
+<
                                                  *'g:go_template_test_suffix'*
 
 Specifies whether or not the package name for new test files should be
@@ -1682,17 +1692,6 @@ the test file will be set to `package foo_test` instead.
 By default, this is disabled.
 >
   let g:go_template_test_suffix = 0
-<
-                                                     *'g:go_template_use_pkg'*
-                                                   *'g:go_template_test_file'*
-
-Like with |'g:go_template_file'|, this specifies the file to use for test
-tempaltes. The template file should be under the `templates` folder,
-alternatively absolute paths can be used, too. Checkout
-|'g:go_template_autocreate'| for more info. By default, the
-`hello_world_test.go` file is used.
->
-  let g:go_template_test_file = "hello_world_test.go"
 <
                                                      *'g:go_template_use_pkg'*
 


### PR DESCRIPTION
It can be useful to have project-specific `.vimrc` files, which set up different templates to use. Rather than having to keep them all in my `~/.vim/plugged/vim-go/templates` directory, I'd quite like to be able to keep the template path alongside my custom `.vimrc` files. for that reason, I've added a `g:go_template_dir` variable that defaults to the current templates directory, so it shouldn't break anything, but I can use `g:go_template_dir` and point to the correct templates easily. Quite a simple change, but IMHO, one worth adding.

Haven't tested this yet, but wanted to get some feedback on what the best approach would be in case of a missing template file. I see 3 options:

* Copy over from the default templates dir (probably adding `go#config#DefaultTemplateDir()` to get it
* Don't handle it differently (i.e. PR as it is)
* Add an additional var like `g:go_template_dir_init` (default to 0), that copies over the default templates from the templates dir should they not exist. 

The third option might yield the best UX, but it's a bit too handhold-y IMO. Pretty soon, we'd end up checking the custom `g:go_template_file`, in the custom dir, and if it doesn't exist, we could end up copying over the default `hello_world.go` to the custom directory, and storing it with a new name. I'm more of the mindset that if people don't understand that the files are expected to exist, they shouldn't be messing with those vars in the first place, but I'm open to suggestions, of course.

Should this PR be accepted, I'll squash all the _"fix typo"_ and _"resolve issue"_ commits, of course