### PR TITLE
refactor terminal handling

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -48,7 +48,7 @@ function! go#config#TermMode() abort
 endfunction
 
 function! go#config#TermEnabled() abort
-  return get(g:, 'go_term_enabled', 0)
+  return has('nvim') && get(g:, 'go_term_enabled', 0)
 endfunction
 
 function! go#config#SetTermEnabled(value) abort

--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -491,7 +491,9 @@ function! s:neocb(mode, ch, buf, data, callback)
 
   let l:buf = ''
 
-  " a single empty string means EOF was reached.
+  " A single empty string means EOF was reached. The first item will never be
+  " an empty string except for when it's the only item and is signaling that
+  " EOF was reached.
   if len(a:data) == 1 && a:data[0] == ''
     " when there's nothing buffered, return early so that an
     " erroneous message will not be added.

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -4,31 +4,33 @@ set cpo&vim
 
 " new creates a new terminal with the given command. Mode is set based on the
 " global variable g:go_term_mode, which is by default set to :vsplit
-function! go#term#new(bang, cmd) abort
-  return go#term#newmode(a:bang, a:cmd, go#config#TermMode())
+function! go#term#new(bang, cmd, errorformat) abort
+  return go#term#newmode(a:bang, a:cmd, a:errorformat, go#config#TermMode())
 endfunction
 
-" new creates a new terminal with the given command and window mode.
-function! go#term#newmode(bang, cmd, mode) abort
-  let mode = a:mode
-  if empty(mode)
-    let mode = go#config#TermMode()
+" go#term#newmode creates a new terminal with the given command and window mode.
+function! go#term#newmode(bang, cmd, errorformat, mode) abort
+  let l:mode = a:mode
+  if empty(l:mode)
+    let l:mode = go#config#TermMode()
   endif
 
