### PR TITLE
lsp: calculate character position correctly

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -263,7 +263,8 @@ function! go#complete#Complete(findstart, base) abort
 
   "findstart = 1 when we need to get the start of the match
   if a:findstart == 1
-    let l:completion = go#lsp#Completion(expand('%:p'), line('.'), col('.'), funcref('s:handler', [l:state]))
+    let [l:line, l:col] = go#lsp#lsp#Position()
+    let l:completion = go#lsp#Completion(expand('%:p'), l:line, l:col, funcref('s:handler', [l:state]))
     if l:completion
       return -3
     endif

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -6,7 +6,7 @@ let s:go_stack = []
 let s:go_stack_level = 0
 
 function! go#def#Jump(mode, type) abort
-  let fname = fnamemodify(expand("%"), ':p:gs?\\?/?')
+  let l:fname = fnamemodify(expand("%"), ':p:gs?\\?/?')
 
   " so guru right now is slow for some people. previously we were using
   " godef which also has it's own quirks. But this issue come up so many
@@ -66,7 +66,7 @@ function! go#def#Jump(mode, type) abort
       let [l:out, l:err] = go#util#ExecInDir(l:cmd)
     endif
   elseif bin_name == 'gopls'
-    let [l:line, l:col] = getpos('.')[1:2]
+    let [l:line, l:col] = go#lsp#lsp#Position()
     " delegate to gopls, with an empty job object and an exit status of 0
     " (they're irrelevant for gopls).
     if a:type

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -520,7 +520,7 @@ function! s:completionHandler(next, msg) abort dict
 
     let l:match = {'abbr': l:item.label, 'word': l:item.textEdit.newText, 'info': '', 'kind': go#lsp#completionitemkind#Vim(l:item.kind)}
     if has_key(l:item, 'detail')
-        let l:match.info = l:item.detail
+        let l:match.menu = l:item.detail
         if go#lsp#completionitemkind#IsFunction(l:item.kind) || go#lsp#completionitemkind#IsMethod(l:item.kind)
           let l:match.info = printf('%s %s', l:item.label, l:item.detail)
 
@@ -575,7 +575,7 @@ endfunction
 
 function! go#lsp#Info(showstatus)
   let l:fname = expand('%:p')
-  let [l:line, l:col] = getpos('.')[1:2]
+  let [l:line, l:col] = go#lsp#lsp#Position()
 
   call go#lsp#DidChange(l:fname)
 
@@ -595,7 +595,7 @@ endfunction
 
 function! go#lsp#GetInfo()
   let l:fname = expand('%:p')
-  let [l:line, l:col] = getpos('.')[1:2]
+  let [l:line, l:col] = go#lsp#lsp#Position()
 
   call go#lsp#DidChange(l:fname)
 
@@ -617,8 +617,8 @@ function! s:infoDefinitionHandler(next, showstatus, msg) abort dict
   let l:msg = a:msg[0]
 
   let l:fname = go#path#FromURI(l:msg.uri)
-  let l:line = l:msg.range.start.line+1
-  let l:col = l:msg.range.start.character+1
+  let l:line = l:msg.range.start.line
+  let l:col = l:msg.range.start.character
 
   let l:lsp = s:lspfactory.get()
   let l:msg = go#lsp#message#Hover(l:fname, l:line, l:col)

--- a/autoload/go/lsp/lsp.vim
+++ b/autoload/go/lsp/lsp.vim
@@ -1,0 +1,43 @@
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+" go#lsp#lsp#Position returns the LSP text position. If no arguments are
+" provided, the cursor position is assumed. Otherwise, there should be two
+" arguments: the line and the column.
+function! go#lsp#lsp#Position(...)
+  if a:0 < 2
+    let [l:line, l:col] = getpos('.')[1:2]
+  else
+    let l:line = a:1
+    let l:col = a:2
+  endif
+	let l:content = getline(l:line)
+
+  " LSP uses 0-based lines.
+  let l:line -= 1
+
+  let l:offset = l:col - 1
+
+  let l:cmd = [go#path#CheckBinPath('lsp-position'), '-offset', l:offset]
+  let [l:out, l:exit]= go#util#Exec(l:cmd, l:content)
+
+  if l:exit != 0
+    call go#util#EchoWarn(l:out)
+    " assume that the line and column calculated directly from the cursor
+    " position is correct, because in the vast majority of cases the column
+    " will be the number of utf-16 code units to the column, too.
+    " than one utf-16 code unit
+    return [l:line, l:col]
+  endif
+
+  let l:col = str2nr(split(l:out)[0])
+
+  return [l:line, l:col]
+endfunction
+
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -146,7 +146,7 @@ function s:workspaceFolderToAddURI(key, val) abort
 endfunction
 
 function! s:position(line, col) abort
-  return {'line': a:line - 1, 'character': a:col-1}
+  return {'line': a:line, 'character': a:col}
 endfunction
 
 " restore Vi compatibility settings

--- a/autoload/go/lsp_test.vim
+++ b/autoload/go/lsp_test.vim
@@ -1,0 +1,49 @@
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+scriptencoding utf-8
+
+func! Test_GetSimpleTextPosition()
+    call s:getinfo('lsp text position should align with cursor position after ascii only')
+endfunction
+
+func! Test_GetMultiByteTextPosition()
+    call s:getinfo('lsp text position should align with cursor position after two place of interest symbols ⌘⌘')
+endfunction
+
+func! Test_GetMultipleCodeUnitTextPosition()
+    call s:getinfo('lsp text position should align with cursor position after Deseret Capital Letter Long I 𐐀')
+endfunction
+
+func! s:getinfo(str)
+  if !go#util#has_job()
+    return
+  endif
+
+  try
+    let g:go_info_mode = 'gopls'
+
+    let l:tmp = gotest#write_file('position/position.go', [
+          \ 'package position',
+          \ '',
+          \ 'func Example() {',
+          \ "\tid := " . '"foo"',
+          \ "\tprintln(" .'"' . a:str . '", id)',
+          \ '}',
+          \ ] )
+
+    let l:expected = 'var id string'
+    let l:actual = go#lsp#GetInfo()
+    call assert_equal(l:expected, l:actual)
+  finally
+    "call delete(l:tmp, 'rf')
+    unlet g:go_info_mode
+  endtry
+endfunction
+
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -115,7 +115,15 @@ endfunction
 
 function! go#tool#DescribeBalloon()
   let l:fname = fnamemodify(bufname(v:beval_bufnr), ':p')
