### PR TITLE
gopls: tell gopls to return plaintext data

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -467,9 +467,7 @@ function! go#lsp#Hover(fname, line, col, handler) abort
 endfunction
 
 function! s:hoverHandler(next, msg) abort dict
-  " gopls returns a MarkupContent.
-  let l:content = substitute(a:msg.contents.value, '```go\n\(.*\)\n```', '\1', '')
-  let l:args = [l:content]
+  let l:args = [a:msg.contents.value]
   call call(a:next, l:args)
 endfunction
 

--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -11,7 +11,11 @@ function! go#lsp#message#Initialize(wd) abort
             \ 'rootUri': go#path#ToURI(a:wd),
             \ 'capabilities': {
               \ 'workspace': {},
-              \ 'textDocument': {}
+              \ 'textDocument': {
+                \ 'hover': {
+                  \ 'contentFormat': ['plaintext'],
+                \ },
+              \ }
             \ }
           \ }
        \ }


### PR DESCRIPTION
Tell gopls to return plaintext data for textDocument/hover requests.

gopls added support for this in
https://go-review.googlesource.com/c/tools/+/172601.