### PR TITLE
move utility functions from tool.vim to util.vim

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -177,7 +177,7 @@ function! go#cmd#Run(bang, ...) abort
   endtry
 
   let items = go#list#Get(l:listtype)
-  let errors = go#tool#FilterValids(items)
+  let errors = go#util#FilterValids(items)
 
   call go#list#Populate(l:listtype, errors, &makeprg)
   call go#list#Window(l:listtype, len(errors))

--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -112,7 +112,7 @@ function! go#coverage#Browser(bang, ...) abort
   let id = call('go#test#Test', args)
 
   if go#util#ShellError() == 0
-    call go#util#ExecuteInDir(['go', 'tool', 'cover', '-html=' . l:tmpname])
+    call go#util#ExecInDir(['go', 'tool', 'cover', '-html=' . l:tmpname])
   endif
 
   call delete(l:tmpname)
@@ -284,7 +284,7 @@ endfunction
 
 function! s:coverage_browser_callback(coverfile, job, exit_status, data)
   if a:exit_status == 0
-    call go#util#ExecuteInDir(['go', 'tool', 'cover', '-html=' . a:coverfile])
+    call go#util#ExecInDir(['go', 'tool', 'cover', '-html=' . a:coverfile])
   endif
 
   call delete(a:coverfile)

--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -112,7 +112,7 @@ function! go#coverage#Browser(bang, ...) abort
   let id = call('go#test#Test', args)
 
   if go#util#ShellError() == 0
-    call go#tool#ExecuteInDir(['go', 'tool', 'cover', '-html=' . l:tmpname])
+    call go#util#ExecuteInDir(['go', 'tool', 'cover', '-html=' . l:tmpname])
   endif
 
   call delete(l:tmpname)
@@ -284,7 +284,7 @@ endfunction
 
 function! s:coverage_browser_callback(coverfile, job, exit_status, data)
   if a:exit_status == 0
