### PR TITLE
add :GoDefType

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -5,7 +5,7 @@ set cpo&vim
 let s:go_stack = []
 let s:go_stack_level = 0
 
-function! go#def#Jump(mode) abort
+function! go#def#Jump(mode, type) abort
   let fname = fnamemodify(expand("%"), ':p:gs?\\?/?')
 
   " so guru right now is slow for some people. previously we were using
@@ -69,7 +69,11 @@ function! go#def#Jump(mode) abort
     let [l:line, l:col] = getpos('.')[1:2]
     " delegate to gopls, with an empty job object and an exit status of 0
     " (they're irrelevant for gopls).
-    call go#lsp#Definition(l:fname, l:line, l:col, function('s:jump_to_declaration_cb', [a:mode, 'gopls', {}, 0]))
+    if a:type
+      call go#lsp#TypeDef(l:fname, l:line, l:col, function('s:jump_to_declaration_cb', [a:mode, 'gopls', {}, 0]))
+    else
+      call go#lsp#Definition(l:fname, l:line, l:col, function('s:jump_to_declaration_cb', [a:mode, 'gopls', {}, 0]))
+    endif
     return
   else
     call go#util#EchoError('go_def_mode value: '. bin_name .' is not valid. Valid values are: [godef, guru, gopls]')

--- a/autoload/go/def_test.vim
+++ b/autoload/go/def_test.vim
@@ -50,7 +50,7 @@ func! Test_Jump_leaves_lists() abort
 
     let l:bufnr = bufnr('%')
     call cursor(6, 7)
-    call go#def#Jump('')
+    call go#def#Jump('', 0)
 
     let start = reltime()
     while bufnr('%') == l:bufnr && reltimefloat(reltime(start)) < 10

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -295,6 +295,25 @@ function! go#lsp#Definition(fname, line, col, handler)
   call l:lsp.sendMessage(l:msg, funcref('s:definitionHandler', [function(a:handler, [], l:state)], l:state))
 endfunction
 
+" go#lsp#Type calls gopls to get the type definition of the identifier at
+" line and col in fname. handler should be a dictionary function that takes a
+" list of strings in the form 'file:line:col: message'. handler will be
+" attached to a dictionary that manages state (statuslines, sets the winid,
+" etc.)
+function! go#lsp#TypeDef(fname, line, col, handler)
+  function! s:typeDefinitionHandler(next, msg) abort dict
+    " gopls returns a []Location; just take the first one.
+    let l:msg = a:msg[0]
+    let l:args = [[printf('%s:%d:%d: %s', go#path#FromURI(l:msg.uri), l:msg.range.start.line+1, l:msg.range.start.character+1, 'lsp does not supply a description')]]
+    call call(a:next, l:args)
+  endfunction
+
+  let l:lsp = s:lspfactory.get()
+  let l:state = s:newHandlerState()
+  let l:msg = go#lsp#message#TypeDefinition(fnamemodify(a:fname, ':p'), a:line, a:col)
+  call l:lsp.sendMessage(l:msg, funcref('s:typeDefinitionHandler', [function(a:handler, [], l:state)], l:state))
+endfunction
+
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -30,6 +30,20 @@ function! go#lsp#message#Definition(file, line, col)
        \ }
 endfunction
 
+
+function! go#lsp#message#TypeDefinition(file, line, col)
+  return {
+          \ 'notification': 0,
+          \ 'method': 'textDocument/typeDefinition',
+          \ 'params': {
+          \   'textDocument': {
+          \       'uri': go#path#ToURI(a:file)
+          \   },
+          \   'position': s:position(a:line, a:col)
+          \ }
+       \ }
+endfunction
+
 function! s:position(line, col)
   return {'line': a:line - 1, 'character': a:col-1}
 endfunction

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -260,7 +260,7 @@ CTRL-]
 g<C-LeftMouse>
 <C-LeftMouse>
 
-    Goto declaration/definition for the declaration under the cursor. By
+    Go to declaration/definition for the identifier under the cursor. By
     default the CTRL-] shortcut, the mapping `gd` and <C-LeftMouse>,
     g<LeftMouse> are enabled to invoke :GoDef for the identifier under the
     cursor. See |'g:go_def_mapping_enabled'| to disable them. No explicit
@@ -272,6 +272,14 @@ g<C-LeftMouse>
     list of file locations you have visited with :GoDef that is retained to
     help you navigate software.
 