-  call go#lsp#Hover(l:fname, v:beval_lnum, v:beval_col, funcref('s:balloon', []))
+
+  let l:winid = win_getid()
+
+  call win_gotoid(bufwinid(v:beval_bufnr))
+
+  let [l:line, l:col] = go#lsp#lsp#Position(v:beval_lnum, v:beval_col)
+  call go#lsp#Hover(l:fname, l:line, l:col, funcref('s:balloon', []))
+
+  call win_gotoid(l:winid)
   return ''
 endfunction
 

--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -24,9 +24,10 @@ fun! gotest#write_file(path, contents) abort
   " Set cursor.
   let l:lnum = 1
   for l:line in a:contents
-    let l:m = match(l:line, "\x1f")
+    let l:m = stridx(l:line, "\x1f")
     if l:m > -1
-      call setpos('.', [0, l:lnum, l:m, 0])
+      let l:byte = line2byte(l:lnum) + l:m
+      exe 'goto '. l:byte
       call setline('.', substitute(getline('.'), "\x1f", '', ''))
       break
     endif

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -67,6 +67,7 @@ let s:packages = {
       \ 'keyify':        ['honnef.co/go/tools/cmd/keyify'],
       \ 'motion':        ['github.com/fatih/motion'],
       \ 'iferr':         ['github.com/koron/iferr'],
+      \ 'lsp-position':  ['github.com/bhcleek/lsp-position/cmd/lsp-position'],
 \ }
 
 " These commands are available on any filetypes


### PR DESCRIPTION
Calculate the character position correctly. This was mostly working, but
could fail in cases where the correct character position was after a
multi-byte character on a line.