### PR TITLE
fix completion of pacakge names on cmdline in null modules

### DIFF
--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -82,6 +82,10 @@ function! s:vendordirs() abort
     if l:err != 0
       return []
     endif
+    if empty(l:root)
+      return []
+    endif
+
     let l:root = split(l:root, '\n')[0] . go#util#PathSep() . 'src'
 
     let [l:dir, l:err] = go#util#ExecInDir(['go', 'list', '-f', '{{.Dir}}'])


### PR DESCRIPTION
Return early when trying to get the vendor directory for a null module
so that trying to tab complete a package name on the cmdline (e.g.
`:GoImport <TAB>` doesn't cause an error.