### PR TITLE
lsp: adjust to gopls changes

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -247,9 +247,10 @@ function! go#complete#GocodeComplete(findstart, base) abort
 endfunction
 
 function! go#complete#Complete(findstart, base) abort
-  let l:state = {'done': 0, 'matches': []}
+  let l:state = {'done': 0, 'matches': [], 'start': -1}
 
-  function! s:handler(state, matches) abort dict
+  function! s:handler(state, start, matches) abort dict
+    let a:state.start = a:start
     let a:state.matches = a:matches
     let a:state.done = 1
   endfunction
@@ -262,15 +263,16 @@ function! go#complete#Complete(findstart, base) abort
       sleep 10m
     endwhile
 
-    let s:completions = l:state.matches
-
     if len(l:state.matches) == 0
       " no matches. cancel and leave completion mode.
       call go#util#EchoInfo("no matches")
       return -3
     endif
 
-    return col('.')
+    let s:completions = l:state.matches
+
+    return l:state.start
+
   else "findstart = 0 when we need to return the list of completions
     return s:completions
   endif

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -214,8 +214,8 @@ function! s:newlsp() abort
   endfunction
 
   function! l:lsp.write(msg) dict abort
-      let l:body = json_encode(a:msg)
-      let l:data = 'Content-Length: ' . strlen(l:body) . "\r\n\r\n" . l:body
+    let l:body = json_encode(a:msg)
+    let l:data = 'Content-Length: ' . strlen(l:body) . "\r\n\r\n" . l:body
 
     if go#util#HasDebug('lsp')
       let g:go_lsp_log = add(go#config#LspLog(), "->\n" . l:data)
@@ -454,7 +454,11 @@ endfunction
 function! s:completionHandler(next, msg) abort dict
   " gopls returns a CompletionList.
   let l:matches = []
+  let l:start = -1
+
   for l:item in a:msg.items
+    let l:start = l:item.textEdit.range.start.character
+
     let l:match = {'abbr': l:item.label, 'word': l:item.textEdit.newText, 'info': '', 'kind': go#lsp#completionitemkind#Vim(l:item.kind)}
     if has_key(l:item, 'detail')
         let l:match.info = l:item.detail
@@ -469,7 +473,7 @@ function! s:completionHandler(next, msg) abort dict
 
     let l:matches = add(l:matches, l:match)
   endfor
-  let l:args = [l:matches]
+  let l:args = [l:start, l:matches]
   call call(a:next, l:args)
 endfunction
 


### PR DESCRIPTION
Adjust the handling of gopls completion responses to account for recent
changes where they refactored how completion candidates are formed. Each
candidate has a start position (often _before_ the cursor position) and
the character within the line where the matches begin. Previously, the
cursor position could be used, because candidate returned from gopls
only included the text after the cursor position.