### PR TITLE
lsp: calculate LSP positions using VimL

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -195,13 +195,6 @@ function! s:newlsp() abort
   endfunction
 
   function! l:lsp.sendMessage(data, handler) dict abort
-    " block while waiting on any in flight initializations to avoid race
-    " conditions initializing gopls.
-    while get(self, 'checkingmodule', 0)
-      sleep 50 m
-      redraw
-    endwhile
-
     if !self.last_request_id
       call go#util#EchoProgress("initializing gopls")
       " TODO(bc): run a server per module and one per GOPATH? (may need to

--- a/autoload/go/lsp/lsp.vim
+++ b/autoload/go/lsp/lsp.vim
@@ -12,28 +12,19 @@ function! go#lsp#lsp#Position(...)
     let l:line = a:1
     let l:col = a:2
   endif
-	let l:content = getline(l:line)
+  let l:content = getline(l:line)
 
   " LSP uses 0-based lines.
-  let l:line -= 1
+  return [l:line - 1, s:character(l:line, l:col)]
+endfunction
 
-  let l:offset = l:col - 1
+function! s:strlen(str) abort
+  let l:runes = split(a:str, '\zs')
+  return len(l:runes) + len(filter(l:runes, 'char2nr(v:val)>=0x10000'))
+endfunction
 
-  let l:cmd = [go#path#CheckBinPath('lsp-position'), '-offset', l:offset]
-  let [l:out, l:exit]= go#util#Exec(l:cmd, l:content)
-
-  if l:exit != 0
-    call go#util#EchoWarn(l:out)
-    " assume that the line and column calculated directly from the cursor
-    " position is correct, because in the vast majority of cases the column
-    " will be the number of utf-16 code units to the column, too.
-    " than one utf-16 code unit
-    return [l:line, l:col]
-  endif
-
-  let l:col = str2nr(split(l:out)[0])
-
-  return [l:line, l:col]
+function! s:character(line, col) abort
+  return s:strlen(getline(a:line)[:col([a:line, a:col - 1])])
 endfunction
 
 " restore Vi compatibility settings

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -67,7 +67,6 @@ let s:packages = {
       \ 'keyify':        ['honnef.co/go/tools/cmd/keyify'],
       \ 'motion':        ['github.com/fatih/motion'],
       \ 'iferr':         ['github.com/koron/iferr'],
-      \ 'lsp-position':  ['github.com/bhcleek/lsp-position/cmd/lsp-position'],
 \ }
 
 " These commands are available on any filetypes


### PR DESCRIPTION
* calculate LSP character position using VimL instead of relying on a
  separate binary.
* remove unnecessary check for checkingmodule property, which was
  completely removed when gopls started supporting null modules.