### PR TITLE
Run godef from buffer path

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -22,7 +22,6 @@ function! go#def#Jump(mode) abort
     if &modified
       let l:stdin_content = join(go#util#GetLines(), "\n")
       call add(l:cmd, "-i")
-      " let [l:out, l:err] = go#util#Exec(l:cmd, l:stdin_content)
       let [l:out, l:err] = go#tool#ExecuteInDir(l:cmd, l:stdin_content)
     else
       let [l:out, l:err] = go#util#ExecuteInDir(l:cmd)

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -22,9 +22,10 @@ function! go#def#Jump(mode) abort
     if &modified
       let l:stdin_content = join(go#util#GetLines(), "\n")
       call add(l:cmd, "-i")
-      let [l:out, l:err] = go#util#Exec(l:cmd, l:stdin_content)
+      " let [l:out, l:err] = go#util#Exec(l:cmd, l:stdin_content)
+      let [l:out, l:err] = go#tool#ExecuteInDir(l:cmd, l:stdin_content)
     else
-      let [l:out, l:err] = go#util#Exec(l:cmd)
+      let [l:out, l:err] = go#util#ExecuteInDir(l:cmd)
     endif
   elseif bin_name == 'guru'
     let cmd = [go#path#CheckBinPath(bin_name)]

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -175,7 +175,7 @@ function! go#tool#ExecuteInDir(cmd, ...) abort
   let dir = getcwd()
   try
     execute cd . fnameescape(expand("%:p:h"))
-    let [l:out, l:err] = call call('go#util#Exec', [a:cmd] + a:000)
+    let [l:out, l:err] = call('go#util#Exec', [a:cmd] + a:000)
   finally
     execute cd . fnameescape(l:dir)
   endtry

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -175,7 +175,7 @@ function! go#tool#ExecuteInDir(cmd, ...) abort
   let dir = getcwd()
   try
     execute cd . fnameescape(expand("%:p:h"))
-    let [l:out, l:err] = go#util#Exec(a:cmd, a:000)
+    let [l:out, l:err] = call call('go#util#Exec', [a:cmd] + a:000)
   finally
     execute cd . fnameescape(l:dir)
   endtry

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -166,7 +166,7 @@ function! go#tool#FilterValids(items) abort
   return filtered
 endfunction
 
-function! go#tool#ExecuteInDir(cmd) abort
+function! go#tool#ExecuteInDir(cmd, ...) abort
   if !isdirectory(expand("%:p:h"))
     return ['', 1]
   endif
@@ -175,7 +175,7 @@ function! go#tool#ExecuteInDir(cmd) abort
   let dir = getcwd()
   try
     execute cd . fnameescape(expand("%:p:h"))
-    let [l:out, l:err] = go#util#Exec(a:cmd)
+    let [l:out, l:err] = go#util#Exec(a:cmd, a:000)
   finally
     execute cd . fnameescape(l:dir)
   endtry


### PR DESCRIPTION
This PR stemmed from this issue:
https://github.com/fatih/vim-go/issues/2149

We now execute `godef` in the current directory of the buffer. 