+    The per-window location stack is shared with |:GoDefType|.
+
+                                                                  *:GoDefType*
+:GoDefType
+
+    Go to type definition for the identifier under the cursor.
+
+    The per-window location stack is shared with |:GoDef|.
                                                                  *:GoDefStack*
 :GoDefStack [number]
 

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -40,8 +40,8 @@ if get(g:, "go_def_mapping_enabled", 1)
   nnoremap <buffer> <silent> <C-]> :GoDef<cr>
   nnoremap <buffer> <silent> <C-LeftMouse> <LeftMouse>:GoDef<cr>
   nnoremap <buffer> <silent> g<LeftMouse> <LeftMouse>:GoDef<cr>
-  nnoremap <buffer> <silent> <C-w><C-]> :<C-u>call go#def#Jump("split")<CR>
-  nnoremap <buffer> <silent> <C-w>] :<C-u>call go#def#Jump("split")<CR>
+  nnoremap <buffer> <silent> <C-w><C-]> :<C-u>call go#def#Jump("split", 0)<CR>
+  nnoremap <buffer> <silent> <C-w>] :<C-u>call go#def#Jump("split", 0)<CR>
   nnoremap <buffer> <silent> <C-t> :<C-U>call go#def#StackPop(v:count1)<cr>
 endif
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -54,7 +54,8 @@ command! -nargs=* -bang GoCoverageBrowser call go#coverage#Browser(<bang>0, <f-a
 command! -nargs=0 -range=% GoPlay call go#play#Share(<count>, <line1>, <line2>)
 
 " -- def
-command! -nargs=* -range GoDef :call go#def#Jump('')
+command! -nargs=* -range GoDef :call go#def#Jump('', 0)
+command! -nargs=* -range GoDefType :call go#def#Jump('', 1)
 command! -nargs=? GoDefPop :call go#def#StackPop(<f-args>)
 command! -nargs=? GoDefStack :call go#def#Stack(<f-args>)
 command! -nargs=? GoDefStackClear :call go#def#StackClear(<f-args>)

--- a/ftplugin/go/mappings.vim
+++ b/ftplugin/go/mappings.vim
@@ -53,10 +53,15 @@ nnoremap <silent> <Plug>(go-rename) :<C-u>call go#rename#Rename(!g:go_jump_to_er
 nnoremap <silent> <Plug>(go-decls) :<C-u>call go#decls#Decls(0, '')<CR>
 nnoremap <silent> <Plug>(go-decls-dir) :<C-u>call go#decls#Decls(1, '')<CR>
 
-nnoremap <silent> <Plug>(go-def) :<C-u>call go#def#Jump('')<CR>
-nnoremap <silent> <Plug>(go-def-vertical) :<C-u>call go#def#Jump("vsplit")<CR>
-nnoremap <silent> <Plug>(go-def-split) :<C-u>call go#def#Jump("split")<CR>
-nnoremap <silent> <Plug>(go-def-tab) :<C-u>call go#def#Jump("tab")<CR>
+nnoremap <silent> <Plug>(go-def) :<C-u>call go#def#Jump('', 0)<CR>
+nnoremap <silent> <Plug>(go-def-vertical) :<C-u>call go#def#Jump("vsplit", 0)<CR>
+nnoremap <silent> <Plug>(go-def-split) :<C-u>call go#def#Jump("split", 0)<CR>
+nnoremap <silent> <Plug>(go-def-tab) :<C-u>call go#def#Jump("tab", 0)<CR>
+
+nnoremap <silent> <Plug>(go-def-type) :<C-u>call go#def#Jump('', 1)<CR>
+nnoremap <silent> <Plug>(go-def-type-vertical) :<C-u>call go#def#Jump("vsplit", 1)<CR>
+nnoremap <silent> <Plug>(go-def-type-split) :<C-u>call go#def#Jump("split", 1)<CR>
+nnoremap <silent> <Plug>(go-def-type-tab) :<C-u>call go#def#Jump("tab", 1)<CR>
 
 nnoremap <silent> <Plug>(go-def-pop) :<C-u>call go#def#StackPop()<CR>
 nnoremap <silent> <Plug>(go-def-stack) :<C-u>call go#def#Stack()<CR>


### PR DESCRIPTION
Add a new function, `:GoDefType`, to jump to type definitions. Because
it relies on gopls, `:GoDefType` will only work in Vim8 and Neovim.