### PR TITLE
completion: fix gocode processing

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -216,6 +216,7 @@ function! s:info_complete(echo, result) abort
 endfunction
 
 function! s:trim_bracket(val) abort
+  echom a:val
   let a:val.word = substitute(a:val.word, '[(){}\[\]]\+$', '', '')
   return a:val
 endfunction
@@ -240,7 +241,7 @@ function! go#complete#GocodeComplete(findstart, base) abort
   else
     let s = getline(".")[col('.') - 1]
     if s =~ '[(){}\{\}]'
-      return map(copy(s:completions[1]), 's:trim_bracket(v:val)')
+      return map(copy(s:completions), 's:trim_bracket(v:val)')
     endif
     return s:completions
   endif


### PR DESCRIPTION
Fix the processing of matches from gocode. This was accidentally broken
in dac81d653dfcec98624a016dc3ba854959d7df9b when the processing of the
gocode results was changed so that the response array was trimmed to the
dictionary in the initial processing of the results.

Fixes #2287