### PR TITLE
completion: fix gocode processing

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -242,8 +242,7 @@ function! go#complete#GocodeComplete(findstart, base) abort
     if s =~ '[(){}\{\}]'
       return map(copy(s:completions[1]), 's:trim_bracket(v:val)')
     endif
-
-    return s:completions[1]
+    return s:completions
   endif
 endfunction
 


### PR DESCRIPTION
Fix the processing of matches from gocode. This was accidentally broken
in dac81d653dfcec98624a016dc3ba854959d7df9b when the processing of the
gocode results was changed so that the response array was trimmed to the
dictionary in the initial processing of the results.