### PR TITLE
fix(golangci-lint): Run linter on the directory

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -44,7 +44,7 @@ function! go#lint#Gometa(bang, autosave, ...) abort
       endif
       let cmd += include
     elseif l:metalinter == "golangci-lint"
-      let goargs[0] = expand('%:p')
+      let goargs[0] = expand('%:p:h')
     endif
   endif
 


### PR DESCRIPTION
Fixes false positives from `unused` & `typecheck` linters.

For example:
mypackage/a.go has function `myFunc()`
mypackage/b.go use function `myFunc()`

threw a `unused` error in mypackage/a.go and a `undef` error in mypackage/b.go

This now checks the files in all directories instead of the current file/buffer