### PR TITLE
fix error at go#def#jump_to_declaration when vim-go uses godef

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -106,10 +106,24 @@ function! go#def#jump_to_declaration(out, mode, bin_name) abort
     let parts = split(out, ':')
   endif
 
+  if len(parts) == 0
+    call go#util#EchoError('go jump_to_declaration '. bin_name .' output is not valid.')
+    return
+  endif
+
+  let line = 1
+  let col = 1
+  let ident = 0
   let filename = parts[0]
-  let line = parts[1]
-  let col = parts[2]
-  let ident = parts[3]
+  if len(parts) > 1
+    let line = parts[1]
+  endif
+  if len(parts) > 2
+    let col = parts[2]
+  endif
+  if len(parts) > 3
+    let ident = parts[3]
+  endif
 
   " Remove anything newer than the current position, just like basic
   " vim tag support


### PR DESCRIPTION
Godef outputs only one line when user tries to jump to module definition,
because of that vim-go shows following error:

```
Error detected while processing function go#def#Jump[70]..go#def#jump_to_declaration:
line   17:
E684: list index out of range: 1
E15: Invalid expression: parts[1]
```

This PR fixes the issue and adds few additional checks.