### PR TITLE
lsp: improve user experience with null modules

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -9,8 +9,8 @@ function! go#cmd#autowrite() abort
     for l:nr in range(0, bufnr('$'))
       if buflisted(l:nr) && getbufvar(l:nr, '&modified')
         " Sleep one second to make sure people see the message. Otherwise it is
-        " often immediacy overwritten by the async messages (which also don't
-        " invoke the "hit ENTER" prompt).
+        " often immediately overwritten by the async messages (which also
+        " doesn't invoke the "hit ENTER" prompt).
         call go#util#EchoWarning('[No write since last change]')
         sleep 1
         return

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -258,7 +258,10 @@ function! go#complete#Complete(findstart, base) abort
 
   "findstart = 1 when we need to get the start of the match
   if a:findstart == 1
-    call go#lsp#Completion(expand('%:p'), line('.'), col('.'), funcref('s:handler', [l:state]))
+    let l:completion = go#lsp#Completion(expand('%:p'), line('.'), col('.'), funcref('s:handler', [l:state]))
+    if l:completion
+      return -3
+    endif
 
     while !l:state.done
       sleep 10m

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -478,7 +478,7 @@ function! s:completionHandler(next, msg) abort dict
 endfunction
 
 function! s:completionErrorHandler(next, error) abort dict
-  call call(a:next, [[]])
+  call call(a:next, [-1, []])
 endfunction
 
 function! go#lsp#Hover(fname, line, col, handler) abort

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -7,7 +7,7 @@ scriptencoding utf-8
 let s:lspfactory = {}
 
 function! s:lspfactory.get() dict abort
-  if !has_key(self, 'current') || empty(self.current)
+  if !has_key(self, 'current') || empty(self.current) || !has_key(self.current, 'job') || empty(self.current.job)
     let self.current = s:newlsp()
   endif
 
@@ -23,8 +23,11 @@ endfunction
 function! s:newlsp() abort
   if !go#util#has_job()
     " TODO(bc): start the server in the background using a shell that waits for the right output before returning.
-    call go#util#EchoError('This feature requires either Vim 8.0.0087 or newer with +job or Neovim.')
-    return
+    call go#util#EchoWarning('Features that rely on gopls will not work without either Vim 8.0.0087 or newer with +job or Neovim')
+    " Sleep one second to make sure people see the message. Otherwise it is
+    " often immediately overwritten by an async message.
+    sleep 1
+    return {'sendMessage': funcref('s:noop')}
   endif
 
   " job is the job used to talk to the backing instance of gopls.

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2183,6 +2183,12 @@ Highlight the current line and breakpoints in the debugger.
 ==============================================================================
 FAQ TROUBLESHOOTING                                     *go-troubleshooting*
 
+How do I troubleshoot problems?~
+
+One of the best ways to understand what vim-go is doing and the output from
+the tools to which it delegates is to use leverage the features described in
+|'g:go_debug'|.
+
 Completion and other functions that use `gopls` don't work~
 
 Vim-go is heavily reliant on `gopls` for completion and other functionality.

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2183,6 +2183,18 @@ Highlight the current line and breakpoints in the debugger.
 ==============================================================================
 FAQ TROUBLESHOOTING                                     *go-troubleshooting*
 
+Completion and other functions that use `gopls` don't work~
+
+Vim-go is heavily reliant on `gopls` for completion and other functionality.
+`gopls` requires either module mode or GOPATH mode; files that are neither in
+GOPATH nor in a Go module will not be analyzed by `gopls`. Many of the
+features that use `gopls` (e.g. completion, jumping to definitions, showing
+identifier information, et al.) can be configured to delegate to other tools.
+e.g. completion via |'omnifunc'|, |'g:go_info_mode'| and |'g:go_def_mode'| can
+be set to use other tools for now (though some of the alternatives to `gopls`
+are effectively at their end of life and support for them from within vim-go
+may be removed soon).
+
 I get "Unknown function: go#config#..." error when I open a Go file.~
 
 This often happens to vim-polyglot users when new config options are added to


### PR DESCRIPTION
##### complete: handle lsp completion error

Call the completion handler with a start position of -1 when there is no
completion start position. The value will not be used, but is necessary
due to the expectations of the callback.

Fixes #2294

##### lsp: avoid Vim errors when gopls cannot be started

Set the sendMessage method of the lsp instance to a noop when lsp cannot
be started due to not having async jobs available so that the functions
that use `sendMessage` don't have to check whether it's available before
calling it in order to avoid Vim errors.

##### lsp: handle using gopls outside of GOPATH mode and module mode

* warn the user when trying to use gopls when in neither GOPATH mode nor
  module mode.
* do not initialize gopls when in neither GOPATH mode nor module mode.

##### completion: cancel when go#lsp#Complete returns non-zero
Cancel completion when `go#lsp#Complete` returns non-zero. This happens,
for instance, when gopls cannot be initialized due to the file being in
neither GOPATH mode nor in module mode.

##### help: add an entry to the FAQ about gopls

Add an entry to the FAQ to explain some of the limitations of gopls and
how to work around them.

##### help: add an FAQ entry about troubleshooting

Add an FAQ entry about using g:go_debug to troubleshoot problems.