### PR TITLE
Add staticcheck/GoStaticCheck command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This plugin adds Go language support for Vim, with the following main features:
   quickfix or location list.
 * Lint your code with `:GoLint`, run your code through `:GoVet` to catch static
   errors, or make sure errors are checked with `:GoErrCheck`.
+* In addition to linters, run `:GoStaticCheck` to get some suggestions to improve
+  overall code quality
 * Advanced source analysis tools utilizing `guru`, such as `:GoImplements`,
   `:GoCallees`, and `:GoReferrers`.
 * ... and many more! Please see [doc/vim-go.txt](doc/vim-go.txt) for more

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -258,6 +258,10 @@ function! go#config#ErrcheckBin() abort
   return get(g:, "go_errcheck_bin", "errcheck")
 endfunction
 
+function! go#config#StaticcheckBin() abort
+  return get(g:, "go_staticcheck_bin", "staticcheck")
+endfunction
+
 function! go#config#MetalinterAutosave() abort
   return get(g:, "go_metalinter_autosave", 0)
 endfunction

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -139,6 +139,7 @@ endfunction
 let s:default_list_type_commands = {
       \ "GoBuild":              "quickfix",
       \ "GoErrCheck":           "quickfix",
+      \ "GoStaticCheck":        "quickfix",
       \ "GoFmt":                "locationlist",
       \ "GoGenerate":           "quickfix",
       \ "GoInstall":            "quickfix",

--- a/autoload/go/staticcheck.vim
+++ b/autoload/go/staticcheck.vim
@@ -1,0 +1,46 @@
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+function! go#staticcheck#Check(bang, ...) abort
+  if a:0 == 0
+    let l:import_path = go#package#ImportPath()
+    if import_path == -1
+      call go#util#EchoError('package is not inside GOPATH src')
+      return
+    endif
+  else
+    let l:import_path = join(a:000, ' ')
+  endif
+
+  call go#util#EchoProgress('[staticcheck] analysing ...')
+  redraw
+
+  let [l:out, l:err] = go#util#Exec([go#config#StaticcheckBin(), l:import_path])
+
+  let l:listtype = go#list#Type("GoStaticCheck")
+  if l:err != 0
+    "" pwd/pkg/file.go:123:45: some reason for error (errcode)
+    let errformat = "%f:%l:%c:\ %m\ (%t%n)"
+
+    " Parse and populate our location list
+    call go#list#ParseFormat(l:listtype, errformat, split(out, "\n"), 'StaticCheck')
+
+    let l:errors = go#list#Get(l:listtype)
+    if empty(l:errors)
+      call go#util#EchoError(l:out)
+      return
+    endif
+
+    if !empty(errors)
+      call go#list#Populate(l:listtype, errors, 'StaticCheck')
+      call go#list#Window(l:listtype, len(errors))
+      if !a:bang
+        call go#list#JumpToFirst(l:listtype)
+      endif
+    endif
+  else
+    call go#list#Clean(l:listtype)
+    call go#util#EchoSuccess('[staticcheck] PASS')
+  endif
+endfunction

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -467,7 +467,7 @@ CTRL-t
 
     If [!] is not given the first error is jumped to.
 
-                                                               *:GoStaticCheck*
+                                                              *:GoStaticCheck*
 :GoStaticCheck! [options]
 
     Check for errors (linting), unused global variables, and suggestions to

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -467,7 +467,7 @@ CTRL-t
 
     If [!] is not given the first error is jumped to.
 
-                                                                 *:GoStaticCheck*
+                                                               *:GoStaticCheck*
 :GoStaticCheck! [options]
 
     Check for errors (linting), unused global variables, and suggestions to

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -55,6 +55,8 @@ tools developed by the Go community to provide a seamless Vim experience.
     quickfix or location list.
   * Lint your code with |:GoLint|, run your code through |:GoVet| to catch
     static errors, or make sure errors are checked with |:GoErrCheck|.
+  * Run your code through |:GoStaticCheck|to lint it, and get some suggestions
+    to improve your code.
   * Advanced source analysis tools utilizing `guru`, such as |:GoImplements|,
     |:GoCallees|, and |:GoReferrers|.
   * Automatic `GOPATH` detection which works with `gb` and `godep`. Change or
@@ -464,6 +466,17 @@ CTRL-t
     `-covermode set,count,atomic`. For a full list please see `go help test`.
 
     If [!] is not given the first error is jumped to.
+
+                                                                 *:GoStaticCheck*
+:GoStaticCheck! [options]
+
+    Check for errors (linting), unused global variables, and suggestions to
+    simplify your code. The output is displayed in the quickfix window.
+
+    You may optionally pass an import path, or full path to check. Default
+    will be the current package.
+
+    if [!] is not given, the first error is jumped to.
 
                                                                  *:GoErrCheck*
 :GoErrCheck! [options]

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -82,6 +82,7 @@ command! -nargs=0 GoMetaLinterAutoSaveToggle call go#lint#ToggleMetaLinterAutoSa
 command! -nargs=* -bang GoLint call go#lint#Golint(<bang>0, <f-args>)
 command! -nargs=* -bang GoVet call go#lint#Vet(<bang>0, <f-args>)
 command! -nargs=* -bang -complete=customlist,go#package#Complete GoErrCheck call go#lint#Errcheck(<bang>0, <f-args>)
+command! -nargs=* -bang -complete=customlist,go#package#Complate GoStaticCheck call go#staticcheck#Check(<bang>0, <f-args>)
 
 " -- alternate
 command! -bang GoAlternate call go#alternate#Switch(<bang>0, '')

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -65,6 +65,7 @@ let s:packages = {
       \ 'keyify':        ['honnef.co/go/tools/cmd/keyify'],
       \ 'motion':        ['github.com/fatih/motion'],
       \ 'iferr':         ['github.com/koron/iferr'],
+      \ 'staticcheck':   ['honnef.co/go/tools/cmd/staticcheck'],
 \ }
 
 " These commands are available on any filetypes


### PR DESCRIPTION
I've been enjoying the staticcheck tool because of its completeness as a linter, and the additional suggestions it makes (e.g. unused global variables and types, which aren't uncommon in my tests). Because `:GoErrCheck` has the `-abspath` flag hard-coded, it's not possible to change the `g:go_errcheck_bin` variable, so I decided to take a stab at adding the `:GoStaticCheck` command.

Most of the code is a straight copy-paste from `go#lint#Errcheck`, though I thought it best not to add the function in the `lint` file. To me `staticcheck` is something I use not as a linter. It's more of a brush used to polish code a bit more. Anyway, depending on the feedback I'll see what I can do to add support for this tool.