### PR TITLE
improve go.mod syntax highlighting

### DIFF
--- a/autoload/go/highlight_test.vim
+++ b/autoload/go/highlight_test.vim
@@ -6,11 +6,14 @@ function! Test_gomodVersion_highlight() abort
   try
     syntax on
 
-    let l:dir= gotest#write_file('gomodtest/go.mod', [
+    let l:dir = gotest#write_file('gomodtest/go.mod', [
           \ 'module github.com/fatih/vim-go',
           \ '',
           \ '\x1frequire (',
           \ '\tversion/simple v1.0.0',
+          \ '\tversion/simple-pre-release v1.0.0-rc',
+          \ '\tversion/simple-pre-release v1.0.0+meta',
+          \ '\tversion/simple-pre-release v1.0.0-rc+meta',
           \ '\tversion/pseudo/premajor v1.0.0-20060102150405-0123456789abcdef',
           \ '\tversion/pseudo/prerelease v1.0.0-prerelease.0.20060102150405-0123456789abcdef',
           \ '\tversion/pseudo/prepatch v1.0.1-0.20060102150405-0123456789abcdef',
@@ -55,11 +58,10 @@ function! Test_gomodVersion_incompatible_highlight() abort
   try
     syntax on
 
-    let l:dir= gotest#write_file('gomodtest/go.mod', [
+    let l:dir = gotest#write_file('gomodtest/go.mod', [
           \ 'module github.com/fatih/vim-go',
           \ '',
           \ '\x1frequire (',
-          \ '\tversion/invalid/incompatible v1.0.0+incompatible',
           \ '\tversion/invalid/premajor/incompatible v1.0.0-20060102150405-0123456789abcdef+incompatible',
           \ '\tversion/invalid/prerelease/incompatible v1.0.0-prerelease.0.20060102150405-0123456789abcdef+incompatible',
           \ '\tversion/invalid/prepatch/incompatible v1.0.1-0.20060102150405-0123456789abcdef+incompatible',

--- a/syntax/gomod.vim
+++ b/syntax/gomod.vim
@@ -38,25 +38,48 @@ highlight default link gomodReplaceOperator Operator
 
 
 " highlight versions:
+"  * vX.Y.Z-pre
 "  * vX.Y.Z
 "  * vX.0.0-yyyyymmddhhmmss-abcdefabcdef
 "  * vX.Y.Z-pre.0.yyyymmddhhmmss-abcdefabcdef
 "  * vX.Y.(Z+1)-0.yyyymmddhhss-abcdefabcdef
-"  * +incompatible suffix when X > 1
+"  see https://godoc.org/golang.org/x/tools/internal/semver for more
+"  information about how semantic versions are parsed and
+"  https://golang.org/cmd/go/ for how pseudo-versions and +incompatible
+"  are applied.
+
+
 " match vX.Y.Z and their prereleases
-syntax match gomodVersion "v\d\+\.\d\+\.\d\+\%(-\%(\w\+\.\)\+0\.\d\{14}-\x\+\)\?"
-" match target when most recent version before the target is X.Y.Z
-syntax match gomodVersion "v\d\+\.\d\+\.[1-9]\{1}\d*\%(-0\.\%(\d\{14}-\x\+\)\)\?"
-" match target without a major version before the commit (e.g.  vX.0.0-yyyymmddhhmmss-abcdefabcdef)
-syntax match gomodVersion "v\d\+\.0\.0-\d\{14\}-\x\+"
+syntax match gomodVersion "v\d\+\.\d\+\.\d\+\%(-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\)\?\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?"
+"                          ^--- version ---^^------------ pre-release  ---------------------^^--------------- metadata ---------------------^
+"   	                     ^--------------------------------------- semantic version -------------------------------------------------------^
 
-" match vX.Y.Z and their prereleases for X>1
-syntax match gomodVersion "v[2-9]\{1}\d\?\.\d\+\.\d\+\%(-\%(\w\+\.\)\+0\.\d\{14\}-\x\+\)\?\%(+incompatible\>\)\?"
-" match target when most recent version before the target is X.Y.Z for X>1
-syntax match gomodVersion "v[2-9]\{1}\d\?\.\d\+\.[1-9]\{1}\d*\%(-0\.\%(\d\{14\}-\x\+\)\)\?\%(+incompatible\>\)\?"
-" match target without a major version before the commit (e.g.  vX.0.0-yyyymmddhhmmss-abcdefabcdef) for X>1
-syntax match gomodVersion "v[2-9]\{1}\d\?\.0\.0-\d\{14\}-\x\+\%(+incompatible\>\)\?"
+" match pseudo versions
+" without a major version before the commit (e.g.  vX.0.0-yyyymmddhhmmss-abcdefabcdef)
+syntax match gomodVersion  "v\d\+\.0\.0-\d\{14\}-\x\+"
+" when most recent version before target is a pre-release
+syntax match gomodVersion  "v\d\+\.\d\+\.\d\+-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?\.0\.\d\{14}-\x\+"
+"                          ^--- version ---^^--- ------ pre-release -----------------^^--------------- metadata ---------------------^
+"                     	   ^------------------------------------- semantic version --------------------------------------------------^
+" most recent version before the target is X.Y.Z
+syntax match gomodVersion "v\d\+\.\d\+\.\d\+\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?-0\.\d\{14}-\x\+"
+"                          ^--- version ---^^--------------- metadata ---------------------^
 
+" match incompatible vX.Y.Z and their prereleases
+syntax match gomodVersion "v[2-9]\{1}\d*\.\d\+\.\d\+\%(-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\)\?\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?+incompatible"
+"                          ^------- version -------^^------------- pre-release ---------------------^^--------------- metadata ---------------------^
+"               	         ^------------------------------------------- semantic version -----------------------------------------------------------^
+
+" match incompatible pseudo versions
+" incompatible without a major version before the commit (e.g.  vX.0.0-yyyymmddhhmmss-abcdefabcdef)
+syntax match gomodVersion "v[2-9]\{1}\d*\.0\.0-\d\{14\}-\x\++incompatible"
+" when most recent version before target is a pre-release
+syntax match gomodVersion "v[2-9]\{1}\d*\.\d\+\.\d\+-\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\%(+\%([0-9A-Za-z-]\+\)\(\.[0-9A-Za-z-]\+\)*\)\?\.0\.\d\{14}-\x\++incompatible"
+"                          ^------- version -------^^---------- pre-release -----------------^^--------------- metadata ---------------------^
+"                     	   ^---------------------------------------- semantic version ------------------------------------------------------^
+" most recent version before the target is X.Y.Z
+syntax match gomodVersion "v[2-9]\{1}\d*\.\d\+\.\d\+\%(+\%([0-9A-Za-z-]\+\)\%(\.[0-9A-Za-z-]\+\)*\)\?-0\.\d\{14}-\x\++incompatible"
+"                          ^------- version -------^^---------------- metadata ---------------------^
 highlight default link gomodVersion Identifier
 
 let b:current_syntax = "gomod"


### PR DESCRIPTION
Ensure that pre-release data and metadata in semantic versions gets
highlighted correctly.

Fixes #2190