### PR TITLE
Changed templates

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -60,11 +60,11 @@ function! go#config#TemplateUsePkg() abort
 endfunction
 
 function! go#config#TemplateTestFile() abort
-  return get(g:, 'go_template_test_file', "hello_world_test.go")
+  return get(g:, 'go_template_test_file', "default_test.go")
 endfunction
 
 function! go#config#TemplateFile() abort
-  return get(g:, 'go_template_file', "hello_world.go")
+  return get(g:, 'go_template_file', "default.go")
 endfunction
 
 function! go#config#StatuslineDuration() abort

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1660,17 +1660,17 @@ By default it is enabled.
 
 Specifies the file under the `templates` folder that is used if a new Go file
 is created. Checkout |'g:go_template_autocreate'| for more info. By default
-the `hello_world.go` file is used.
+the `default.go` file is used.
 >
-  let g:go_template_file = "hello_world.go"
+  let g:go_template_file = "default.go"
 <
                                                    *'g:go_template_test_file'*
 
 Specifies the file under the `templates` folder that is used if a new Go test
 file is created. Checkout |'g:go_template_autocreate'| for more info. By
-default the `hello_world_test.go` file is used.
+default the `default_test.go` file is used.
 >
-  let g:go_template_test_file = "hello_world_test.go"
+  let g:go_template_test_file = "default_test.go"
 <
                                                      *'g:go_template_use_pkg'*
 

--- a/templates/default.go
+++ b/templates/default.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+}

--- a/templates/default_test.go
+++ b/templates/default_test.go
@@ -1,0 +1,8 @@
+package main
+
+import (
+	"testing"
+)
+
+func Test(t *testing.T) {
+}

--- a/templates/hello_world.go
+++ b/templates/hello_world.go
@@ -1,7 +1,0 @@
-package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("vim-go")
-}

--- a/templates/hello_world_test.go
+++ b/templates/hello_world_test.go
@@ -1,7 +1,0 @@
-package main
-
-import "testing"
-
-func TestHelloWorld(t *testing.T) {
-	// t.Fatal("not implemented")
-}


### PR DESCRIPTION
I've changed the template contents, when i started using the plugin it annoyed me to no end (until i figured out how to change it)<br>
i've also changed the names of the files, i think `default.go` is a better name then `hello_world.go`
My changes here are for making vim-go work better without configuration, using `hello_world.go` kind of forced people into changing the templates whereas with more generic templates they might never need to :)

EDIT: Looks like travis does not like my changes, i don't see how i could have screwed anything up since all i did was change the file names and contents