### PR TITLE
lsp: show info of function type correctly

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -521,8 +521,11 @@ function! s:infoDefinitionHandler(next, showstatus, msg) abort dict
 endfunction
 
 function! s:info(content) abort dict
+  let l:content = a:content[0]
   " strip off the method set and fields of structs and interfaces.
-  let l:content = substitute(a:content[0], '{.*', '', '')
+  if l:content =~# '^type [^ ]\+ \(struct\|interface\)'
+    let l:content = substitute(l:content, '{.*', '', '')
+  endif
   call go#util#ShowInfo(l:content)
 endfunction
 


### PR DESCRIPTION
Only strip the '{' onwards on type struct and interface types so that
functions that have a parameter of type interface{} and function types
don't get truncated.

Fixes #2243