-  let state = {
+  let l:state = {
         \ 'cmd': a:cmd,
         \ 'bang' : a:bang,
         \ 'winid': win_getid(winnr()),
-        \ 'stdout': []
+        \ 'stdout': [],
+        \ 'stdout_buf': '',
+        \ 'errorformat': a:errorformat,
       \ }
 
   " execute go build in the files directory
-  let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
-  let dir = getcwd()
+  let l:cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
+  let l:dir = getcwd()
 
-  execute cd . fnameescape(expand("%:p:h"))
+  execute l:cd . fnameescape(expand("%:p:h"))
 
-  execute mode.' __go_term__'
+  execute l:mode . ' __go_term__'
 
   setlocal filetype=goterm
   setlocal bufhidden=delete
@@ -41,83 +43,103 @@ function! go#term#newmode(bang, cmd, mode) abort
   "
   " Don't set an on_stderr, because it will be passed the same data as
   " on_stdout. See https://github.com/neovim/neovim/issues/2836
-  let job = {
+  let l:job = {
         \ 'on_stdout': function('s:on_stdout', [], state),
         \ 'on_exit' : function('s:on_exit', [], state),
       \ }
 
-  let state.id = termopen(a:cmd, job)
-  let state.termwinid = win_getid(winnr())
+  let l:state.id = termopen(a:cmd, l:job)
+  let l:state.termwinid = win_getid(winnr())
 
-  execute cd . fnameescape(dir)
+  execute l:cd . fnameescape(l:dir)
 
   " resize new term if needed.
-  let height = go#config#TermHeight()
-  let width = go#config#TermWidth()
+  let l:height = go#config#TermHeight()
+  let l:width = go#config#TermWidth()
 
   " Adjust the window width or height depending on whether it's a vertical or
   " horizontal split.
-  if mode =~ "vertical" || mode =~ "vsplit" || mode =~ "vnew"
-    exe 'vertical resize ' . width
+  if l:mode =~ "vertical" || l:mode =~ "vsplit" || l:mode =~ "vnew"
+    exe 'vertical resize ' . l:width
   elseif mode =~ "split" || mode =~ "new"
-    exe 'resize ' . height
+    exe 'resize ' . l:height
   endif
 
   " we also need to resize the pty, so there you go...
-  call jobresize(state.id, width, height)
+  call jobresize(l:state.id, l:width, l:height)
 
-  call win_gotoid(state.winid)
+  call win_gotoid(l:state.winid)
 
-  return state.id
+  return l:state.id
 endfunction
 
 function! s:on_stdout(job_id, data, event) dict abort
-  call extend(self.stdout, a:data)
+  " A single empty string means EOF was reached. The first item will never be
+  " the empty string except for when it's the only item and is signaling that
+  " EOF was reached.
+  if len(a:data) == 1 && a:data[0] == ''
+    " when there's nothing buffered, return early so that an
+    " erroneous message will not be added.
+    if self.stdout_buf == ''
+      return
+    endif
+
+    let self.stdout = add(self.stdout, self.stdout_buf)
+  else
+    let l:data = copy(a:data)
+    let l:data[0] = self.stdout_buf . l:data[0]
+
+    " The last element may be a partial line; save it for next time.
+    let self.stdout_buf = l:data[-1]
+    let self.stdout = extend(self.stdout, l:data[:-2])
+  endif
 endfunction
 
 function! s:on_exit(job_id, exit_status, event) dict abort
+  let l:winid = win_getid(winnr())
+  call win_gotoid(self.winid)
   let l:listtype = go#list#Type("_term")
 
-  " usually there is always output so never branch into this clause
-  if empty(self.stdout)
-    call s:cleanlist(self.winid, l:listtype)
+  if a:exit_status == 0
+    call go#list#Clean(l:listtype)
+    call win_gotoid(l:winid)
     return
   endif
 
-  let errors = go#util#ParseErrors(self.stdout)
-  let errors = go#util#FilterValids(errors)
+  call win_gotoid(self.winid)
 
-  if !empty(errors)
-    " close terminal; we don't need it anymore
-    call win_gotoid(self.termwinid)
-    close
+  let l:title = self.cmd
+  if type(l:title) == v:t_list
+    let l:title = join(self.cmd)
+  endif
 
-    call win_gotoid(self.winid)
+  let l:i = 0
+  while l:i < len(self.stdout)
+    let self.stdout[l:i] = substitute(self.stdout[l:i], "\r$", '', 'g')
+    let l:i += 1
+  endwhile
 
-    let title = self.cmd
-    if type(title) == v:t_list
-      let title = join(self.cmd)
-    endif
-    call go#list#Populate(l:listtype, errors, title)
-    call go#list#Window(l:listtype, len(errors))
-    if !self.bang
-      call go#list#JumpToFirst(l:listtype)
-    endif
+  call go#list#ParseFormat(l:listtype, self.errorformat, self.stdout, l:title)
+  let l:errors = go#list#Get(l:listtype)
+  call go#list#Window(l:listtype, len(l:errors))
 
+  if empty(l:errors)
+    call go#util#EchoError( '[' . l:title . '] ' . "FAIL")
+    call win_gotoid(l:winid)
     return
   endif
 
-  call s:cleanlist(self.winid, l:listtype)
-endfunction
+  " close terminal; we don't need it anymore
+  call win_gotoid(self.termwinid)
+  close!
 
-function! s:cleanlist(winid, listtype) abort
-  " There are no errors. Clean and close the list. Jump to the window to which
-  " the location list is attached, close the list, and then jump back to the
-  " current window.
-  let winid = win_getid(winnr())
-  call win_gotoid(a:winid)
-  call go#list#Clean(a:listtype)
-  call win_gotoid(l:winid)
+  if self.bang
+    call win_gotoid(l:winid)
+    return
+  endif
+
+  call win_gotoid(self.winid)
+  call go#list#JumpToFirst(l:listtype)
 endfunction
 
 " restore Vi compatibility settings

--- a/autoload/go/term_test.vim
+++ b/autoload/go/term_test.vim
@@ -17,7 +17,7 @@ func! Test_GoTermNewMode()
     let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
 
     set nosplitright
-    call go#term#newmode(0, cmd, '')
+    call go#term#new(0, cmd, &errorformat)
     let actual = expand('%:p')
     call assert_equal(actual, l:expected)
 
@@ -41,7 +41,7 @@ func! Test_GoTermNewMode_SplitRight()
     let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
 
     set splitright
-    call go#term#newmode(0, cmd, '')
+    call go#term#new(0, cmd, &errorformat)
     let actual = expand('%:p')
     call assert_equal(actual, l:expected)
 

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -30,8 +30,8 @@ function! go#test#Test(bang, compile, ...) abort
     call add(args, printf("-timeout=%s", timeout))
   endif
 
-  if has('nvim') && go#config#TermEnabled()
-    call go#term#new(a:bang, ["go"] + args)
+  if go#config#TermEnabled()
+    call go#term#new(a:bang, ["go"] + args, s:errorformat())
   endif
 
   if go#util#has_job()

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -511,42 +511,6 @@ function! go#util#ParseErrors(lines) abort
   return errors
 endfunction
 
-" FilterValids filters the given items with only items that have a valid
-" filename. Any non valid filename is filtered out.
-function! go#util#FilterValids(items) abort
-  " Remove any nonvalid filename from the location list to avoid opening an
-  " empty buffer. See https://github.com/fatih/vim-go/issues/287 for
-  " details.
-  let filtered = []
-  let is_readable = {}
-
-  for item in a:items
-    if has_key(item, 'bufnr')
-      let filename = bufname(item.bufnr)
-    elseif has_key(item, 'filename')
-      let filename = item.filename
-    else
-      " nothing to do, add item back to the list
-      call add(filtered, item)
-      continue
-    endif
-
-    if !has_key(is_readable, filename)
-      let is_readable[filename] = filereadable(filename)
-    endif
-    if is_readable[filename]
-      call add(filtered, item)
-    endif
-  endfor
-
-  for k in keys(filter(is_readable, '!v:val'))
-    echo "vim-go: " | echohl Identifier | echon "[run] Dropped " | echohl Constant | echon  '"' . k . '"'
-    echohl Identifier | echon " from location list (nonvalid filename)" | echohl None
-  endfor
-
-  return filtered
-endfunction
-
 function! go#util#ShowInfo(info)
   if empty(a:info)
     return


### PR DESCRIPTION
Use errorformat for GoRun error handling.

Remove go#util#FilterValids, because there are no remaining callers.

Add local variable prefix, `l:` to variables in autoload/go/term.vim.

Handle stdout correctly in autoload/go/term.vim, including stripping
unnecessary line endings that Neovim seems to add when the job is
attached to a terminal.

Use the usual functions for managing lists in autoload/go/term.vim
instead of having some one-offs.

Fixes #1260