-    call go#tool#ExecuteInDir(['go', 'tool', 'cover', '-html=' . a:coverfile])
+    call go#util#ExecuteInDir(['go', 'tool', 'cover', '-html=' . a:coverfile])
   endif
 
   call delete(a:coverfile)

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -22,9 +22,9 @@ function! go#def#Jump(mode) abort
     if &modified
       let l:stdin_content = join(go#util#GetLines(), "\n")
       call add(l:cmd, "-i")
-      let [l:out, l:err] = go#tool#ExecuteInDir(l:cmd, l:stdin_content)
+      let [l:out, l:err] = go#util#ExecuteInDir(l:cmd, l:stdin_content)
     else
-      let [l:out, l:err] = go#tool#ExecuteInDir(l:cmd)
+      let [l:out, l:err] = go#util#ExecuteInDir(l:cmd)
     endif
   elseif bin_name == 'guru'
     let cmd = [go#path#CheckBinPath(bin_name)]
@@ -61,9 +61,9 @@ function! go#def#Jump(mode) abort
     endif
 
     if &modified
-      let [l:out, l:err] = go#tool#ExecuteInDir(l:cmd, l:stdin_content)
+      let [l:out, l:err] = go#util#ExecuteInDir(l:cmd, l:stdin_content)
     else
-      let [l:out, l:err] = go#tool#ExecuteInDir(l:cmd)
+      let [l:out, l:err] = go#util#ExecuteInDir(l:cmd)
     endif
   else
     call go#util#EchoError('go_def_mode value: '. bin_name .' is not valid. Valid values are: [godef, guru]')

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -22,9 +22,9 @@ function! go#def#Jump(mode) abort
     if &modified
       let l:stdin_content = join(go#util#GetLines(), "\n")
       call add(l:cmd, "-i")
-      let [l:out, l:err] = go#util#ExecuteInDir(l:cmd, l:stdin_content)
+      let [l:out, l:err] = go#util#ExecInDir(l:cmd, l:stdin_content)
     else
-      let [l:out, l:err] = go#util#ExecuteInDir(l:cmd)
+      let [l:out, l:err] = go#util#ExecInDir(l:cmd)
     endif
   elseif bin_name == 'guru'
     let cmd = [go#path#CheckBinPath(bin_name)]
@@ -61,9 +61,9 @@ function! go#def#Jump(mode) abort
     endif
 
     if &modified
-      let [l:out, l:err] = go#util#ExecuteInDir(l:cmd, l:stdin_content)
+      let [l:out, l:err] = go#util#ExecInDir(l:cmd, l:stdin_content)
     else
-      let [l:out, l:err] = go#util#ExecuteInDir(l:cmd)
+      let [l:out, l:err] = go#util#ExecInDir(l:cmd)
     endif
   else
     call go#util#EchoError('go_def_mode value: '. bin_name .' is not valid. Valid values are: [godef, guru]')

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -35,7 +35,7 @@ function! go#doc#OpenBrowser(...) abort
       let godoc_url .= "#" . name
     endif
 
-    call go#tool#OpenBrowser(godoc_url)
+    call go#util#OpenBrowser(godoc_url)
     return
   endif
 
@@ -49,7 +49,7 @@ function! go#doc#OpenBrowser(...) abort
 
   " example url: https://godoc.org/github.com/fatih/set#Set
   let godoc_url = go#config#DocUrl() . "/" . pkg . "#" . exported_name
-  call go#tool#OpenBrowser(godoc_url)
+  call go#util#OpenBrowser(godoc_url)
 endfunction
 
 function! go#doc#Open(newmode, mode, ...) abort

--- a/autoload/go/issue.vim
+++ b/autoload/go/issue.vim
@@ -7,7 +7,7 @@ let s:templatepath = go#util#Join(expand('<sfile>:p:h:h:h'), '.github', 'ISSUE_T
 function! go#issue#New() abort
   let body = substitute(s:issuebody(), '[^A-Za-z0-9_.~-]', '\="%".printf("%02X",char2nr(submatch(0)))', 'g')
   let url = "https://github.com/fatih/vim-go/issues/new?body=" . l:body
-  call go#tool#OpenBrowser(l:url)
+  call go#util#OpenBrowser(l:url)
 endfunction
 
 function! s:issuebody() abort

--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -66,7 +66,7 @@ function! go#package#ImportPath() abort
     return s:import_paths[dir]
   endif
 
-  let [l:out, l:err] = go#util#ExecuteInDir(['go', 'list'])
+  let [l:out, l:err] = go#util#ExecInDir(['go', 'list'])
   if l:err != 0
     return -1
   endif

--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -66,7 +66,7 @@ function! go#package#ImportPath() abort
     return s:import_paths[dir]
   endif
 
-  let [l:out, l:err] = go#tool#ExecuteInDir(['go', 'list'])
+  let [l:out, l:err] = go#util#ExecuteInDir(['go', 'list'])
   if l:err != 0
     return -1
   endif

--- a/autoload/go/play.vim
+++ b/autoload/go/play.vim
@@ -35,7 +35,7 @@ function! go#play#Share(count, line1, line2) abort
   endif
 
   if go#config#PlayOpenBrowser()
-    call go#tool#OpenBrowser(url)
+    call go#util#OpenBrowser(url)
   endif
 
   echo "vim-go: snippet uploaded: ".url

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -39,7 +39,7 @@ function! go#rename#Rename(bang, ...) abort
     return
   endif
 
-  let [l:out, l:err] = go#util#ExecuteInDir(l:cmd)
+  let [l:out, l:err] = go#util#ExecInDir(l:cmd)
   call s:parse_errors(l:err, a:bang, split(l:out, '\n'))
 endfunction
 

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -39,7 +39,7 @@ function! go#rename#Rename(bang, ...) abort
     return
   endif
 
-  let [l:out, l:err] = go#tool#ExecuteInDir(l:cmd)
+  let [l:out, l:err] = go#util#ExecuteInDir(l:cmd)
   call s:parse_errors(l:err, a:bang, split(l:out, '\n'))
 endfunction
 

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -89,7 +89,7 @@ function s:parse_errors(exit_val, bang, out)
 
   let l:listtype = go#list#Type("GoRename")
   if a:exit_val != 0
-    let errors = go#tool#ParseErrors(a:out)
+    let errors = go#util#ParseErrors(a:out)
     call go#list#Populate(l:listtype, errors, 'Rename')
     call go#list#Window(l:listtype, len(errors))
     if !empty(errors) && !a:bang

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -85,7 +85,7 @@ function! s:on_exit(job_id, exit_status, event) dict abort
   endif
 
   let errors = go#util#ParseErrors(self.stdout)
-  let errors = go#tool#FilterValids(errors)
+  let errors = go#util#FilterValids(errors)
 
   if !empty(errors)
     " close terminal; we don't need it anymore

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -84,7 +84,7 @@ function! s:on_exit(job_id, exit_status, event) dict abort
     return
   endif
 
-  let errors = go#tool#ParseErrors(self.stdout)
+  let errors = go#util#ParseErrors(self.stdout)
   let errors = go#tool#FilterValids(errors)
 
   if !empty(errors)

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -64,7 +64,7 @@ function! go#test#Test(bang, compile, ...) abort
 
   let l:cmd = ['go'] + l:args
 
-  let [l:out, l:err] = go#util#ExecuteInDir(l:cmd)
+  let [l:out, l:err] = go#util#ExecInDir(l:cmd)
   " TODO(bc): When the output is JSON, the JSON should be run through a
   " filter to produce lines that are more easily described by errorformat.
 

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -64,7 +64,7 @@ function! go#test#Test(bang, compile, ...) abort
 
   let l:cmd = ['go'] + l:args
 
-  let [l:out, l:err] = go#tool#ExecuteInDir(l:cmd)
+  let [l:out, l:err] = go#util#ExecuteInDir(l:cmd)
   " TODO(bc): When the output is JSON, the JSON should be run through a
   " filter to produce lines that are more easily described by errorformat.
 

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -177,30 +177,6 @@ function! go#tool#Exists(importpath) abort
     return 0
 endfunction
 
-function! go#tool#OpenBrowser(url) abort
-    let l:cmd = go#config#PlayBrowserCommand()
-    if len(l:cmd) == 0
-        redraw
-        echohl WarningMsg
-        echo "It seems that you don't have general web browser. Open URL below."
-        echohl None
-        echo a:url
-        return
-    endif
-
-    " if setting starts with a !.
-    if l:cmd =~ '^!'
-        let l:cmd = substitute(l:cmd, '%URL%', '\=escape(shellescape(a:url), "#")', 'g')
-        silent! exec l:cmd
-    elseif cmd =~ '^:[A-Z]'
-        let l:cmd = substitute(l:cmd, '%URL%', '\=escape(a:url,"#")', 'g')
-        exec l:cmd
-    else
-        let l:cmd = substitute(l:cmd, '%URL%', '\=shellescape(a:url)', 'g')
-        call go#util#System(l:cmd)
-    endif
-endfunction
-
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -40,7 +40,7 @@ function! go#tool#Files(...) abort
     endif
   endfor
 
-  let [l:out, l:err] = go#util#ExecuteInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', l:combined])
+  let [l:out, l:err] = go#util#ExecInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', l:combined])
   return split(l:out, '\n')
 endfunction
 
@@ -50,7 +50,7 @@ function! go#tool#Deps() abort
   else
     let format = "{{range $f := .Deps}}{{$f}}\n{{end}}"
   endif
-  let [l:out, l:err] = go#util#ExecuteInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', l:format])
+  let [l:out, l:err] = go#util#ExecInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', l:format])
   return split(l:out, '\n')
 endfunction
 
@@ -61,14 +61,14 @@ function! go#tool#Imports() abort
   else
     let format = "{{range $f := .Imports}}{{$f}}{{printf \"\\n\"}}{{end}}"
   endif
-  let [l:out, l:err] = go#util#ExecuteInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', l:format])
+  let [l:out, l:err] = go#util#ExecInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', l:format])
   if l:err != 0
     echo out
     return imports
   endif
 
   for package_path in split(out, '\n')
-    let [l:out, l:err] = go#util#ExecuteInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', '{{.Name}}', l:package_path])
+    let [l:out, l:err] = go#util#ExecInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', '{{.Name}}', l:package_path])
     if l:err != 0
       echo out
       return imports
@@ -92,7 +92,7 @@ function! go#tool#Info(showstatus) abort
 endfunction
 
 function! go#tool#PackageName() abort
-  let [l:out, l:err] = go#util#ExecuteInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', '{{.Name}}'])
+  let [l:out, l:err] = go#util#ExecInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', '{{.Name}}'])
   if l:err != 0
       return -1
   endif
@@ -169,7 +169,7 @@ endfunction
 " Exists checks whether the given importpath exists or not. It returns 0 if
 " the importpath exists under GOPATH.
 function! go#tool#Exists(importpath) abort
-    let [l:out, l:err] = go#util#ExecuteInDir(['go', 'list', a:importpath])
+    let [l:out, l:err] = go#util#ExecInDir(['go', 'list', a:importpath])
     if l:err != 0
         return -1
     endif

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -40,7 +40,7 @@ function! go#tool#Files(...) abort
     endif
   endfor
 
-  let [l:out, l:err] = go#tool#ExecuteInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', l:combined])
+  let [l:out, l:err] = go#util#ExecuteInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', l:combined])
   return split(l:out, '\n')
 endfunction
 
@@ -50,7 +50,7 @@ function! go#tool#Deps() abort
   else
     let format = "{{range $f := .Deps}}{{$f}}\n{{end}}"
   endif
-  let [l:out, l:err] = go#tool#ExecuteInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', l:format])
+  let [l:out, l:err] = go#util#ExecuteInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', l:format])
   return split(l:out, '\n')
 endfunction
 
@@ -61,14 +61,14 @@ function! go#tool#Imports() abort
   else
     let format = "{{range $f := .Imports}}{{$f}}{{printf \"\\n\"}}{{end}}"
   endif
-  let [l:out, l:err] = go#tool#ExecuteInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', l:format])
+  let [l:out, l:err] = go#util#ExecuteInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', l:format])
   if l:err != 0
     echo out
     return imports
   endif
 
   for package_path in split(out, '\n')
-    let [l:out, l:err] = go#tool#ExecuteInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', '{{.Name}}', l:package_path])
+    let [l:out, l:err] = go#util#ExecuteInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', '{{.Name}}', l:package_path])
     if l:err != 0
       echo out
       return imports
@@ -92,7 +92,7 @@ function! go#tool#Info(showstatus) abort
 endfunction
 
 function! go#tool#PackageName() abort
-  let [l:out, l:err] = go#tool#ExecuteInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', '{{.Name}}'])
+  let [l:out, l:err] = go#util#ExecuteInDir(['go', 'list', '-tags', go#config#BuildTags(), '-f', '{{.Name}}'])
   if l:err != 0
       return -1
   endif
@@ -166,26 +166,10 @@ function! go#tool#FilterValids(items) abort
   return filtered
 endfunction
 
-function! go#tool#ExecuteInDir(cmd, ...) abort
-  if !isdirectory(expand("%:p:h"))
-    return ['', 1]
-  endif
-
-  let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
-  let dir = getcwd()
-  try
-    execute cd . fnameescape(expand("%:p:h"))
-    let [l:out, l:err] = call('go#util#Exec', [a:cmd] + a:000)
-  finally
-    execute cd . fnameescape(l:dir)
-  endtry
-  return [l:out, l:err]
-endfunction
-
 " Exists checks whether the given importpath exists or not. It returns 0 if
 " the importpath exists under GOPATH.
 function! go#tool#Exists(importpath) abort
-    let [l:out, l:err] = go#tool#ExecuteInDir(['go', 'list', a:importpath])
+    let [l:out, l:err] = go#util#ExecuteInDir(['go', 'list', a:importpath])
     if l:err != 0
         return -1
     endif

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -100,36 +100,6 @@ function! go#tool#PackageName() abort
   return split(out, '\n')[0]
 endfunction
 
-function! go#tool#ParseErrors(lines) abort
-  let errors = []
-
-  for line in a:lines
-    let fatalerrors = matchlist(line, '^\(fatal error:.*\)$')
-    let tokens = matchlist(line, '^\s*\(.\{-}\):\(\d\+\):\s*\(.*\)')
-
-    if !empty(fatalerrors)
-      call add(errors, {"text": fatalerrors[1]})
-    elseif !empty(tokens)
-      " strip endlines of form ^M
-      let out = substitute(tokens[3], '\r$', '', '')
-
-      call add(errors, {
-            \ "filename" : fnamemodify(tokens[1], ':p'),
-            \ "lnum"     : tokens[2],
-            \ "text"     : out,
-            \ })
-    elseif !empty(errors)
-      " Preserve indented lines.
-      " This comes up especially with multi-line test output.
-      if match(line, '^\s') >= 0
-        call add(errors, {"text": substitute(line, '\r$', '', '')})
-      endif
-    endif
-  endfor
-
-  return errors
-endfunction
-
 " FilterValids filters the given items with only items that have a valid
 " filename. Any non valid filename is filtered out.
 function! go#tool#FilterValids(items) abort

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -100,42 +100,6 @@ function! go#tool#PackageName() abort
   return split(out, '\n')[0]
 endfunction
 
-" FilterValids filters the given items with only items that have a valid
-" filename. Any non valid filename is filtered out.
-function! go#tool#FilterValids(items) abort
-  " Remove any nonvalid filename from the location list to avoid opening an
-  " empty buffer. See https://github.com/fatih/vim-go/issues/287 for
-  " details.
-  let filtered = []
-  let is_readable = {}
-
-  for item in a:items
-    if has_key(item, 'bufnr')
-      let filename = bufname(item.bufnr)
-    elseif has_key(item, 'filename')
-      let filename = item.filename
-    else
-      " nothing to do, add item back to the list
-      call add(filtered, item)
-      continue
-    endif
-
-    if !has_key(is_readable, filename)
-      let is_readable[filename] = filereadable(filename)
-    endif
-    if is_readable[filename]
-      call add(filtered, item)
-    endif
-  endfor
-
-  for k in keys(filter(is_readable, '!v:val'))
-    echo "vim-go: " | echohl Identifier | echon "[run] Dropped " | echohl Constant | echon  '"' . k . '"'
-    echohl Identifier | echon " from location list (nonvalid filename)" | echohl None
-  endfor
-
-  return filtered
-endfunction
-
 " Exists checks whether the given importpath exists or not. It returns 0 if
 " the importpath exists under GOPATH.
 function! go#tool#Exists(importpath) abort

--- a/autoload/go/tool_test.vim
+++ b/autoload/go/tool_test.vim
@@ -5,7 +5,7 @@ set cpo&vim
 func! Test_ExecuteInDir() abort
   let l:tmp = gotest#write_file('a/a.go', ['package a'])
   try
-    let l:out = go#util#ExecuteInDir(['pwd'])
+    let l:out = go#util#ExecInDir(['pwd'])
     call assert_equal([l:tmp . "/src/a\n", 0], l:out)
   finally
     call delete(l:tmp, 'rf')
@@ -17,7 +17,7 @@ func! Test_ExecuteInDir_nodir() abort
   exe ':e ' . l:tmp . '/new-dir/a'
 
   try
-    let l:out = go#util#ExecuteInDir(['pwd'])
+    let l:out = go#util#ExecInDir(['pwd'])
     call assert_equal(['', 1], l:out)
   finally
     call delete(l:tmp, 'rf')

--- a/autoload/go/tool_test.vim
+++ b/autoload/go/tool_test.vim
@@ -5,7 +5,7 @@ set cpo&vim
 func! Test_ExecuteInDir() abort
   let l:tmp = gotest#write_file('a/a.go', ['package a'])
   try
-    let l:out = go#tool#ExecuteInDir(['pwd'])
+    let l:out = go#util#ExecuteInDir(['pwd'])
     call assert_equal([l:tmp . "/src/a\n", 0], l:out)
   finally
     call delete(l:tmp, 'rf')
@@ -17,7 +17,7 @@ func! Test_ExecuteInDir_nodir() abort
   exe ':e ' . l:tmp . '/new-dir/a'
 
   try
-    let l:out = go#tool#ExecuteInDir(['pwd'])
+    let l:out = go#util#ExecuteInDir(['pwd'])
     call assert_equal(['', 1], l:out)
   finally
     call delete(l:tmp, 'rf')

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -511,6 +511,42 @@ function! go#util#ParseErrors(lines) abort
   return errors
 endfunction
 
+" FilterValids filters the given items with only items that have a valid
+" filename. Any non valid filename is filtered out.
+function! go#util#FilterValids(items) abort
+  " Remove any nonvalid filename from the location list to avoid opening an
+  " empty buffer. See https://github.com/fatih/vim-go/issues/287 for
+  " details.
+  let filtered = []
+  let is_readable = {}
+
+  for item in a:items
+    if has_key(item, 'bufnr')
+      let filename = bufname(item.bufnr)
+    elseif has_key(item, 'filename')
+      let filename = item.filename
+    else
+      " nothing to do, add item back to the list
+      call add(filtered, item)
+      continue
+    endif
+
+    if !has_key(is_readable, filename)
+      let is_readable[filename] = filereadable(filename)
+    endif
+    if is_readable[filename]
+      call add(filtered, item)
+    endif
+  endfor
+
+  for k in keys(filter(is_readable, '!v:val'))
+    echo "vim-go: " | echohl Identifier | echon "[run] Dropped " | echohl Constant | echon  '"' . k . '"'
+    echohl Identifier | echon " from location list (nonvalid filename)" | echohl None
+  endfor
+
+  return filtered
+endfunction
+
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -196,6 +196,22 @@ function! go#util#Exec(cmd, ...) abort
   return call('s:exec', [[l:bin] + a:cmd[1:]] + a:000)
 endfunction
 
+function! go#util#ExecuteInDir(cmd, ...) abort
+  if !isdirectory(expand("%:p:h"))
+    return ['', 1]
+  endif
+
+  let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
+  let dir = getcwd()
+  try
+    execute cd . fnameescape(expand("%:p:h"))
+    let [l:out, l:err] = call('go#util#Exec', [a:cmd] + a:000)
+  finally
+    execute cd . fnameescape(l:dir)
+  endtry
+  return [l:out, l:err]
+endfunction
+
 function! s:exec(cmd, ...) abort
   let l:bin = a:cmd[0]
   let l:cmd = go#util#Shelljoin([l:bin] + a:cmd[1:])

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -457,6 +457,30 @@ function! go#util#HasDebug(flag)
   return index(go#config#Debug(), a:flag) >= 0
 endfunction
 
+function! go#util#OpenBrowser(url) abort
+    let l:cmd = go#config#PlayBrowserCommand()
+    if len(l:cmd) == 0
+        redraw
+        echohl WarningMsg
+        echo "It seems that you don't have general web browser. Open URL below."
+        echohl None
+        echo a:url
+        return
+    endif
+
+    " if setting starts with a !.
+    if l:cmd =~ '^!'
+        let l:cmd = substitute(l:cmd, '%URL%', '\=escape(shellescape(a:url), "#")', 'g')
+        silent! exec l:cmd
+    elseif cmd =~ '^:[A-Z]'
+        let l:cmd = substitute(l:cmd, '%URL%', '\=escape(a:url,"#")', 'g')
+        exec l:cmd
+    else
+        let l:cmd = substitute(l:cmd, '%URL%', '\=shellescape(a:url)', 'g')
+        call go#util#System(l:cmd)
+    endif
+endfunction
+
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -196,7 +196,7 @@ function! go#util#Exec(cmd, ...) abort
   return call('s:exec', [[l:bin] + a:cmd[1:]] + a:000)
 endfunction
 
-function! go#util#ExecuteInDir(cmd, ...) abort
+function! go#util#ExecInDir(cmd, ...) abort
   if !isdirectory(expand("%:p:h"))
     return ['', 1]
   endif


### PR DESCRIPTION
tool.vim should contain function that use the go tool (e.g. `go list`). Move general purpose utility functions in tool.vim to util.vim