### PR TITLE
lsp: handle changes to function and method completions

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -522,7 +522,17 @@ function! s:completionHandler(next, msg) abort dict
     if has_key(l:item, 'detail')
         let l:match.info = l:item.detail
         if go#lsp#completionitemkind#IsFunction(l:item.kind) || go#lsp#completionitemkind#IsMethod(l:item.kind)
-          let l:match.info = printf('func %s %s', l:item.label, l:item.detail)
+          let l:match.info = printf('%s %s', l:item.label, l:item.detail)
+
+          " The detail provided by gopls hasn't always provided the the full
+          " signature including the return value. The label used to be the
+          " function signature and the detail was the return value. Handle
+          " that case for backward compatibility. This can be removed in the
+          " future once it's likely that the majority of users are on a recent
+          " version of gopls.
+          if l:item.detail !~ '^func'
+            let l:match.info = printf('func %s %s', l:item.label, l:item.detail)
+          endif
         endif
     endif
 


### PR DESCRIPTION
gopls is changing the values in the label and details of completions so
that the label is the name of the function or method and the detail is
the full signature w/ return value. Handle both the new way and the old
way for backward compatibility until golang.org/x/tools/gopls@latest
serves the new way and users have had a reasonable time to update.