### PR TITLE
Prefer the system PATH for some commands

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -55,7 +55,7 @@ endfunction
 function! go#doc#Open(newmode, mode, ...) abort
   " With argument: run "godoc [arg]".
   if len(a:000)
-    let [l:out, l:err] = go#util#Exec(['go', 'doc'] + a:000)
+    let [l:out, l:err] = go#util#ExecSystem(['go', 'doc'] + a:000)
   else " Without argument: run gogetdoc on cursor position.
     let [l:out, l:err] = s:gogetdoc(0)
     if out == -1

--- a/autoload/go/import.vim
+++ b/autoload/go/import.vim
@@ -32,7 +32,7 @@ function! go#import#SwitchImport(enabled, localname, path, bang) abort
   endif
 
   if a:bang == "!"
-    let [l:out, l:err] = go#util#Exec(['go', 'get', '-u', '-v', path])
+    let [l:out, l:err] = go#util#ExecSystem(['go', 'get', '-u', '-v', path])
     if err != 0
       call s:Error("Can't find import: " . path . ":" . out)
     endif

--- a/autoload/go/issue.vim
+++ b/autoload/go/issue.vim
@@ -24,10 +24,10 @@ function! s:issuebody() abort
       redir END
       let body = extend(body, split(out, "\n")[0:2])
     elseif l =~ '^\* Go version'
-      let [out, err] = go#util#Exec(['go', 'version'])
+      let [out, err] = go#util#ExecSystem(['go', 'version'])
       let body = add(body, substitute(l:out, rtrimpat, '', ''))
     elseif l =~ '^\* Go environment'
-      let [out, err] = go#util#Exec(['go', 'env'])
+      let [out, err] = go#util#ExecSystem(['go', 'env'])
       let body = add(body, substitute(l:out, rtrimpat, '', ''))
     endif
   endfor

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -128,9 +128,9 @@ function! go#lint#Vet(bang, ...) abort
   endif
 
   if a:0 == 0
-    let [l:out, l:err] = go#util#Exec(['go', 'vet', go#package#ImportPath()])
+    let [l:out, l:err] = go#util#ExecSystem(['go', 'vet', go#package#ImportPath()])
   else
-    let [l:out, l:err] = go#util#Exec(['go', 'tool', 'vet'] + a:000)
+    let [l:out, l:err] = go#util#ExecSystem(['go', 'tool', 'vet'] + a:000)
   endif
 
   let l:listtype = go#list#Type("GoVet")

--- a/autoload/go/mod.vim
+++ b/autoload/go/mod.vim
@@ -30,7 +30,7 @@ function! go#mod#Format() abort
 
   let current_col = col('.')
   let l:args = ['go', 'mod', 'edit', '--fmt', l:tmpname]
-  let [l:out, l:err] = go#util#Exec(l:args)
+  let [l:out, l:err] = go#util#ExecSystem(l:args)
   let diff_offset = len(readfile(l:tmpname)) - line('$')
 
   if l:err == 0

--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -96,7 +96,7 @@ function! go#package#FromPath(arg) abort
   endif
 
   execute l:cd fnameescape(l:path)
-  let [l:out, l:err] = go#util#Exec(['go', 'list'])
+  let [l:out, l:err] = go#util#ExecSystem(['go', 'list'])
   execute l:cd fnameescape(l:dir)
   if l:err != 0
     return -1
@@ -114,7 +114,7 @@ function! go#package#FromPath(arg) abort
 endfunction
 
 function! go#package#CompleteMembers(package, member) abort
-  let [l:content, l:err] = go#util#Exec(['go', 'doc', a:package])
+  let [l:content, l:err] = go#util#ExecSystem(['go', 'doc', a:package])
   if l:err || !len(content)
     return []
   endif

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -175,7 +175,7 @@ function! go#tool#ExecuteInDir(cmd) abort
   let dir = getcwd()
   try
     execute cd . fnameescape(expand("%:p:h"))
