### PR TITLE
lint the correct package when :GoLint is called without arguments

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -101,10 +101,11 @@ function! go#lint#Gometa(bang, autosave, ...) abort
   endif
 endfunction
 
-" Golint calls 'golint'.
+" Golint calls 'golint' on the current directory. Any warnings are populated in
+" the location list
 function! go#lint#Golint(bang, ...) abort
   if a:0 == 0
-    let [l:out, l:err] = go#util#ExecInDir([go#config#GolintBin(), '.'])
+    let [l:out, l:err] = go#util#Exec([go#config#GolintBin(), go#package#ImportPath()])
   else
     let [l:out, l:err] = go#util#Exec([go#config#GolintBin()] + a:000)
   endif

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -105,7 +105,7 @@ endfunction
 " the location list
 function! go#lint#Golint(bang, ...) abort
   if a:0 == 0
-    let [l:out, l:err] = go#util#Exec([go#config#GolintBin(), go#package#ImportPath()])
+    let [l:out, l:err] = go#util#Exec([go#config#GolintBin(), expand('%:p:h')])
   else
     let [l:out, l:err] = go#util#Exec([go#config#GolintBin()] + a:000)
   endif

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -11,7 +11,7 @@ func! Test_GometaGolangciLint() abort
 endfunc
 
 func! s:gometa(metalinter) abort
-  let $GOPATH = fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint'
+  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
   silent exe 'e ' . $GOPATH . '/src/lint/lint.go'
 
   try
@@ -36,6 +36,7 @@ func! s:gometa(metalinter) abort
 
     call gotest#assert_quickfix(actual, expected)
   finally
+      call call(RestoreGOPATH, [])
       unlet g:go_metalinter_enabled
   endtry
 endfunc
@@ -49,7 +50,7 @@ func! Test_GometaWithDisabledGolangciLint() abort
 endfunc
 
 func! s:gometawithdisabled(metalinter) abort
-  let $GOPATH = fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint'
+  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
   silent exe 'e ' . $GOPATH . '/src/lint/lint.go'
 
   try
@@ -74,6 +75,7 @@ func! s:gometawithdisabled(metalinter) abort
 
     call gotest#assert_quickfix(actual, expected)
   finally
+    call call(RestoreGOPATH, [])
     unlet g:go_metalinter_disabled
   endtry
 endfunc
@@ -87,7 +89,7 @@ func! Test_GometaAutoSaveGolangciLint() abort
 endfunc
 
 func! s:gometaautosave(metalinter) abort
-  let $GOPATH = fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint'
+  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
   silent exe 'e ' . $GOPATH . '/src/lint/lint.go'
 
   try
@@ -114,12 +116,13 @@ func! s:gometaautosave(metalinter) abort
 
     call gotest#assert_quickfix(actual, expected)
   finally
+    call call(RestoreGOPATH, [])
     unlet g:go_metalinter_autosave_enabled
   endtry
 endfunc
 
 func! Test_Vet() abort
-  let $GOPATH = fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint'
+  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
   silent exe 'e ' . $GOPATH . '/src/vet/vet.go'
   compiler go
 
@@ -134,6 +137,63 @@ func! Test_Vet() abort
   call setqflist([], 'r')
 
   call go#lint#Vet(1)
+
+  let actual = getqflist()
+  let start = reltime()
+  while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+    sleep 100m
+    let actual = getqflist()
+  endwhile
+
+  call gotest#assert_quickfix(actual, expected)
+  call call(RestoreGOPATH, [])
+endfunc
+
+func! Test_Lint_GOPATH() abort
+  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
+
+  silent exe 'e ' . $GOPATH . '/src/lint/lint.go'
+  compiler go
+
+  let expected = [
+          \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported'},
+          \ {'lnum': 5, 'bufnr': 6, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
+      \ ]
+
+  let winnr = winnr()
+
+  " clear the location lists
+  call setqflist([], 'r')
+
+  call go#lint#Golint(1)
+
+  let actual = getqflist()
+  let start = reltime()
+  while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+    sleep 100m
+    let actual = getqflist()
+  endwhile
+
+  call gotest#assert_quickfix(actual, expected)
+
+  call call(RestoreGOPATH, [])
+endfunc
+
+func! Test_Lint_NullModule() abort
+  silent exe 'e ' . fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint/src/lint/lint.go'
+  compiler go
+
+  let expected = [
+          \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported'},
+          \ {'lnum': 5, 'bufnr': 6, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
+      \ ]
+
+  let winnr = winnr()
+
+  " clear the location lists
+  call setqflist([], 'r')
+
+  call go#lint#Golint(1)
 
   let actual = getqflist()
   let start = reltime()


### PR DESCRIPTION
##### lint: lint the correct package

Lint the correct package when `:GoLint` is called without arguments.

Add tests for go#lint#Golint.

Refactor autoload/go/lint_test.vim to make sure that GOPATH is unset
after each test.

Fixes #2321


