### PR TITLE
debug: allow debugging outside GOPATH without a go.mod

### DIFF
--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -137,7 +137,9 @@ function! go#package#ImportPath() abort
 endfunction
 
 
-" FromPath returns the import path of arg.
+" go#package#FromPath returns the import path of arg. -1 is returned when arg
+" does not specify a package. -2 is returned when arg is a relative path
+" outside of GOPATH and not in a module.
 function! go#package#FromPath(arg) abort
   let l:cd = exists('*haslocaldir') && haslocaldir() ? 'lcd' : 'cd'
   let l:dir = getcwd()
@@ -156,10 +158,10 @@ function! go#package#FromPath(arg) abort
 
   let l:importpath = split(l:out, '\n')[0]
 
-  " go list returns '_CURRENTDIRECTORY' if the directory is not inside GOPATH.
-  " Check it and retun an error if that is the case
+  " go list returns '_CURRENTDIRECTORY' if the directory is neither in GOPATH
+  " nor in a module. Check it and retun an error if that is the case
   if l:importpath[0] ==# '_'
-    return -1
+    return -2
   endif
 
   return l:importpath

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2026,8 +2026,9 @@ rest of the commands and mappings become available after starting debug mode.
       * Setup the debug windows according to |'g:go_debug_windows'|.
       * Make the `:GoDebug*` commands and `(go-debug-*)` mappings available.
 
-    The current directory is used if [pkg] is empty. Any other arguments will
-    be passed to the program.
+    The directory of the current buffer is used if [pkg] is empty. Any other
+    arguments will be passed to the program. When [pkg] is relative, it will
+    be interpreted relative to the directory of the current buffer.
 
     Use |:GoDebugStop| to stop `dlv` and exit debugging mode.
 
@@ -2039,7 +2040,6 @@ rest of the commands and mappings become available after starting debug mode.
 
     Use `-test.flag` to pass flags to `go test` when debugging a test; for
     example `-test.v` or `-test.run TestFoo`
-
 
                                                              *:GoDebugRestart*
 :GoDebugRestart


### PR DESCRIPTION
Do not try to determine the package name being debugged. Delve supports
debugging and testing without specifying a package name; vim-go should,
too. One of the things that this makes easier is debugging code that is
neither in GOPATH nor in a module.

Remove unnecessary is_test key from the state dictionary.

Remove code that set the current directory when debugging tests. Because
delve is started as an async job, its cwd will be set to the directory
of the buffer from which debugging is started, anyway. Using `lcd` to
set the buffer local directory is just another thing to keep track of
and it doesn't seem to have any real benefit.

Update documentation to explain how relative paths work for `:GoDebug`
and `:GoDebugTest`.

Refactor go#package#FromPath so that it returns -2 when the package is
neither in GOPATH nor in the current module.