### PR TITLE
Add '_internal_test.go' to alternate files

### DIFF
--- a/autoload/go/alternate.vim
+++ b/autoload/go/alternate.vim
@@ -8,24 +8,32 @@ function! go#alternate#Switch(bang, cmd) abort
   if empty(file)
     call go#util#EchoError("no buffer name")
     return
+  elseif file =~# '^\f\+_internal_test\.go$'
+    let l:root = split(file, '_internal_test.go$')[0]
+    let l:alt_files = [l:root . ".go", l:root . '_test.go']
   elseif file =~# '^\f\+_test\.go$'
     let l:root = split(file, '_test.go$')[0]
-    let l:alt_file = l:root . ".go"
+    let l:alt_files = [l:root . "_internal_test.go", l:root . '.go']
   elseif file =~# '^\f\+\.go$'
     let l:root = split(file, ".go$")[0]
-    let l:alt_file = l:root . '_test.go'
+    let l:alt_files = [l:root . '_test.go', l:root . '_internal_test.go']
   else
     call go#util#EchoError("not a go file")
     return
   endif
-  if !filereadable(alt_file) && !bufexists(alt_file) && !a:bang
-    call go#util#EchoError("couldn't find ".alt_file)
-    return
-  elseif empty(a:cmd)
-    execute ":" . go#config#AlternateMode() . " " . alt_file
-  else
-    execute ":" . a:cmd . " " . alt_file
-  endif
+  let l:alt_file = ""
+  for alt_file in l:alt_files
+    if !filereadable(alt_file) && !bufexists(alt_file) && !a:bang
+      continue
+    elseif empty(a:cmd)
+      execute ":" . go#config#AlternateMode() . " " . alt_file
+      return
+    else
+      execute ":" . a:cmd . " " . alt_file
+      return
+    endif
+  endfor
+  call go#util#EchoError("couldn't find " . join(l:alt_files, " or "))
 endfunction
 
 " restore Vi compatibility settings

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -675,7 +675,9 @@ CTRL-t
 
     Alternates between the implementation and test code. For example if in
     main.go, switch to main_test.go. Uses the |'g:go_alternate_mode'| setting
-    as the command to open the file.
+    as the command to open the file. The files to alternate (in order) are
+    'x.go', 'x_test.go', and 'x_internal_test.go', if a file does not exist
+    then it will be skipped.
 
     If [!] is given then it switches to the new file even if it does not
     exist.


### PR DESCRIPTION
Usually tests written in `_test.go` files are in another package so the tests can be written as a user of the package, but sometimes when we need to test package internals then the suggested way is to separate those tests in a file ending with `_internal_test.go` and leave them in the same package so the internals can be tested.

I added the possibility to alternate between a file and it's internal tests the following way:

| Files you have | Current file | Current file after go#alternate#Switch|
| --- | --- | --- |
| x.go, x_test.go, x_internal_test.go | x.go | x_test.go |
| x.go, x_test.go, x_internal_test.go | x_test.go | x_internal_test.go |
| x.go, x_test.go, x_internal_test.go | x_internal_test.go | x.go |
| x.go, x_test.go | x.go | x_test.go |
| x.go, x_test.go | x_test.go | x.go |
| x.go, x_internal_test.go | x.go | x_internal_test.go |
| x.go, x_internal_test.go | x_internal_test.go | x.go |
| x_test.go, x_internal_test.go | x_test.go | x_internal_test.go |
| x_test.go, x_internal_test.go | x_internal_test.go | x_test.go |
| x.go | x.go | [error] |
| x_test.go | x_test.go | [error] |
| x_internal_test.go | x_internal_test.go | [error] |