### PR TITLE
adds options to suppress/customize delve logging; closes #2200

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -210,6 +210,15 @@ function! go#config#DebugCommands() abort
   return g:go_debug_commands
 endfunction
 
+function! go#config#DebugLogOutput() abort
+  let shouldlog = get(g:, 'go_debug_log', 1)
+  if shouldlog
+     return  "--log --log_output " .  get(g:, 'go_debug_log_output', 'debugger, rpc')
+   else
+     return ""
+   endif
+endfunction
+
 function! go#config#LspLog() abort
   " make sure g:go_lsp_log is set so that it can be added to easily.
   let g:go_lsp_log = get(g:, 'go_lsp_log', [])

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -211,12 +211,7 @@ function! go#config#DebugCommands() abort
 endfunction
 
 function! go#config#DebugLogOutput() abort
-  let shouldlog = get(g:, 'go_debug_log', 1)
-  if shouldlog
-     return  "--log --log_output " .  get(g:, 'go_debug_log_output', 'debugger, rpc')
-   else
-     return ""
-   endif
+  return get(g:, 'go_debug_log_output', 'debugger, rpc')
 endfunction
 
 function! go#config#LspLog() abort

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -624,7 +624,7 @@ function! go#debug#Start(is_test, ...) abort
           \ '--output', tempname(),
           \ '--headless',
           \ '--api-version', '2',
-          \ '--log', '--log-output', 'debugger,rpc',
+          \ go#config#DebugLogOutput(),
           \ '--listen', go#config#DebugAddress(),
     \]
 

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -617,6 +617,8 @@ function! go#debug#Start(is_test, ...) abort
       let l:args = ['--'] + a:000[1:]
     endif
 
+    let l:debugLogOutput = go#config#DebugLogOutput()
+    let l:shouldLog = debugLogOutput isnot '' ? 1 : 0
     let l:cmd = [
           \ dlv,
           \ (a:is_test ? 'test' : 'debug'),
@@ -624,9 +626,11 @@ function! go#debug#Start(is_test, ...) abort
           \ '--output', tempname(),
           \ '--headless',
           \ '--api-version', '2',
-          \ go#config#DebugLogOutput(),
           \ '--listen', go#config#DebugAddress(),
     \]
+    if shouldLog
+      let cmd += ['--log', '--log-output', debugLogOutput]
+    endif
 
     let buildtags = go#config#BuildTags()
     if buildtags isnot ''

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2153,6 +2153,22 @@ Defaults to `127.0.0.1:8181`:
   let g:go_debug_address = '127.0.0.1:8181'
 <
 
+                                                        *'g:go_debug_log'*
+
+Set to `1` to enable logging of debugging output to standard error, or `0` to suppress log output.
+Defaults to `1`:
+>
+  let g:go_debug_log = 1
+<
+
+                                                        *'g:go_debug_log_output'*
+
+Specifies log output options for `dlv` if |g:go_debug_log| is set to `1`. Value should be a single string of comma-separated options suitable for passing to `dlv`.
+Default: `'debugger, rpc'`:
+>
+  let g:go_debug_log = 'debugger, rpc'
+<
+
                                                      *'g:go_highlight_debug'*
 
 Highlight the current line and breakpoints in the debugger.

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2153,17 +2153,11 @@ Defaults to `127.0.0.1:8181`:
   let g:go_debug_address = '127.0.0.1:8181'
 <
 
-                                                        *'g:go_debug_log'*
+                                                     *'g:go_debug_log_output'*
 
-Set to `1` to enable logging of debugging output to standard error, or `0` to suppress log output.
-Defaults to `1`:
->
-  let g:go_debug_log = 1
-<
-
-                                                        *'g:go_debug_log_output'*
-
-Specifies log output options for `dlv` if |g:go_debug_log| is set to `1`. Value should be a single string of comma-separated options suitable for passing to `dlv`.
+Specifies log output options for `dlv`. Value should be a single string 
+of comma-separated options suitable for passing to `dlv`.  An empty string 
+(`''`) will suppress logging entirely.
 Default: `'debugger, rpc'`:
 >
   let g:go_debug_log = 'debugger, rpc'


### PR DESCRIPTION
This PR addresses #2200 and introduces the following variables:
`g:go_debug_log` - defaults to `1`; set to `0` to suppress logging output
`g:go_debug_log_output`: defaults to `debugger, rpc`; set to a string that corresponds to the [delve `log_output` options](https://github.com/go-delve/delve/blob/v1.2.0/Documentation/usage/dlv.md#options). Will only be used if `go_debug_log` is set to `1`.

Documentation is also included.

This PR preserves the current behavior through its default settings so should be completely transparent to existing users.