### PR TITLE
Fix did change

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -21,7 +21,7 @@ function! s:lspfactory.reset() dict abort
   endif
 endfunction
 
-function! s:newlsp()
+function! s:newlsp() abort
   if !go#util#has_job()
     " TODO(bc): start the server in the background using a shell that waits for the right output before returning.
     call go#util#EchoError('This feature requires either Vim 8.0.0087 or newer with +job or Neovim.')
@@ -251,10 +251,10 @@ function! s:newlsp()
   return l:lsp
 endfunction
 
-function! s:noop()
+function! s:noop() abort
 endfunction
 
-function! s:newHandlerState(statustype)
+function! s:newHandlerState(statustype) abort
   let l:state = {
         \ 'winid': win_getid(winnr()),
         \ 'statustype': a:statustype,
@@ -324,7 +324,7 @@ endfunction
 " list of strings in the form 'file:line:col: message'. handler will be
 " attached to a dictionary that manages state (statuslines, sets the winid,
 " etc.)
-function! go#lsp#Definition(fname, line, col, handler)
+function! go#lsp#Definition(fname, line, col, handler) abort
   call go#lsp#DidChange(a:fname)
 
   let l:lsp = s:lspfactory.get()
@@ -346,7 +346,7 @@ endfunction
 " list of strings in the form 'file:line:col: message'. handler will be
 " attached to a dictionary that manages state (statuslines, sets the winid,
 " etc.)
-function! go#lsp#TypeDef(fname, line, col, handler)
+function! go#lsp#TypeDef(fname, line, col, handler) abort
   call go#lsp#DidChange(a:fname)
 
   let l:lsp = s:lspfactory.get()
@@ -363,7 +363,7 @@ function! s:typeDefinitionHandler(next, msg) abort dict
   call call(a:next, l:args)
 endfunction
 
-function! go#lsp#DidOpen(fname)
+function! go#lsp#DidOpen(fname) abort
   if get(b:, 'go_lsp_did_open', 0)
     return
   endif
@@ -397,7 +397,7 @@ function! go#lsp#DidChange(fname)
   call l:lsp.sendMessage(l:msg, l:state)
 endfunction
 
-function! go#lsp#DidClose(fname)
+function! go#lsp#DidClose(fname) abort
   if !filereadable(a:fname)
     return
   endif
@@ -415,7 +415,7 @@ function! go#lsp#DidClose(fname)
   let b:go_lsp_did_open = 0
 endfunction
 
-function! go#lsp#Completion(fname, line, col, handler)
+function! go#lsp#Completion(fname, line, col, handler) abort
   call go#lsp#DidChange(a:fname)
 
   let l:lsp = s:lspfactory.get()
@@ -449,7 +449,7 @@ function! s:completionErrorHandler(next, error) abort dict
   call call(a:next, [[]])
 endfunction
 
-function! go#lsp#Hover(fname, line, col, handler)
+function! go#lsp#Hover(fname, line, col, handler) abort
   call go#lsp#DidChange(a:fname)
 
   let l:lsp = s:lspfactory.get()

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -381,10 +381,8 @@ function! go#lsp#DidOpen(fname) abort
   let b:go_lsp_did_open = 1
 endfunction
 
-function! go#lsp#DidChange(fname)
-  if get(b:, 'go_lsp_did_open', 0)
-    return go#lsp#DidOpen(a:fname)
-  endif
+function! go#lsp#DidChange(fname) abort
+  call go#lsp#DidOpen(a:fname)
 
   if !filereadable(a:fname)
     return

--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -2,7 +2,7 @@
 let s:cpo_save = &cpo
 set cpo&vim
 
-function! go#lsp#message#Initialize(wd)
+function! go#lsp#message#Initialize(wd) abort
   return {
           \ 'notification': 0,
           \ 'method': 'initialize',
@@ -17,7 +17,7 @@ function! go#lsp#message#Initialize(wd)
        \ }
 endfunction
 
-function! go#lsp#message#Definition(file, line, col)
+function! go#lsp#message#Definition(file, line, col) abort
   return {
           \ 'notification': 0,
           \ 'method': 'textDocument/definition',
@@ -31,7 +31,7 @@ function! go#lsp#message#Definition(file, line, col)
 endfunction
 
 
-function! go#lsp#message#TypeDefinition(file, line, col)
+function! go#lsp#message#TypeDefinition(file, line, col) abort
   return {
           \ 'notification': 0,
           \ 'method': 'textDocument/typeDefinition',
@@ -44,7 +44,7 @@ function! go#lsp#message#TypeDefinition(file, line, col)
        \ }
 endfunction
 
-function! go#lsp#message#DidOpen(file, content)
+function! go#lsp#message#DidOpen(file, content) abort
   return {
           \ 'notification': 1,
           \ 'method': 'textDocument/didOpen',
@@ -58,7 +58,7 @@ function! go#lsp#message#DidOpen(file, content)
        \ }
 endfunction
 
-function! go#lsp#message#DidChange(file, content)
+function! go#lsp#message#DidChange(file, content) abort
   return {
           \ 'notification': 1,
           \ 'method': 'textDocument/didChange',
@@ -75,7 +75,7 @@ function! go#lsp#message#DidChange(file, content)
        \ }
 endfunction
 
-function! go#lsp#message#DidClose(file)
+function! go#lsp#message#DidClose(file) abort
   return {
           \ 'notification': 1,
           \ 'method': 'textDocument/didClose',
@@ -87,7 +87,7 @@ function! go#lsp#message#DidClose(file)
        \ }
 endfunction
 
-function! go#lsp#message#Completion(file, line, col)
+function! go#lsp#message#Completion(file, line, col) abort
   return {
           \ 'notification': 0,
           \ 'method': 'textDocument/completion',
@@ -100,7 +100,7 @@ function! go#lsp#message#Completion(file, line, col)
        \ }
 endfunction
 
-function! go#lsp#message#Hover(file, line, col)
+function! go#lsp#message#Hover(file, line, col) abort
   return {
           \ 'notification': 0,
           \ 'method': 'textDocument/hover',
@@ -113,7 +113,7 @@ function! go#lsp#message#Hover(file, line, col)
        \ }
 endfunction
 
-function! s:position(line, col)
+function! s:position(line, col) abort
   return {'line': a:line - 1, 'character': a:col-1}
 endfunction
 


### PR DESCRIPTION
##### add abort modifiers to lsp functions

##### sync buffer to gopls in go#lsp#DidChange correctly
Call `go#lsp#DidOpen` unconditionally in `go#lsp#DidChange` instead of
_only_ calling it and returning early when the document has already been
opened. 🤦 oof.

Fixes #2214


