### PR TITLE
Neovim warning messages not working

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -24,9 +24,6 @@ function! s:newlsp() abort
   if !go#util#has_job()
     " TODO(bc): start the server in the background using a shell that waits for the right output before returning.
     call go#util#EchoWarning('Features that rely on gopls will not work without either Vim 8.0.0087 or newer with +job or Neovim')
-    " Sleep one second to make sure people see the message. Otherwise it is
-    " often immediately overwritten by an async message.
-    sleep 1
     return {'sendMessage': funcref('s:noop')}
   endif
 
@@ -178,9 +175,6 @@ function! s:newlsp() abort
         if go#config#NullModuleWarning() && (!has_key(self, 'warned') || !self.warned)
           call go#util#EchoWarning('Features that rely on gopls will not work correctly outside of GOPATH or a module.')
           let self.warned = 1
-          " Sleep one second to make sure people see the message. Otherwise it is
-          " often immediately overwritten by an async message.
-          sleep 1
         endif
 
         return -1


### PR DESCRIPTION
### What did you do?
I run `nvim helloworld.go` outside of a go module, and  neovim gives a 1 second delay before the buffer loads.

It looks like the delay is intentional, as its supposed to display the warning message "Features that rely on gopls will not work correctly outside of GOPATH or a module." from `autoload/go/lsp.vim`. The delay goes away when I remove the following sleep line.  The problem is the `echom` warning is not displayed in neovim, but it is displayed properly in vim. I'm new to go, so without the message I didn't realize what I was doing wrong when opening helloworld has an extra 1 second delay after installing the plugin.

### What did you expect to happen?
When opening a go file in neovim outside of a go module, warn the user of missing gopls functionality like vim, or maybe silently fail with no warning.

### What happened instead?
neovim displays a blank terminal for 1 second before loading the buffer, no message is displayed, and `:message` is empty.
### Configuration:
#### NOT working vim-go version:
bcdc25f8 (latest master)
#### WORKING vim-go version (no delay, no gopls?):
v1.20 (last stable)
#### FIRST BAD from git bisect:
bfe04ba5

#### NOT working `~/.config/nvim/init.vim`
<details><summary>init.vim</summary><br><pre>
call plug#begin('~/.local/share/nvim/plugged')
    Plug 'fatih/vim-go', {'do': 'GoUpdateBinaries'}
call plug#end()
</pre></details>

#### WORKING ~/.vimrc
I used `vim -u NORC` and `ln -s ~/.local/share/nvim/plugged/vim-go ~/.vim/pack/plugins/start/vim-go` just to be sure both editors had the same version.

#### NOT working neovim version (first three lines from `:version`):
<!-- :version -->
NVIM v0.3.5
Build type: Release
LuaJIT 2.0.5

#### WOKRING vim version (first three lines from `:version`):
<!-- :version -->
VIM - Vi IMproved 8.1 (2018 May 18, compiled Apr 26 2019 21:55:55)
Included patches: 1-1186
Compiled by Arch Linux

#### Go version (`go version`):
<!-- go version -->
go version go1.12.5 linux/amd64
#### Go environment
<details><summary><code>go env</code> Output:</summary><br><pre>
<!-- go env -->
GOARCH="amd64"
GOBIN=""
GOCACHE="/home/ronan/.cache/go-build"
GOEXE=""
GOFLAGS=""
GOHOSTARCH="amd64"
GOHOSTOS="linux"
GOOS="linux"
GOPATH="/home/ronan/.local/share/go"
GOPROXY=""
GORACE=""
GOROOT="/usr/lib/go"
GOTMPDIR=""
GOTOOLDIR="/usr/lib/go/pkg/tool/linux_amd64"
GCCGO="gccgo"
CC="gcc"
CXX="g++"
CGO_ENABLED="1"
GOMOD=""
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-g -O2"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-g -O2"
PKG_CONFIG="pkg-config"
GOGCCFLAGS="-fPIC -m64 -pthread -fmessage-length=0 -fdebug-prefix-map=/tmp/go-build492656124=/tmp/go-build -gno-record-gcc-switches"
</pre></details>

I wasn't able to figure out why the warning doesn't show. If anyone can reproduce, I think I'd be willing to try to get to the bottom of this one myself.