### PR TITLE
Check list length before handling the godoc result

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -619,6 +619,10 @@ function! s:info(show, content) abort dict
 endfunction
 
 function! s:infoFromHoverContent(content) abort
+  if len(a:content) < 1
+    return ''
+  endif
+
   let l:content = a:content[0]
 
   " strip godoc summary


### PR DESCRIPTION
Fix the index out of range issue when handling empty result from gopls

When using `go_info_mode='gopls'`, there's an index-out-of-range issue when handling empty result from gopls. This occurs frequently when you turned on `go_auto_type_info` and the cursor hovered on something like an imported package name.

For example, use the code above:

```
fmt.Println("test")
```

When running `:GoInfo` on the word `fmt`, vim says:

```
vim-go: [info] SUCCESS
Error detected while processing function <SNR>153_on_stdout[1]..<SNR>153_neocb[58]..286[33]..<SNR>152_hoverHandler[9]..<SNR>152_info[1]..<SNR>152_infoFromHoverContent:
line    1:
E684: list index out of range: 0
Press ENTER or type command to continue
Error detected while processing function <SNR>153_on_stdout[1]..<SNR>153_neocb[58]..286[33]..<SNR>152_hoverHandler[9]..<SNR>152_info[1]..<SNR>152_infoFromHoverContent:
line    1:
E15: Invalid expression: a:content[0]
Press ENTER or type command to continue
Error detected while processing function <SNR>153_on_stdout[1]..<SNR>153_neocb:
line   58:
E170: Missing :endwhile
Press ENTER or type command to continue
```

