### PR TITLE
fix completion with gopls

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -270,9 +270,8 @@ function! go#complete#Complete(findstart, base) abort
       return -3
     endif
 
-    return col('.') - (len(l:state.matches[0].abbr) - len(l:state.matches[0].word))
-    "findstart = 0 when we need to return the list of completions
-  else
+    return col('.')
+  else "findstart = 0 when we need to return the list of completions
     return s:completions
   endif
 endfunction


### PR DESCRIPTION
Just return the current column instead of trying to calculate it,
because the word field will contain _exactly_ what remains to be
inserted when an item is selected.