### PR TITLE
fix gometalinter errformat description comment

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -78,8 +78,8 @@ function! go#lint#Gometa(bang, autosave, ...) abort
     echon "vim-go: " | echohl Function | echon "[metalinter] PASS" | echohl None
   else
     " GoMetaLinter can output one of the two, so we look for both:
-    "   <file>:<line>:[<column>]: <message> (<linter>)
-    "   <file>:<line>:: <message> (<linter>)
+    "   <file>:<line>:<column>:<severity>: <message> (<linter>)
+    "   <file>:<line>::<severity>: <message> (<linter>)
     " This can be defined by the following errorformat:
     let errformat = "%f:%l:%c:%t%*[^:]:\ %m,%f:%l::%t%*[^:]:\ %m"
 


### PR DESCRIPTION
Fix old comment.

https://github.com/alecthomas/gometalinter#format-key
> `{{.Path}}:{{.Line}}:{{if .Col}}{{.Col}}{{end}}:{{.Severity}}: {{.Message}} ({{.Linter}})`