### PR TITLE
lsp: remove checks for null modules

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -14,10 +14,6 @@ function! go#config#VersionWarning() abort
   return get(g:, 'go_version_warning', 1)
 endfunction
 
-function! go#config#NullModuleWarning() abort
-  return get(g:, 'go_null_module_warning', 1)
-endfunction
-
 function! go#config#BuildTags() abort
   return get(g:, 'go_build_tags', '')
 endfunction

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1217,14 +1217,6 @@ enabled.
   let g:go_version_warning = 1
 <
 
-                                                  *'g:go_null_module_warning'*
-
-Enable warning when trying to use lsp features in a null module. By default it
-is enabled.
->
-  let g:go_null_module_warning = 1
-<
-
                                               *'g:go_code_completion_enabled'*
 
 Enable code completion with |'omnifunc'|. By default it is enabled.


### PR DESCRIPTION
Remove checks for null modules. gopls supports null modules now, so
there's no need to warn about their use or prevent gopls from starting
when in a null module directory.