### PR TITLE
add a gopls option for g:go_info_mode

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -93,22 +93,6 @@ endfunction
 function! s:async_info(echo, showstatus)
   let state = {'echo': a:echo}
 
-  function! s:complete(job, exit_status, messages) abort dict
-    if a:exit_status != 0
-      return
-    endif
-
-    if &encoding != 'utf-8'
-      let i = 0
-      while i < len(a:messages)
-        let a:messages[i] = iconv(a:messages[i], 'utf-8', &encoding)
-        let i += 1
-      endwhile
-    endif
-
-    let result = s:info_filter(self.echo, join(a:messages, "\n"))
-    call s:info_complete(self.echo, result)
-  endfunction
   " explicitly bind complete to state so that within it, self will
   " always refer to state. See :help Partial for more information.
   let state.complete = function('s:complete', [], state)
@@ -149,6 +133,23 @@ function! s:async_info(echo, showstatus)
         \ })
 
   call go#job#Start(cmd, opts)
+endfunction
+
+function! s:complete(job, exit_status, messages) abort dict
+  if a:exit_status != 0
+    return
+  endif
+
+  if &encoding != 'utf-8'
+    let i = 0
+    while i < len(a:messages)
+      let a:messages[i] = iconv(a:messages[i], 'utf-8', &encoding)
+      let i += 1
+    endwhile
+  endif
+
+  let result = s:info_filter(self.echo, join(a:messages, "\n"))
+  call s:info_complete(self.echo, result)
 endfunction
 
 function! s:gocodeFile()

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -246,7 +246,7 @@ function! go#guru#DescribeInfo(showstatus) abort
         \ 'selected': -1,
         \ 'needs_scope': 0,
         \ 'custom_parse': function('s:info'),
-        \ 'disable_progress': 1,
+        \ 'disable_progress': a:showstatus == 0,
         \ }
 
   call s:run_guru(args)

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -383,6 +383,13 @@ function! go#lsp#DidOpen(fname) abort
 endfunction
 
 function! go#lsp#DidChange(fname) abort
+  " DidChange is called even when fname isn't open in a buffer (e.g. via
+  " go#lsp#Info); don't report the file as open or as having changed when it's
+  " not actually a buffer.
+  if bufnr(a:fname) == -1
+    return
+  endif
+
   call go#lsp#DidOpen(a:fname)
 
   if !filereadable(a:fname)
@@ -464,6 +471,42 @@ function! s:hoverHandler(next, msg) abort dict
   let l:content = substitute(a:msg.contents.value, '```go\n\(.*\)\n```', '\1', '')
   let l:args = [l:content]
   call call(a:next, l:args)
+endfunction
+
+function! go#lsp#Info(showstatus)
+  let l:fname = expand('%:p')
+  let [l:line, l:col] = getpos('.')[1:2]
+
+  call go#lsp#DidChange(l:fname)
+
+  let l:lsp = s:lspfactory.get()
+  let l:state = s:newHandlerState('')
+  let l:state.handleResult = funcref('s:infoDefinitionHandler', [function('s:info', [])], l:state)
+  let l:state.error = funcref('s:noop')
+  let l:msg = go#lsp#message#Definition(l:fname, l:line, l:col)
+  call l:lsp.sendMessage(l:msg, l:state)
+endfunction
+
+function! s:infoDefinitionHandler(next, msg) abort dict
+  " gopls returns a []Location; just take the first one.
+  let l:msg = a:msg[0]
+
+  let l:fname = go#path#FromURI(l:msg.uri)
+  let l:line = l:msg.range.start.line+1
+  let l:col = l:msg.range.start.character+1
+
+  let l:lsp = s:lspfactory.get()
+  let l:msg = go#lsp#message#Hover(l:fname, l:line, l:col)
+  let l:state = s:newHandlerState('info')
+  let l:state.handleResult = funcref('s:hoverHandler', [function('s:info', [], l:state)], l:state)
+  let l:state.error = funcref('s:noop')
+  call l:lsp.sendMessage(l:msg, l:state)
+endfunction
+
+function! s:info(content) abort dict
+  " strip off the method set and fields of structs and interfaces.
+  let l:content = substitute(a:content, '{.*', '', '')
+  call go#util#ShowInfo(l:content)
 endfunction
 
 " restore Vi compatibility settings

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -117,9 +117,10 @@ function! s:newlsp() abort
 
             if has_key(l:response, 'error')
               call l:handler.requestComplete(0)
-              call go#util#EchoError(l:response.error.message)
               if has_key(l:handler, 'error')
                 call call(l:handler.error, [l:response.error.message])
+              else
+                call go#util#EchoError(l:response.error.message)
               endif
               return
             endif

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -252,7 +252,7 @@ function! s:newlsp() abort
   return l:lsp
 endfunction
 
-function! s:noop() abort
+function! s:noop(...) abort
 endfunction
 
 function! s:newHandlerState(statustype) abort
@@ -455,6 +455,7 @@ function! go#lsp#Hover(fname, line, col, handler) abort
   let l:msg = go#lsp#message#Hover(a:fname, a:line, a:col)
   let l:state = s:newHandlerState('hover')
   let l:state.handleResult = funcref('s:hoverHandler', [function(a:handler, [], l:state)], l:state)
+  let l:state.error = funcref('s:noop')
   call l:lsp.sendMessage(l:msg, l:state)
 endfunction
 

--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -30,7 +30,6 @@ function! go#lsp#message#Definition(file, line, col) abort
        \ }
 endfunction
 
-
 function! go#lsp#message#TypeDefinition(file, line, col) abort
   return {
           \ 'notification': 0,

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -86,8 +86,10 @@ function! go#tool#Info(showstatus) abort
     call go#complete#Info(a:showstatus)
   elseif l:mode == 'guru'
     call go#guru#DescribeInfo(a:showstatus)
+  elseif l:mode == 'gopls'
+    call go#lsp#Info(a:showstatus)
   else
-    call go#util#EchoError('go_info_mode value: '. l:mode .' is not valid. Valid values are: [gocode, guru]')
+    call go#util#EchoError('go_info_mode value: '. l:mode .' is not valid. Valid values are: [gocode, guru, gopls]')
   endif
 endfunction
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1251,8 +1251,8 @@ updated. By default it's disabled. The delay can be configured with the
 
 Use this option to define the command to be used for |:GoInfo|. By default
 `gocode` is being used as it's the fastest option. But one might also use
-`guru` as it's covers more cases and is more accurate.  Current valid options
-are: `[gocode, guru]` >
+`gopls` or `guru` as they cover more cases and are more accurate.  Current
+valid options are: `[gocode, guru, gopls]` >
 
   let g:go_info_mode = 'gocode'
 <


### PR DESCRIPTION
##### move function to script scope
Move function script scope to avoid redefinition problems while a
reference to it is held.


##### respect showstatus when using guru to get identifier info

##### lsp: use default error handler only when one isn't provided

##### lsp: swallow errors when hovering
Swallow errors from gopls when hovering so that hovering over a
non-identifier (e.g. a keyword) won't display an error to the user.


##### add gopls option for g:go_info_mode

