### PR TITLE
support vim8 popup window when run GoDoc

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -178,6 +178,9 @@ function! go#config#DocUrl() abort
   return godoc_url
 endfunction
 
+function! go#config#DocPopupWindow() abort
+  return get(g:, 'go_doc_popup_window', 0)
+endfunction
 function! go#config#DefReuseBuffer() abort
   return get(g:, 'go_def_reuse_buffer', 0)
 endfunction

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -76,6 +76,18 @@ function! go#doc#Open(newmode, mode, ...) abort
 endfunction
 
 function! s:GodocView(newposition, position, content) abort
+  " popup window
+  if go#config#DocPopupWindow() && has("patch-8.1.1513")
+    call popup_clear()
+
+    call popup_atcursor(split(a:content, '\n'), {
+          \ 'padding': [1, 1, 1, 1],
+          \ 'borderchars': ['-','|','-','|','+','+','+','+'],
+          \ "border": [1, 1, 1, 1],
+          \ })
+    return
+  endif
+
   " reuse existing buffer window if it exists otherwise create a new one
   let is_visible = bufexists(s:buf_nr) && bufwinnr(s:buf_nr) != -1
   if !bufexists(s:buf_nr)


### PR DESCRIPTION
When vim8 has patch `patch-8.1.1513` we can use popup window.
set `let go_doc_popup_window = 1` and run `:GoDoc` , document will display on the popup window

![image](https://user-images.githubusercontent.com/7888591/59166247-8b33e280-8b62-11e9-824b-ab72d137aa76.png)