### PR TITLE
display message when type info cannot be determined

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -197,8 +197,10 @@ function! s:info_filter(echo, result) abort
   let wordMatch = substitute(wordMatch, "'", "''", "g")
   let filtered = filter(l:candidates, "v:val.info =~ '".wordMatch."'")
 
-  if len(l:filtered) != 1
-    return ""
+  if len(l:filtered) == 0
+    return "no matches"
+  elseif len(l:filtered) > 1
+    return "ambiguous match"
   endif
 
   return l:filtered[0].info


### PR DESCRIPTION
Tell the user when the type info of the identifer under the cursor
cannot be determined whe using gocode.

Fixes #2120 