### PR TITLE
package/FromPath: -1 if there's no code

### DIFF
--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -153,20 +153,8 @@ function! go#package#FromPath(arg) abort
   if glob("*.go") == ""
     " There's no Go code in this directory. We might be in a module directory
     " which doesn't have any code at this level.
-    let l:module = s:module()
-    if !empty(l:module)
-      let l:importpath = l:module.path
-
-      " Build up a fake import path by combining the module path and the path
-      " to the target directory (relative to the module diretory).
-      execute l:cd fnameescape(l:module.dir)
-      let l:relativepath = fnamemodify(l:path, ':.')
-      if l:relativepath != l:path
-        let l:importpath .= '/' . l:relativepath
-      endif
-      execute l:cd fnameescape(l:dir)
-
-      return l:importpath
+    if !empty(s:module())
+      return -1
     endif
   endif
   let [l:out, l:err] = go#util#Exec(['go', 'list'])

--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -144,12 +144,31 @@ function! go#package#FromPath(arg) abort
   let l:cd = exists('*haslocaldir') && haslocaldir() ? 'lcd' : 'cd'
   let l:dir = getcwd()
 
-  let l:path = a:arg
+  let l:path = fnamemodify(a:arg, ':p')
   if !isdirectory(l:path)
     let l:path = fnamemodify(l:path, ':h')
   endif
 
   execute l:cd fnameescape(l:path)
+  if glob("*.go") == ""
+    " There's no Go code in this directory. We might be in a module directory
+    " which doesn't have any code at this level.
+    let l:module = s:module()
+    if !empty(l:module)
+      let l:importpath = l:module.path
+
+      " Build up a fake import path by combining the module path and the path
+      " to the target directory (relative to the module diretory).
+      execute l:cd fnameescape(l:module.dir)
+      let l:relativepath = fnamemodify(l:path, ':.')
+      if l:relativepath != l:path
+        let l:importpath .= '/' . l:relativepath
+      endif
+      execute l:cd fnameescape(l:dir)
+
+      return l:importpath
+    endif
+  endif
   let [l:out, l:err] = go#util#Exec(['go', 'list'])
   execute l:cd fnameescape(l:dir)
   if l:err != 0


### PR DESCRIPTION
To determine the import path of a directory, vim-go currently relies on
`go list`.

With Go modules, this has a few side effects, one of which is that it
makes a number of HTTP requests if there is no code in the current
directory. For example,

    $ export GO111MODULE=on
    $ cd $GOPATH/src
    $ mkdir my.example/foo/bar/baz/qux
    $ cd my.example/foo/bar/baz/qux

    $ go mod init
    go: creating new go.mod: module my.example/foo/bar/baz/qux

    $ go list -v
    Fetching https://my.example/foo/bar/baz?go-get=1
    https fetch failed: Get https://my.example/foo/bar/baz?go-get=1: dial tcp: lookup my.example: no such host
    Fetching https://my.example/foo/bar?go-get=1
    https fetch failed: Get https://my.example/foo/bar?go-get=1: dial tcp: lookup my.example: no such host
    Fetching https://my.example/foo?go-get=1
    https fetch failed: Get https://my.example/foo?go-get=1: dial tcp: lookup my.example: no such host
    Fetching https://my.example?go-get=1
    https fetch failed: Get https://my.example?go-get=1: dial tcp: lookup my.example: no such host
    can't load package: package my.example/foo/bar/baz/qux: unknown import path "my.example/foo/bar/baz/qux": cannot find module providing package my.example/foo/bar/baz/qux

Whether this behavior is desirable is still under discussion (see
golang/go#29452), but meanwhile this is affecting the experience of
using vim-go since bfe04ba.

Specifically, if the domain (`my.example`) points to an address that
takes some time to respond, it takes quite a while for vim to be ready
upon opening a new file. For example, if the timeout is even 3 seconds,
it gets multiplied by the number of components in the import path.

To work around this, this changes FromPath to return -1 early if there is no
Go code in the current directory.