### PR TITLE
use gopls for autocompletion in Vim8 and Neovim

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -219,12 +219,22 @@ function! s:trim_bracket(val) abort
   return a:val
 endfunction
 
-let s:completions = ""
-function! go#complete#Complete(findstart, base) abort
+let s:completions = []
+
+function! go#complete#GocodeComplete(findstart, base) abort
   "findstart = 1 when we need to get the text length
   if a:findstart == 1
-    execute "silent let s:completions = " . s:gocodeAutocomplete()
-    return col('.') - s:completions[0] - 1
+    let l:completions = []
+    execute "silent let l:completions = " . s:gocodeAutocomplete()
+
+    if len(l:completions) == 0 || len(l:completions) >= 2 && len(l:completions[1]) == 0
+      " no matches. cancel and leave completion mode.
+      call go#util#EchoInfo("no matches")
+      return -3
+    endif
+
+    let s:completions = l:completions[1]
+    return col('.') - l:completions[0] - 1
     "findstart = 0 when we need to return the list of completions
   else
     let s = getline(".")[col('.') - 1]
@@ -233,6 +243,37 @@ function! go#complete#Complete(findstart, base) abort
     endif
 
     return s:completions[1]
+  endif
+endfunction
+
+function! go#complete#Complete(findstart, base) abort
+  let l:state = {'done': 0, 'matches': []}
+
+  function! s:handler(state, matches) abort dict
+    let a:state.matches = a:matches
+    let a:state.done = 1
+  endfunction
+
+  "findstart = 1 when we need to get the start of the match
+  if a:findstart == 1
+    call go#lsp#Completion(expand('%:p'), line('.'), col('.'), funcref('s:handler', [l:state]))
+
+    while !l:state.done
+      sleep 10m
+    endwhile
+
+    let s:completions = l:state.matches
+
+    if len(l:state.matches) == 0
+      " no matches. cancel and leave completion mode.
+      call go#util#EchoInfo("no matches")
+      return -3
+    endif
+
+    return col('.') - (len(l:state.matches[0].abbr) - len(l:state.matches[0].word))
+    "findstart = 0 when we need to return the list of completions
+  else
+    return s:completions
   endif
 endfunction
 

--- a/autoload/go/lsp/completionitemkind.vim
+++ b/autoload/go/lsp/completionitemkind.vim
@@ -1,0 +1,47 @@
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+let s:Text = 1
+let s:Method = 2
+let s:Function = 3
+let s:Constructor = 4
+let s:Field = 5
+let s:Variable = 6
+let s:Class = 7
+let s:Interface = 8
+let s:Module = 9
+let s:Property = 10
+let s:Unit = 11
+let s:Value = 12
+let s:Enum = 13
+let s:Keyword = 14
+let s:Snippet = 15
+let s:Color = 16
+let s:File = 17
+let s:Reference = 18
+let s:Folder = 19
+let s:EnumMember = 20
+let s:Constant = 21
+let s:Struct = 22
+let s:Event = 23
+let s:Operator = 24
+let s:TypeParameter = 25
+
+function! go#lsp#completionitemkind#Vim(kind)
+  if a:kind == s:Method || a:kind == s:Function || a:kind == s:Constructor
+    return 'f'
+  elseif a:kind == s:Variable || a:kind == s:Constant
+    return 'v'
+  elseif a:kind == s:Field || a:kind == s:Property
+    return 'm'
+  elseif a:kind == s:Class || a:kind == s:Interface || a:kind == s:Struct
+    return 't'
+  endif
+endfunction
+
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -87,6 +87,19 @@ function! go#lsp#message#DidClose(file)
        \ }
 endfunction
 
+function! go#lsp#message#Completion(file, line, col)
+  return {
+          \ 'notification': 0,
+          \ 'method': 'textDocument/completion',
+          \ 'params': {
+          \   'textDocument': {
+          \       'uri': go#path#ToURI(a:file)
+          \   },
+          \   'position': s:position(a:line, a:col),
+          \ }
+       \ }
+endfunction
+
 function! s:position(line, col)
   return {'line': a:line - 1, 'character': a:col-1}
 endfunction

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -42,7 +42,7 @@ tools developed by the Go community to provide a seamless Vim experience.
   * Quickly execute your current file(s) with |:GoRun|.
   * Improved syntax highlighting and folding.
   * Debug programs with integrated `delve` support with |:GoDebugStart|.
-  * Completion support via `gocode`.
+  * Completion support via `gocode` and `gopls`.
   * `gofmt` or `goimports` on save keeps the cursor position and undo history.
   * Go to symbol/declaration with |:GoDef|.
   * Look up documentation with |:GoDoc| or |:GoDocBrowser|.
@@ -1184,6 +1184,15 @@ cleaned for each package after `60` seconds. This can be changed with the
 Returns the description of the identifer under the cursor. Can be used to plug
 into the statusline.
 
+                                                      *go#complete#Complete()*
+
+Uses `gopls` for autocompletion. By default, it is hooked up to |'omnifunc'|
+for Vim8 and Neovim.
+
+                                                *go#complete#GocodeComplete()*
+
+Uses `gocode` for autocompletion. By default, it is hooked up to |'omnifunc'|
+for Vim 7.4.
 
                                                    *go#tool#DescribeBalloon()*
 

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -25,8 +25,11 @@ setlocal noexpandtab
 
 compiler go
 
-" Set gocode completion
+" Set autocompletion
 setlocal omnifunc=go#complete#Complete
+if !go#util#has_job()
+  setlocal omnifunc=go#complete#GocodeComplete
+endif
 
 if get(g:, "go_doc_keywordprg_enabled", 1)
   " keywordprg doesn't allow to use vim commands, override it


### PR DESCRIPTION
##### notify gopls about changes

##### use gopls for autocompletion
Use gopls for autocompletion when jobs are available (e.g. Vim8 and
Neovim).

Cancel completion in when there are no matches available.


