### PR TITLE
Prevent go fmt autosave from attempting to write to fugitive buffers

### DIFF
--- a/autoload/go/auto.vim
+++ b/autoload/go/auto.vim
@@ -47,7 +47,9 @@ endfunction
 function! go#auto#fmt_autosave()
   " Go code formatting on save
   if get(g:, "go_fmt_autosave", 1)
-    call go#fmt#Format(-1)
+    if filereadable(expand("%@"))
+      call go#fmt#Format(-1)
+    endif
   endif
 endfunction
 


### PR DESCRIPTION
Fixes [this issue](https://github.com/tpope/vim-fugitive/issues/1128#issuecomment-446087055) from the vim-go side. Not sure if this is the way to go, but it works for me.