### PR TITLE
lint: remove go_metalinter_disabled option and fix tests

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -271,10 +271,6 @@ function! go#config#MetalinterEnabled() abort
   return get(g:, "go_metalinter_enabled", default_enabled)
 endfunction
 
-function! go#config#MetalinterDisabled() abort
-  return get(g:, "go_metalinter_disabled", [])
-endfunction
-
 function! go#config#GolintBin() abort
   return get(g:, "go_golint_bin", "golint")
 endfunction

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -22,10 +22,6 @@ function! go#lint#Gometa(bang, autosave, ...) abort
     for linter in linters
       let cmd += ["--enable=".linter]
     endfor
-
-    for linter in go#config#MetalinterDisabled()
-      let cmd += ["--disable=".linter]
-    endfor
   else
     " the user wants something else, let us use it.
     let cmd = split(go#config#MetalinterCommand(), " ")

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -3,7 +3,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 func! Test_Gometa() abort
-  call s:gometa('gometaliner')
+  call s:gometa('gometalinter')
 endfunc
 
 func! Test_GometaGolangciLint() abort
@@ -11,14 +11,19 @@ func! Test_GometaGolangciLint() abort
 endfunc
 
 func! s:gometa(metalinter) abort
-  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
+  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnamemodify(getcwd(), ':p') . 'test-fixtures/lint')
   silent exe 'e ' . $GOPATH . '/src/lint/lint.go'
 
   try
-    let g:go_metalinter_comand = a:metalinter
+    let g:go_metalinter_command = a:metalinter
     let expected = [
           \ {'lnum': 5, 'bufnr': bufnr('%')+1, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingFooDoc should have comment or be unexported (golint)'}
         \ ]
+    if a:metalinter == 'golangci-lint'
+      let expected = [
+            \ {'lnum': 5, 'bufnr': bufnr('%')+1, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function `MissingFooDoc` should have comment or be unexported (golint)'}
+          \ ]
+    endif
 
     " clear the quickfix lists
     call setqflist([], 'r')
@@ -41,45 +46,6 @@ func! s:gometa(metalinter) abort
   endtry
 endfunc
 
-func! Test_GometaWithDisabled() abort
-  call s:gometawithdisabled('gometalinter')
-endfunc
-
-func! Test_GometaWithDisabledGolangciLint() abort
-  call s:gometawithdisabled('golangci-lint')
-endfunc
-
-func! s:gometawithdisabled(metalinter) abort
-  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
-  silent exe 'e ' . $GOPATH . '/src/lint/lint.go'
-
-  try
-    let g:go_metalinter_comand = a:metalinter
-    let expected = [
-          \ {'lnum': 5, 'bufnr': bufnr('%')+1, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingFooDoc should have comment or be unexported (golint)'}
-        \ ]
-
-    " clear the quickfix lists
-    call setqflist([], 'r')
-
-    let g:go_metalinter_disabled = ['vet']
-
-    call go#lint#Gometa(0, 0, $GOPATH . '/src/foo')
-
-    let actual = getqflist()
-    let start = reltime()
-    while len(actual) == 0 && reltimefloat(reltime(start)) < 10
-      sleep 100m
-      let actual = getqflist()
-    endwhile
-
-    call gotest#assert_quickfix(actual, expected)
-  finally
-    call call(RestoreGOPATH, [])
-    unlet g:go_metalinter_disabled
-  endtry
-endfunc
-
 func! Test_GometaAutoSave() abort
   call s:gometaautosave('gometalinter')
 endfunc
@@ -93,10 +59,15 @@ func! s:gometaautosave(metalinter) abort
   silent exe 'e ' . $GOPATH . '/src/lint/lint.go'
 
   try
-    let g:go_metalinter_comand = a:metalinter
+    let g:go_metalinter_command = a:metalinter
     let expected = [
           \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported (golint)'}
         \ ]
+    if a:metalinter == 'golangci-lint'
+      let expected = [
+            \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function `MissingDoc` should have comment or be unexported (golint)'}
+          \ ]
+    endif
 
     let winnr = winnr()
 


### PR DESCRIPTION
Fix the tests for golangci-lint by:
* spelling g:go_metalinter_command correctly
* modifying the expectations for golangci-lint now that the tests
  actually run it.

Remove g:go_metalinter_disabled option. Given that both golangci-lint
and gometalinter have all linters disabled using `--disable-all` and
then only the linters in g:go_metalinter_enabled run,
g:go_metalinter_disabled is extraneous. golangci-lint prevents the use
of both `--disable-all` and `--disable`, too.