### PR TITLE
fix typo in function namespace

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -24,7 +24,7 @@ function! go#def#Jump(mode) abort
       call add(l:cmd, "-i")
       let [l:out, l:err] = go#tool#ExecuteInDir(l:cmd, l:stdin_content)
     else
-      let [l:out, l:err] = go#util#ExecuteInDir(l:cmd)
+      let [l:out, l:err] = go#tool#ExecuteInDir(l:cmd)
     endif
   elseif bin_name == 'guru'
     let cmd = [go#path#CheckBinPath(bin_name)]


### PR DESCRIPTION
Fixes a typo in the ExecuteInDir namespace. 