### PR TITLE
synchronize with gopls on certain events

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -368,6 +368,10 @@ function! go#lsp#DidOpen(fname)
     return
   endif
 
+  if !filereadable(a:fname)
+    return
+  endif
+
   let l:lsp = s:lspfactory.get()
   let l:msg = go#lsp#message#DidOpen(fnamemodify(a:fname, ':p'), join(go#util#GetLines(), "\n") . "\n")
   let l:state = s:newHandlerState('')
@@ -382,6 +386,10 @@ function! go#lsp#DidChange(fname)
     return go#lsp#DidOpen(a:fname)
   endif
 
+  if !filereadable(a:fname)
+    return
+  endif
+
   let l:lsp = s:lspfactory.get()
   let l:msg = go#lsp#message#DidChange(fnamemodify(a:fname, ':p'), join(go#util#GetLines(), "\n") . "\n")
   let l:state = s:newHandlerState('')
@@ -390,6 +398,10 @@ function! go#lsp#DidChange(fname)
 endfunction
 
 function! go#lsp#DidClose(fname)
+  if !filereadable(a:fname)
+    return
+  endif
+
   if !get(b:, 'go_lsp_did_open', 0)
     return
   endif

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -82,9 +82,16 @@ endif
 augroup vim-go-buffer
   autocmd! * <buffer>
 
-  " TODO(bc): notify gopls about changes on CursorHold when the buffer is
-  " modified.
-  " TODO(bc): notify gopls that the file on disk is correct on BufWritePost
+  " The file is registered (textDocument/DidOpen) with gopls in in
+  " plugin/go.vim on the FileType event.
+  " TODO(bc): handle all the other events that may be of interest to gopls,
+  " too (e.g.  BufFilePost , CursorHold , CursorHoldI, FileReadPost,
+  " StdinReadPre, BufWritePost, TextChange, TextChangedI)
+  if go#util#has_job()
+    autocmd BufWritePost <buffer> call go#lsp#DidChange(expand('<afile>:p'))
+    autocmd FileChangedShell <buffer> call go#lsp#DidChange(expand('<afile>:p'))
+    autocmd BufDelete <buffer> call go#lsp#DidClose(expand('<afile>:p'))
+  endif
 
   autocmd CursorHold <buffer> call go#auto#auto_type_info()
   autocmd CursorHold <buffer> call go#auto#auto_sameids()

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -234,6 +234,14 @@ function! s:gofiletype_post()
   let &g:fileencodings = s:current_fileencodings
 endfunction
 
+function! s:register()
+  if !(&modifiable && expand('<amatch>') ==# 'go')
+    return
+  endif
+
+  call go#lsp#DidOpen(expand('<afile>:p'))
+endfunction
+
 augroup vim-go
   autocmd!
 
@@ -245,6 +253,10 @@ augroup vim-go
   autocmd BufNewFile *.s if &modifiable | setlocal fileencoding=utf-8 fileformat=unix | endif
   autocmd BufRead *.s call s:gofiletype_pre()
   autocmd BufReadPost *.s call s:gofiletype_post()
+
+  if go#util#has_job()
+    autocmd FileType * call s:register()
+  endif
 augroup end
 
 " restore Vi compatibility settings


### PR DESCRIPTION
##### do not synchronize pseudo-files with gopls

##### register files with gopls when FileType is set
Register files when FileType is set. This will pre-load gopls and cause
it to start tracking files before it's otherwise needed. Because gopls
will already be loaded, there is less likely to be a delay the first
time a user runs a command that needs it.


##### synchronize buffers with gopls
Notify gopls when buffers have changed. This won't catch all use cases,
but it least makes sure that gopls is notified when the the file is
changed on disk (e.g. via `:GoFmt`, `:GoRename`, or other actions by the
user) and when gopls should consider the file to be closed, because the
buffer was deleted.


Fixes #2207 