### PR TITLE
metalinter: filter autosave results manually

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -84,7 +84,13 @@ function! go#lint#Gometa(bang, autosave, ...) abort
   else
     let l:winid = win_getid(winnr())
     " Parse and populate our location list
-    call go#list#ParseFormat(l:listtype, errformat, split(out, "\n"), 'GoMetaLinter')
+
+    let l:messages = split(out, "\n")
+
+    if a:autosave
+      call s:metalinterautosavecomplete(fnamemodify(expand('%:p'), ":."), 0, 1, l:messages)
+    endif
+    call go#list#ParseFormat(l:listtype, errformat, l:messages, 'GoMetaLinter')
 
     let errors = go#list#Get(l:listtype)
     call go#list#Window(l:listtype, len(errors))
@@ -226,6 +232,7 @@ function! s:lint_job(args, bang, autosave)
 
   if a:autosave
     let l:opts.for = "GoMetaLinterAutoSave"
+    let l:opts.complete = funcref('s:metalinterautosavecomplete', [expand('%:p:t')])
   endif
 
   " autowrite is not enabled for jobs
@@ -273,6 +280,21 @@ function! s:golangcilintcmd(bin_path)
   let cmd += ["--exclude-use-default=false"]
 
   return cmd
+endfunction
+
+function! s:metalinterautosavecomplete(filepath, job, exit_code, messages)
+  if len(a:messages) == 0
+    return
+  endif
+
+  let l:file = expand('%:p:t')
+  let l:idx = len(a:messages) - 1
+  while l:idx >= 0
+    if a:messages[l:idx] !~# '^' . a:filepath . ':'
+      call remove(a:messages, l:idx)
+    endif
+    let l:idx -= 1
+  endwhile
 endfunction
 
 " restore Vi compatibility settings


### PR DESCRIPTION
Filter results of running the metalinter manually in preparation for
merging #2367, so that merging #2367 won't suddenly start reporting
results for all files in a package when the metalinter is golangci-lint
since golangci-lint does not have a way to filter its results to include
only the results for a single file.