### PR TITLE
Remove mention of vim-godebug from documentation

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -149,9 +149,6 @@ The following plugins are supported for use with vim-go:
   https://github.com/SirVer/ultisnips or
   https://github.com/joereynolds/vim-minisnip
 
-* Integration with `delve` (Neovim only):
-  https://github.com/jodosha/vim-godebug
-
 * Interactive |:GoDecls| and |:GoDeclsDir|:
   https://github.com/ctrlpvim/ctrlp.vim or
   https://github.com/junegunn/fzf.vim or


### PR DESCRIPTION
Now that vim-go has first-class support for Delve, there doesn't seem a reason to recommend another plugin to do the same thing. If there's something this plugin does that the native Delve support does, I can add mention of that to this section instead.