### PR TITLE
Update README.md to notify code completion support via gopls

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This plugin adds Go language support for Vim, with the following main features:
 * Quickly execute your current file(s) with `:GoRun`.
 * Improved syntax highlighting and folding.
 * Debug programs with integrated `delve` support with `:GoDebugStart`.
-* Completion support via `gocode`.
+* Completion support via `gocode` and `gopls`.
 * `gofmt` or `goimports` on save keeps the cursor position and undo history.
 * Go to symbol/declaration with `:GoDef`.
 * Look up documentation with `:GoDoc` or `:GoDocBrowser`.


### PR DESCRIPTION
According to this commit https://github.com/fatih/vim-go/commit/579d926ab9b16546febaa43bf104651634c20cbb , vim-go supports code completion using `gopls`.
I think it should be reflected on README.md.