### PR TITLE
add initial support for gopls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VIMS ?= vim-7.4 vim-8.0 nvim
 
-all: install test lint
+all: install lint test
 
 install:
 	@echo "==> Installing Vims: $(VIMS)"

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -210,6 +210,12 @@ function! go#config#DebugCommands() abort
   return g:go_debug_commands
 endfunction
 
+function! go#config#LspLog() abort
+  " make sure g:go_lsp_log is set so that it can be added to easily.
+  let g:go_lsp_log = get(g:, 'go_lsp_log', [])
+  return g:go_lsp_log
+endfunction
+
 function! go#config#SetDebugDiag(value) abort
   let g:go_debug_diag = a:value
 endfunction

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -65,8 +65,14 @@ function! go#def#Jump(mode) abort
     else
       let [l:out, l:err] = go#util#ExecInDir(l:cmd)
     endif
+  elseif bin_name == 'gopls'
+    let [l:line, l:col] = getpos('.')[1:2]
+    " delegate to gopls, with an empty job object and an exit status of 0
+    " (they're irrelevant for gopls).
+    call go#lsp#Definition(l:fname, l:line, l:col, function('s:jump_to_declaration_cb', [a:mode, 'gopls', {}, 0]))
+    return
   else
-    call go#util#EchoError('go_def_mode value: '. bin_name .' is not valid. Valid values are: [godef, guru]')
+    call go#util#EchoError('go_def_mode value: '. bin_name .' is not valid. Valid values are: [godef, guru, gopls]')
     return
   endif
 
@@ -85,15 +91,19 @@ function! s:jump_to_declaration_cb(mode, bin_name, job, exit_status, data) abort
 
   call go#def#jump_to_declaration(a:data[0], a:mode, a:bin_name)
 
-  " capture the active window so that after the exit_cb and close_cb callbacks
-  " can return to it when a:mode caused a split.
+  " capture the active window so that callbacks for jobs, exit_cb and
+  " close_cb, and callbacks for gopls can return to it when a:mode caused a
+  " split.
   let self.winid = win_getid(winnr())
 endfunction
 
+" go#def#jump_to_declaration parses out (expected to be
+" 'filename:line:col: message').
 function! go#def#jump_to_declaration(out, mode, bin_name) abort
   let final_out = a:out
   if a:bin_name == "godef"
-    " append the type information to the same line so our we can parse it.
+    " append the type information to the same line so it will be parsed
+    " correctly using guru's output format.
     " This makes it compatible with guru output.
     let final_out = join(split(a:out, '\n'), ':')
   endif

--- a/autoload/go/issue.vim
+++ b/autoload/go/issue.vim
@@ -5,7 +5,7 @@ set cpo&vim
 let s:templatepath = go#util#Join(expand('<sfile>:p:h:h:h'), '.github', 'ISSUE_TEMPLATE.md')
 
 function! go#issue#New() abort
-  let body = substitute(s:issuebody(), '[^A-Za-z0-9_.~-]', '\="%".printf("%02X",char2nr(submatch(0)))', 'g')
+  let body = go#uriEncode(s:issuebody())
   let url = "https://github.com/fatih/vim-go/issues/new?body=" . l:body
   call go#util#OpenBrowser(l:url)
 endfunction

--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -296,6 +296,11 @@ function! go#job#Start(cmd, options)
     unlet l:options._start
   endif
 
