### PR TITLE
lint: run golint in null module packages successfully

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -101,11 +101,10 @@ function! go#lint#Gometa(bang, autosave, ...) abort
   endif
 endfunction
 
-" Golint calls 'golint' on the current directory. Any warnings are populated in
-" the location list
+" Golint calls 'golint'.
 function! go#lint#Golint(bang, ...) abort
   if a:0 == 0
-    let [l:out, l:err] = go#util#Exec([go#config#GolintBin(), go#package#ImportPath()])
+    let [l:out, l:err] = go#util#ExecInDir([go#config#GolintBin(), '.'])
   else
     let [l:out, l:err] = go#util#Exec([go#config#GolintBin()] + a:000)
   endif


### PR DESCRIPTION
Do not try to determine the package name to give to golint, because
`go#pacakge#ImportPath` returns -1 for null modules. Just use . to
indicate the package in the current directory.

Fixes #2316