### PR TITLE
fix quote for g:go_null_module_warning in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ IMPROVEMENTS:
   [[GH-2289]](https://github.com/fatih/vim-go/pull/2289)
 * Improve the user experience when using null modules.
   [[GH-2300]](https://github.com/fatih/vim-go/pull/2300)
-* Add option, `g:go_null_module_warning' to silence the warning when trying to
+* Add option, `g:go_null_module_warning` to silence the warning when trying to
   use gopls with a null module.
   [[GH-2309]](https://github.com/fatih/vim-go/pull/2309)
 * Modify `:GoReportGitHubIssue` to include vim-go configuration values


### PR DESCRIPTION
This is a small fix for quotes consistency. This target line was recently added at https://github.com/fatih/vim-go/commit/aed548a. What I expect is in https://github.com/fatih/vim-go/blob/master/CHANGELOG.md `g:go_null_module_warning` is highlighted as a code block.