### PR TITLE
lsp: disable null module warning

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -14,6 +14,10 @@ function! go#config#VersionWarning() abort
   return get(g:, 'go_version_warning', 1)
 endfunction
 
+function! go#config#NullModuleWarning() abort
+  return get(g:, 'go_null_module_warning', 1)
+endfunction
+
 function! go#config#BuildTags() abort
   return get(g:, 'go_build_tags', '')
 endfunction

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -175,7 +175,7 @@ function! s:newlsp() abort
       " do not attempt to send a message to gopls when using neither GOPATH
       " mode nor module mode.
       if go#package#FromPath(l:wd) == -2
-        if !has_key(self, 'warned') || !self.warned
+        if go#config#NullModuleWarning() && (!has_key(self, 'warned') || !self.warned)
           call go#util#EchoWarning('Features that rely on gopls will not work correctly outside of GOPATH or a module.')
           let self.warned = 1
           " Sleep one second to make sure people see the message. Otherwise it is

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1204,6 +1204,14 @@ balloonexpr`.
 ==============================================================================
 SETTINGS                                                        *go-settings*
 
+                                                     *'g:go_version_warning'*
+
+Enable warning when using an unsupported version of Vim. By default it is
+enabled.
+>
+  let g:go_version_warning = 1
+<
+
                                               *'g:go_code_completion_enabled'*
 
 Enable code completion with |'omnifunc'|. By default it is enabled.

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1212,6 +1212,14 @@ enabled.
   let g:go_version_warning = 1
 <
 
+                                                  *'g:go_null_module_warning'*
+
+Enable warning when trying to use lsp features in a null module. By default it
+is enabled.
+>
+  let g:go_null_module_warning = 1
+<
+
                                               *'g:go_code_completion_enabled'*
 
 Enable code completion with |'omnifunc'|. By default it is enabled.


### PR DESCRIPTION
* document g:go_version_warning
* add config option to disable warning when in a null module


