### PR TITLE
clear buffer-local autocmds correctly

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 .local/
+.cache/
+.dlv/
 .git/
+.viminfo

--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -85,7 +85,7 @@ function! go#coverage#Clear() abort
 
   " remove the autocmd we defined
   augroup vim-go-coverage
-    autocmd!
+    autocmd! * <buffer>
   augroup end
 endfunction
 
@@ -242,7 +242,7 @@ function! go#coverage#overlay(file) abort
 
   " clear the matches if we leave the buffer
   augroup vim-go-coverage
-    autocmd!
+    autocmd! * <buffer>
     autocmd BufWinLeave <buffer> call go#coverage#Clear()
   augroup end
 

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -473,7 +473,7 @@ function! s:start_cb(res) abort
   exe bufwinnr(oldbuf) 'wincmd w'
 
   augroup vim-go-debug
-    autocmd!
+    autocmd! * <buffer>
     autocmd FileType go nmap <buffer> <F5>   <Plug>(go-debug-continue)
     autocmd FileType go nmap <buffer> <F6>   <Plug>(go-debug-print)
     autocmd FileType go nmap <buffer> <F9>   <Plug>(go-debug-breakpoint)

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -486,7 +486,7 @@ function! s:same_ids_highlight(exit_val, output, mode) abort
     " re-apply SameIds at the current cursor position at the time the buffer
     " is redisplayed: e.g. :edit, :GoRename, etc.
     augroup vim-go-sameids
-      autocmd!
+      autocmd! * <buffer>
       autocmd BufWinEnter <buffer> nested call go#guru#SameIds(0)
     augroup end
   endif
@@ -511,7 +511,7 @@ function! go#guru#ClearSameIds() abort
 
   " remove the autocmds we defined
   augroup vim-go-sameids
-    autocmd!
+    autocmd! * <buffer>
   augroup end
 
   return 0


### PR DESCRIPTION
Clear buffer-local autocmds correctly without clearing the same autocmds
for other buffers.

As an example of why this should be done: prior to this change, opening
a window for each of two separate files and then running `:GoCoverage`
in each would highlight coverage as expected. Loading a third buffer
into one of the windows would clear the highlighting in that window and
would _also_ remove the other window's buffer-local autocmd event to
clear its coverage highlighting. Loading a different buffer into the
other window would unexpectedly _keep_ the highlighting, because the
autocmd event configuration was removed when the third buffer was loaded
into its window.