### PR TITLE
lsp: redraw after each sleep

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -176,6 +176,7 @@ function! s:newlsp() abort
     " conditions initializing gopls.
     while get(self, 'checkingmodule', 0)
       sleep 50 m
+      redraw
     endwhile
 
     if !self.last_request_id


### PR DESCRIPTION
Redraw after each sleep while waiting for initialization so that the
screen doesn't get painted with control characters while the user is
navigating.