### PR TITLE
Add docs for using deoplete with gopls completion

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -138,8 +138,16 @@ The following plugins are supported for use with vim-go:
   https://github.com/Shougo/neocomplete.vim
 
 * Real-time completion (Neovim and Vim 8):
-  https://github.com/Shougo/deoplete.nvim and
-  https://github.com/zchee/deoplete-go
+  https://github.com/Shougo/deoplete.nvim
+
+  When using gopls for autocompletion, add the following line to your vimrc.
+  This instructs deoplete to use omni completion for Go files.
+
+    call deoplete#custom#option('omni_patterns', { 'go': '[^. *\t]\.\w*' })
+
+  When using gocode for autocompletion, install:
+
+    https://github.com/zchee/deoplete-go
 
 * Display source code navigation in a sidebar:
   https://github.com/majutsushi/tagbar

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -140,14 +140,10 @@ The following plugins are supported for use with vim-go:
 * Real-time completion (Neovim and Vim 8):
   https://github.com/Shougo/deoplete.nvim
 
-  When using gopls for autocompletion, add the following line to your vimrc.
-  This instructs deoplete to use omni completion for Go files.
+  Add the following line to your vimrc. This instructs deoplete to use omni
+  completion for Go files.
 
     call deoplete#custom#option('omni_patterns', { 'go': '[^. *\t]\.\w*' })
-
-  When using gocode for autocompletion, install:
-
-    https://github.com/zchee/deoplete-go
 
 * Display source code navigation in a sidebar:
   https://github.com/majutsushi/tagbar


### PR DESCRIPTION
This recommends configuring the "omni_patterns" parameter, which instructs deoplete to call the omnifunc when a certain regular expression is matched.

I found this solution here: https://github.com/Shougo/deoplete.nvim/issues/965
The idea of adding docs for this was discussed here: https://github.com/fatih/vim-go/issues/2185