-    let [l:out, l:err] = go#util#Exec(a:cmd)
+    let [l:out, l:err] = go#util#ExecSystem(a:cmd)
   finally
     execute cd . fnameescape(l:dir)
   endtry

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -52,7 +52,7 @@ function! go#util#IsMac() abort
   return has('mac') ||
         \ has('macunix') ||
         \ has('gui_macvim') ||
-        \ go#util#Exec(['uname'])[0] =~? '^darwin'
+        \ go#util#ExecSystem(['uname'])[0] =~? '^darwin'
 endfunction
 
  " Checks if using:
@@ -174,6 +174,8 @@ function! go#util#System(str, ...) abort
 endfunction
 
 " Exec runs a shell command "cmd", which must be a list, one argument per item.
+" Exec uses a modified PATH which includes go-specific binary locations before
+" the usual PATH.
 " Every list entry will be automatically shell-escaped
 " Every other argument is passed to stdin.
 function! go#util#Exec(cmd, ...) abort
@@ -193,6 +195,23 @@ function! go#util#Exec(cmd, ...) abort
 
   " Finally execute the command using the full, resolved path. Do not pass the
   " unmodified command as the correct program might not exist in $PATH.
+  return call('s:exec', [[l:bin] + a:cmd[1:]] + a:000)
+endfunction
+
+" ExecSystem runs a shell command "cmd", which must be a list, one argument per item.
+" Unlike 'Exec', 'ExecSystem' will not modify the $PATH for go tools.
+" 'ExecSystem' should be preferred when running a tool that is not expected to
+" exist in the $GOPATH/bin directory.
+" Every list entry will be automatically shell-escaped
+" Every other argument is passed to stdin.
+function! go#util#ExecSystem(cmd, ...) abort
+  if len(a:cmd) == 0
+    call go#util#EchoError("go#util#ExecSystem() called with empty a:cmd")
+    return ['', 1]
+  endif
+
+  let l:bin = a:cmd[0]
+
   return call('s:exec', [[l:bin] + a:cmd[1:]] + a:000)
 endfunction
 

--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -88,7 +88,7 @@ fun! gotest#assert_buffer(skipHeader, want) abort
     call writefile(l:want, l:tmp . '/want')
     call go#fmt#run('gofmt', l:tmp . '/have', l:tmp . '/have')
     call go#fmt#run('gofmt', l:tmp . '/want', l:tmp . '/want')
-    let [l:out, l:err] = go#util#Exec(["diff", "-u", l:tmp . '/have', l:tmp . '/want'])
+    let [l:out, l:err] = go#util#ExecSystem(["diff", "-u", l:tmp . '/have', l:tmp . '/want'])
   finally
     call delete(l:tmp . '/have')
     call delete(l:tmp . '/want')


### PR DESCRIPTION
The default $PATH is a better place to look than $GOPATH/bin for some
tools. This is especially true for 'go', 'diff', and 'uname'.

If someone incidentally creates a go binary named 'go' or the like, but
has configured their $PATH to prefer the system 'go' binary to the one
in their $GOPATH, it seems unexpected to go ahead and run it anyway.

For the tools that are expected to be in the $GOPATH/bin folder, like
'goimports', it does make sense to just go ahead and check that folder
first.

-------------------

In case you're curious what motivates this change, I'll briefly explain the situation I ran into. I created some language benchmarks, which meant I had folders named `lambda-bench/rust` and [`lambda-bench/go`](https://github.com/euank/lambda-bench/tree/benchmark-2018-09/go) and the like.

Unfortunately, this meant my go package import path ended in `go`, so when I typed `:GoInstall` it of course ended up as a binary named `$GOPATH/bin/go`. After doing this, `vim-go` basically would fall over since it would execute the wrong go binary.

My `$PATH` does include `$GOROOT/bin` well before `$GOPATH/bin`, but that didn't help since `vim-go` goes out of its way to prefer `$GOPATH`.

I'm sure you could say "just don't name a folder that contains go code 'go' ever", and that might also be a reasonable outcome... but it seems a little nicer to me to remove that footgun entirely.