### PR TITLE
lsp: always initialize in GOPATH mode

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -174,7 +174,7 @@ function! s:newlsp() abort
 
       " do not attempt to send a message to gopls when using neither GOPATH
       " mode nor module mode.
-      if go#package#FromPath(l:wd)
+      if go#package#FromPath(l:wd) == -2
         if !has_key(self, 'warned') || !self.warned
           call go#util#EchoWarning('Features that rely on gopls will not work correctly outside of GOPATH or a module.')
           let self.warned = 1


### PR DESCRIPTION
Warn the user and do not initialize gopls only when in using a null
module and in module mode.

Fixes #2301