+  " noblock was added in 8.1.350; remove it if it's not supported.
+  if has_key(l:options, 'noblock') && (has('nvim') || !has("patch-8.1.350"))
+    call remove(l:options, 'noblock')
+  endif
+
   if go#util#HasDebug('shell-commands')
     call go#util#EchoInfo('job command: ' . string(a:cmd))
   endif

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -1,0 +1,302 @@
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+scriptencoding utf-8
+
+let s:lspfactory = {}
+
+function! s:lspfactory.get() dict abort
+  if !has_key(self, 'current')
+    " TODO(bc): check that the lsp is still running.
+    let self.current = s:newlsp()
+  endif
+
+  return self.current
+endfunction
+
+function! s:lspfactory.reset() dict abort
+  if has_key(self, 'current')
+    call remove(self, 'current')
+  endif
+endfunction
+
+function! s:newlsp()
+  if !go#util#has_job()
+    " TODO(bc): start the server in the background using a shell that waits for the right output before returning.
+    call go#util#EchoError('This feature requires either Vim 8.0.0087 or newer with +job or Neovim.')
+    return
+  endif
+
+  " job is the job used to talk to the backing instance of gopls.
+  " ready is 0 until the initialize response has been received. 1 afterwards.
+  " queue is messages to send after initialization
+  " last_request_id is id of the most recently sent request.
+  " buf is unprocessed/incomplete responses
+  " handlers is request id -> callback
+  let l:lsp = {
+        \ 'job':  '',
+        \ 'ready': 0,
+        \ 'queue': [],
+        \ 'last_request_id': 0,
+        \ 'buf': '',
+        \ 'handlers': {},
+        \ }
+
+  function! l:lsp.readMessage(data) dict abort
+    let l:responses = []
+    let l:rest = a:data
+
+    while 1
+      " Look for the end of the HTTP headers
+      let l:body_start_idx = matchend(l:rest, "\r\n\r\n")
+
+      if l:body_start_idx < 0
+        " incomplete header
+        break
+      endif
+
+      " Parse the Content-Length header.
+      let l:header = l:rest[:l:body_start_idx - 4]
+      let l:length_match = matchlist(
+      \   l:header,
+      \   '\vContent-Length: *(\d+)'
+      \)
+
+      if empty(l:length_match)
+        " TODO(bc): shutdown gopls?
+        throw "invalid JSON-RPC header:\n" . l:header
+      endif
+
+      " get the start of the rest
+      let l:rest_start_idx = l:body_start_idx + str2nr(l:length_match[1])
+
+      if len(l:rest) < l:rest_start_idx
+        " incomplete response body
+        break
+      endif
+
+      if go#util#HasDebug('lsp')
+        let g:go_lsp_log = add(go#config#LspLog(), {
+              \ 'response': l:rest[:l:rest_start_idx - 1]
+        \ })
+      endif
+
+      let l:body = l:rest[l:body_start_idx : l:rest_start_idx - 1]
+      let l:rest = l:rest[l:rest_start_idx :]
+
+      try
+        " add the json body to the list.
+        call add(l:responses, json_decode(l:body))
+
+        " TODO(bc): set status line stuff similarly to how job.vim handles it.
+      catch
+        " TODO(bc): log the message and/or show an error message.
+      finally
+        " intentionally left blank.
+      endtry
+    endwhile
+
+    return [l:rest, l:responses]
+  endfunction
+
+  function! l:lsp.handleMessage(ch, data) dict abort
+      let self.buf .= a:data
+
+      let [self.buf, l:responses] = self.readMessage(self.buf)
+
+      if self.ready is 0
+        for l:response in l:responses
+          " TODO(bc): handle notifications that aren't InitializeResult (e.g.
+          " window/showMessage).
+          call self.handleInitializeResult(l:response)
+        endfor
+      endif
+
+      if self.ready is 1
+        for l:response in l:responses
+          if has_key(l:response, 'id') && has_key(self.handlers, l:response.id)
+            try
+              if has_key(l:response, 'error')
+                call go#util#EchoError(l:response.message)
+                return
+              endif
+
+              call call(self.handlers[l:response.id], [l:response.result])
+            finally
+              call remove(self.handlers, l:response.id)
+            endtry
+          endif
+        endfor
+      endif
+  endfunction
+
+  function! l:lsp.handleInitializeResult(response) dict abort
+    " TODO(bc): send initialized message to the server?
+
+    "if get(a:response, 'method', '') is# 'initialize'
+    "  " TODO(bc): can this even happen?
+    "  let self.ready = 1
+    " elseif type(get(a:response, 'result')) is v:t_dict && has_key(a:response.result, 'capabilities')
+    if type(get(a:response, 'result')) is v:t_dict && has_key(a:response.result, 'capabilities')
+      " TODO(bc): store capabilities
+      let self.ready = 1
+    endif
+
+    if self.ready is 0
+      return
+    endif
+
+    " send messages queued while waiting for ready.
+    for l:item in self.queue
+      call self.sendMessage(l:item.data, l:item.handler)
+    endfor
+
+    " reset the queue
+    let self.queue = []
+  endfunction
+
+  function! l:lsp.sendMessage(data, handler) dict abort
+    if !self.last_request_id
+      " TODO(bc): run a server per module and one per GOPATH? (may need to
+      " keep track of servers by rootUri).
+      let l:msg = self.newMessage(go#lsp#message#Initialize(getcwd()))
+
+      " TODO(bc): update the statusline similarly to how job.vim does when
+      " starting a job.
+      call self.write(l:msg)
+    endif
+
+    if !self.ready
+      call add(self.queue, {'data': a:data, 'handler': a:handler})
+      return
+    endif
+
+    let l:msg = self.newMessage(a:data)
+    if has_key(l:msg, 'id')
+      let self.handlers[l:msg.id] = a:handler
+    endif
+
+    " TODO(bc): update the statusline similarly to how job.vim does when
+    " starting a job.
+    call self.write(l:msg)
+  endfunction
+
+  " newMessage returns a message constructed from data. data should be a dict
+  " with 2 or 3 keys: notification, method, and optionally params.
+  function! l:lsp.newMessage(data) dict abort
+    let l:msg = {
+          \ 'method': a:data.method,
+          \ 'jsonrpc': '2.0',
+          \ }
+
+    if !a:data.notification
+      let self.last_request_id += 1
+      let l:msg.id = self.last_request_id
+    endif
+
+    if has_key(a:data, 'params')
+      let l:msg.params = a:data.params
+    endif
+
+    return l:msg
+  endfunction
+
+  function! l:lsp.write(msg) dict abort
+      let l:body = json_encode(a:msg)
+      let l:data = 'Content-Length: ' . strlen(l:body) . "\r\n\r\n" . l:body
+
+    if go#util#HasDebug('lsp')
+      let g:go_lsp_log = add(go#config#LspLog(), {
+            \ 'request':  l:data,
+      \ })
+    endif
+
+    if has('nvim')
+      call chansend(self.job, l:data)
+      return
+    endif
+
+    call ch_sendraw(self.job, l:data)
+  endfunction
+
+  function! l:lsp.exit_cb(job, exit_status) dict abort
+    call s:lspfactory.reset()
+  endfunction
+  " explicitly bind close_cb to state so that within it, self will always refer
+
+  function! l:lsp.close_cb(ch) dict abort
+    " TODO(bc): does anything need to be done here?
+  endfunction
+
+  function! l:lsp.err_cb(ch, msg) dict abort
+    if go#util#HasDebug('lsp')
+      let g:go_lsp_log = add(go#config#LspLog(), {
+            \ 'stderr':  a:msg,
+      \ })
+    endif
+  endfunction
+
+  " explicitly bind callbacks to l:lsp so that within it, self will always refer
+  " to l:lsp instead of l:opts. See :help Partial for more information.
+  let l:opts = {
+        \ 'in_mode': 'raw',
+        \ 'out_mode': 'raw',
+        \ 'err_mode': 'nl',
+        \ 'noblock': 1,
+        \ 'err_cb': funcref('l:lsp.err_cb', [], l:lsp),
+        \ 'out_cb': funcref('l:lsp.handleMessage', [], l:lsp),
+        \ 'close_cb': funcref('l:lsp.close_cb', [], l:lsp),
+        \ 'exit_cb': funcref('l:lsp.exit_cb', [], l:lsp),
+        \ 'cwd': getcwd(),
+        \}
+
+  let bin_path = go#path#CheckBinPath("gopls")
+  if empty(bin_path)
+    return
+  endif
+
+  " TODO(bc): output a message indicating which directory lsp is going to
+  " start in.
+  let l:lsp.job = go#job#Start('gopls', l:opts)
+
+  " TODO(bc): send the initialize message now?
+  return l:lsp
+endfunction
+
+function! s:noop()
+endfunction
+
+function! s:newHandlerState()
+  " TODO(bc): capture the window id, set status, etc.
+  let l:state = {
+        \ 'winid': win_getid(winnr()),
+      \ }
+
+  return l:state
+endfunction
+
+" go#lsp#Definition calls gopls to get the definition of the identifier at
+" line and col in fname. handler should be a dictionary function that takes a
+" list of strings in the form 'file:line:col: message'. handler will be
+" attached to a dictionary that manages state (statuslines, sets the winid,
+" etc.)
+function! go#lsp#Definition(fname, line, col, handler)
+  function! s:definitionHandler(next, msg) abort dict
+    " gopls returns a []Location; just take the first one.
+    let l:msg = a:msg[0]
+    let l:args = [[printf('%s:%d:%d: %s', go#path#FromURI(l:msg.uri), l:msg.range.start.line+1, l:msg.range.start.character+1, 'lsp does not supply a description')]]
+    call call(a:next, l:args)
+  endfunction
+
+  let l:lsp = s:lspfactory.get()
+  let l:state = s:newHandlerState()
+  let l:msg = go#lsp#message#Definition(fnamemodify(a:fname, ':p'), a:line, a:col)
+  call l:lsp.sendMessage(l:msg, funcref('s:definitionHandler', [function(a:handler, [], l:state)], l:state))
+endfunction
+
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -1,0 +1,41 @@
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+function! go#lsp#message#Initialize(wd)
+  return {
+          \ 'notification': 0,
+          \ 'method': 'initialize',
+          \ 'params': {
+            \ 'processId': getpid(),
+            \ 'rootUri': go#path#ToURI(a:wd),
+            \ 'capabilities': {
+              \ 'workspace': {},
+              \ 'textDocument': {}
+            \ }
+          \ }
+       \ }
+endfunction
+
+function! go#lsp#message#Definition(file, line, col)
+  return {
+          \ 'notification': 0,
+          \ 'method': 'textDocument/definition',
+          \ 'params': {
+          \   'textDocument': {
+          \       'uri': go#path#ToURI(a:file)
+          \   },
+          \   'position': s:position(a:line, a:col)
+          \ }
+       \ }
+endfunction
+
+function! s:position(line, col)
+  return {'line': a:line - 1, 'character': a:col-1}
+endfunction
+
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -205,6 +205,37 @@ function! s:CygwinPath(path)
    return substitute(a:path, '\\', '/', "g")
 endfunction
 
+" go#path#ToURI converts path to a file URI. path should be an absolute path.
+" Relative paths cannot be properly converted to a URI; when path is a
+" relative path, the file scheme will not be prepended.
+function! go#path#ToURI(path)
+  let l:path = a:path
+  if l:path[1:2] is# ':\'
+    let l:path = '/' . l:path[0:1] . l:path[3:]
+  endif
+
+  return substitute(
+  \   (l:path[0] is# '/' ? 'file://' : '') . go#uri#EncodePath(l:path),
+  \   '\\',
+  \   '/',
+  \   'g',
+  \)
+endfunction
+
+function! go#path#FromURI(uri) abort
+    let l:i = len('file://')
+    let l:encoded_path = a:uri[: l:i - 1] is# 'file://' ? a:uri[l:i :] : a:uri
+
+    let l:path = go#uri#Decode(l:encoded_path)
+
+    " If the path is like /C:/foo/bar, it should be C:\foo\bar instead.
+    if l:path =~# '^/[a-zA-Z]:'
+        let l:path = substitute(l:path[1:], '/', '\\', 'g')
+    endif
+
+    return l:path
+endfunction
+
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/autoload/go/uri.vim
+++ b/autoload/go/uri.vim
@@ -3,9 +3,17 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 function! go#uri#Encode(value) abort
+    return s:encode(a:value, '[^A-Za-z0-9_.~-]')
+endfunction
+
+function! go#uri#EncodePath(value) abort
+    return s:encode(a:value, '[^/A-Za-z0-9_.~-]')
+endfunction
+
+function! s:encode(value, unreserved)
     return substitute(
     \   a:value,
-    \   '[^A-Za-z0-9_.~-]',
+    \   a:unreserved,
     \   '\="%".printf(''%02X'', char2nr(submatch(0)))',
     \   'g'
     \)
@@ -15,7 +23,7 @@ function! go#uri#Decode(value) abort
     return substitute(
     \   a:value,
     \   '%\(\x\x\)',
-    \   '\=nr2char(''0x'' . submatch(1))',
+    \   '\=nr2char(''0X'' . submatch(1))',
     \   'g'
     \)
 endfunction

--- a/autoload/go/uri.vim
+++ b/autoload/go/uri.vim
@@ -1,0 +1,26 @@
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+function! go#uri#Encode(value) abort
+    return substitute(
+    \   a:value,
+    \   '[^A-Za-z0-9_.~-]',
+    \   '\="%".printf(''%02X'', char2nr(submatch(0)))',
+    \   'g'
+    \)
+endfunction
+
+function! go#uri#Decode(value) abort
+    return substitute(
+    \   a:value,
+    \   '%\(\x\x\)',
+    \   '\=nr2char(''0x'' . submatch(1))',
+    \   'g'
+    \)
+endfunction
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1350,7 +1350,7 @@ a private internal service. Default is 'https://godoc.org'.
 
 Use this option to define the command to be used for |:GoDef|. By default
 `guru` is being used as it covers all edge cases. But one might also use
-`godef` as it's faster. Current valid options are: `[guru, godef]` >
+`godef` as it's faster. Current valid options are: `[guru, godef, gopls]` >
 
   let g:go_def_mode = 'guru'
 <
@@ -1761,6 +1761,7 @@ Currently accepted values:
   debugger-state     Expose debugger state in 'g:go_debug_diag'.
   debugger-commands  Echo communication between vim-go and `dlv`; requests and
                      responses are recorded in `g:go_debug_commands`.
+  lsp                Record lsp requests and responses in g:go_lsp_log.
 >
       let g:go_debug = []
 <

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -79,6 +79,10 @@ endif
 augroup vim-go-buffer
   autocmd! * <buffer>
 
+  " TODO(bc): notify gopls about changes on CursorHold when the buffer is
+  " modified.
+  " TODO(bc): notify gopls that the file on disk is correct on BufWritePost
+
   autocmd CursorHold <buffer> call go#auto#auto_type_info()
   autocmd CursorHold <buffer> call go#auto#auto_sameids()
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -56,6 +56,7 @@ let s:packages = {
       \ 'gogetdoc':      ['github.com/zmb3/gogetdoc'],
       \ 'goimports':     ['golang.org/x/tools/cmd/goimports'],
       \ 'golint':        ['golang.org/x/lint/golint'],
+      \ 'gopls':         ['golang.org/x/tools/cmd/gopls'],
       \ 'gometalinter':  ['github.com/alecthomas/gometalinter'],
       \ 'gomodifytags':  ['github.com/fatih/gomodifytags'],
       \ 'gorename':      ['golang.org/x/tools/cmd/gorename'],


### PR DESCRIPTION
Add initial support for gopls. This PR adds the foundation for transitioning to use gopls and introduces a new option for `g:go_def_mode`, `gopls`.

##### lint before running tests

##### extract URI encoding function
Extract function to URI encode strings and add the decoding function,
too.

Use the new uri encoding function when reporting a GitHub issue.

changes. Lines starting


##### add gopls to tools

##### teach vim-go to get definition information from gopls

Fixes #2146 