### PR TITLE
snippets: rename snippet errn->err

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -151,7 +151,7 @@ if err := ${1:condition}; err != nil {
 endsnippet
 
 # error snippet
-snippet errn "Error return " !b
+snippet err "Error return" !b
 if err != nil {
 	return err
 }


### PR DESCRIPTION
This PR renames the snippet `errn` to `err`, since `errn` is already in use for the return of two variables. It also makes sense to give the simple return of `err` the shortest snippet name `err`.