### PR TITLE
[add] toggle autocomplete option

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1202,7 +1202,7 @@ balloonexpr`.
 ==============================================================================
 SETTINGS                                                        *go-settings*
 
-                                                      *'g:auto_complete_enabled'*
+                                                   *'g:auto_complete_enabled'*
 
 Use auto complation(set omnifunc=go#complete#Complete).
 By default it is enabled.

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1202,6 +1202,14 @@ balloonexpr`.
 ==============================================================================
 SETTINGS                                                        *go-settings*
 
+                                                      *'g:auto_complete_enabled'*
+
+Use auto complation(set omnifunc=go#complete#Complete).
+By default it is enabled.
+>
+  let g:auto_complete_enabled = 1
+<
+
                                                       *'g:go_test_show_name'*
 
 Show the name of each failed test before the errors and logs output by the
@@ -2155,8 +2163,8 @@ Defaults to `127.0.0.1:8181`:
 
                                                      *'g:go_debug_log_output'*
 
-Specifies log output options for `dlv`. Value should be a single string 
-of comma-separated options suitable for passing to `dlv`.  An empty string 
+Specifies log output options for `dlv`. Value should be a single string
+of comma-separated options suitable for passing to `dlv`.  An empty string
 (`''`) will suppress logging entirely.
 Default: `'debugger, rpc'`:
 >

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -25,10 +25,12 @@ setlocal noexpandtab
 
 compiler go
 
-" Set autocompletion
-setlocal omnifunc=go#complete#Complete
-if !go#util#has_job()
-  setlocal omnifunc=go#complete#GocodeComplete
+if get(g:, "go_autocomplete_enabled", 1)
+  " Set autocompletion
+  setlocal omnifunc=go#complete#Complete
+  if !go#util#has_job()
+    setlocal omnifunc=go#complete#GocodeComplete
+  endif
 endif
 
 if get(g:, "go_doc_keywordprg_enabled", 1)


### PR DESCRIPTION
Hi.
Thanks for make great plugin.

This pr is add toggle vim-go autocompletin setting.
Recently, I think that many users consolidate AutoComplete into LSPs.
So while using vim-go's wonderful command,
I think that there is a user who wants to leave complement from LSP plug-in.