### PR TITLE
Fix highlighting for function return types when highlight_function_arguments is enabled

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -270,7 +270,7 @@ if go#config#HighlightFunctions() || go#config#HighlightFunctionArguments()
   syn match goFunction          /\w\+/ nextgroup=goSimpleArguments contained skipwhite skipnl
   syn match goReceiverType      /\w\+/ contained
 if go#config#HighlightFunctionArguments()
-  syn match goSimpleArguments   /(\(\w\|\_s\|[*\.\[\],\{\}<>-]\)*)/ contained contains=goArgumentName nextgroup=goSimpleArguments skipwhite skipnl
+  syn match goSimpleArguments   /(\(\w\|\_s\|[*\.\[\],\{\}<>-]\)*)/ contained contains=goArgumentName skipwhite skipnl
   syn match goArgumentName      /\w\+\(\s*,\s*\w\+\)*\ze\s\+\(\w\|\.\|\*\|\[\)/ contained nextgroup=goArgumentType skipwhite skipnl
   syn match goArgumentType      /\([^,)]\|\_s\)\+,\?/ contained nextgroup=goArgumentName skipwhite skipnl
                         \ contains=goVarArgs,goType,goSignedInts,goUnsignedInts,goFloats,goComplexes,goDeclType,goBlock


### PR DESCRIPTION
# Problem

vim-go does not highlight function return types with brackets correctly when `g:go_highlight_function_arguments = 1` is setted.

## expected highlight


![190106014753](https://user-images.githubusercontent.com/4361134/50726787-1bee3880-1155-11e9-9551-210968d19d04.png)


## actual highlight

![190106014726](https://user-images.githubusercontent.com/4361134/50726778-0bd65900-1155-11e9-8dde-49160939b9e0.png)


vim-go does not highlight the returned types of `b` function, which are `string` and `error`.
It should be highlighted as `goType` syntax group (green color in this color scheme), but they actually have `goSimpleArguments` syntax group.


note: If `let g:go_highlight_function_arguments = 0`, it is highlighted below.


![190106015724](https://user-images.githubusercontent.com/4361134/50726880-70de7e80-1156-11e9-95e0-48a92fe99707.png)



## configuration to reproduce

`test.vim`. Need to replace `/path/to/vim-go/` with the actual path.

```vim
let g:go_highlight_function_arguments = 1
set nocompatible
set rtp^=/path/to/vim-go/
syntax on
```

`test.go`

```go
package main

type T struct{}

func a() error {
	return nil
}
func b(x int) (string, error) {
	return "", nil
}
func c(y bool, z T) (str string, err error) {
	return
}
```

```bash
$ vim --clean -u test.vim test.go
```


# cause

`goSImpleArtuments` syntax matching definition has a problem.
It matches a function argument (e.g. `(a int)`, `(a int, b bool)`).

it specifys `nextgroup=goSimpleArguments`, it means the group repeats itself. Return types with bracktes are concealed by this `nextgroup` definition.

```
func b(x int) (string, error) {
  //  ^^^^^^^                 goSimpleArguments
  //          ^^^^^^^^^^^^^^^ repeated goSimpleArguments
```

I'm not sure why the nextgroup is specified. I think it's unnecessary because I guess go syntax does not allow an argument list after an argument list.
If someone knows the reasons of the nextgroup, please tell me it :pray:
