### PR TITLE
go/lsp: don't proceed when LSP output is of type string

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -405,6 +405,12 @@ function! go#lsp#Completion(fname, line, col, handler)
   function! s:completionHandler(next, msg) abort dict
     " gopls returns a CompletionList.
     let l:matches = []
+
+    " a:msg is of type String when it can't resolve the completion
+    if type(a:msg) != v:t_dict 
+      return
+    endif
+
     for l:item in a:msg.items
       let l:match = {'abbr': l:item.label, 'word': l:item.textEdit.newText, 'info': '', 'kind': go#lsp#completionitemkind#Vim(l:item.kind)}
       if has_key(l:item, 'detail')


### PR DESCRIPTION
`a:msg` is of type string if gopls can't resolve a completion. This is reproducible if you write a random identifier and try to complete (I discovered when I mispelled a variable). Such as `reps.  <<<< complete here`. In this case `a:msg` is of type string and contains the following message: `cannot resolve reps`. 


However this is not working well, somehow vim-go is blocking and I have to press C-c. I think we're sleeping or blocking somewhere but couldn't find the place for it. This is not mergable therefore but opening in case you know how to fix it properly. 

Also I wonder if this gopls related issue. I would expect to return the data as JSON, do you think that's the problem? 