### PR TITLE
lsp: convert LSP text position to vim column correctly

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -281,7 +281,7 @@ function! go#complete#Complete(findstart, base) abort
 
     let s:completions = l:state.matches
 
-    return l:state.start
+    return go#lsp#lsp#PositionOf(getline(l:line+1), l:state.start)
 
   else "findstart = 0 when we need to return the list of completions
     return s:completions

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -402,7 +402,7 @@ endfunction
 function! s:definitionHandler(next, msg) abort dict
   " gopls returns a []Location; just take the first one.
   let l:msg = a:msg[0]
-  let l:args = [[printf('%s:%d:%d: %s', go#path#FromURI(l:msg.uri), l:msg.range.start.line+1, l:msg.range.start.character+1, 'lsp does not supply a description')]]
+  let l:args = [[printf('%s:%d:%d: %s', go#path#FromURI(l:msg.uri), l:msg.range.start.line+1, go#lsp#lsp#PositionOf(getline(l:msg.range.start.line+1), l:msg.range.start.character), 'lsp does not supply a description')]]
   call call(a:next, l:args)
 endfunction
 
@@ -424,7 +424,7 @@ endfunction
 function! s:typeDefinitionHandler(next, msg) abort dict
   " gopls returns a []Location; just take the first one.
   let l:msg = a:msg[0]
-  let l:args = [[printf('%s:%d:%d: %s', go#path#FromURI(l:msg.uri), l:msg.range.start.line+1, l:msg.range.start.character+1, 'lsp does not supply a description')]]
+  let l:args = [[printf('%s:%d:%d: %s', go#path#FromURI(l:msg.uri), l:msg.range.start.line+1, go#lsp#lsp#PositionOf(getline(l:msg.range.start.line+1), l:msg.range.start.character), 'lsp does not supply a description')]]
   call call(a:next, l:args)
 endfunction
 

--- a/autoload/go/lsp/lsp.vim
+++ b/autoload/go/lsp/lsp.vim
@@ -27,6 +27,30 @@ function! s:character(line, col) abort
   return s:strlen(getline(a:line)[:col([a:line, a:col - 1])])
 endfunction
 
+" go#lsp#PositionOf returns len(content[0:units]) where units is utf-16 code
+" units. This is mostly useful for converting LSP text position to vim
+" position.
+function! go#lsp#lsp#PositionOf(content, units) abort
+  if a:units == 0
+    return 1
+  endif
+
+  let l:remaining = a:units
+  let l:str = ""
+  for l:rune in split(a:content, '\zs')
+    if l:remaining < 0
+      break
+    endif
+    let l:remaining -= 1
+    if char2nr(l:rune) >= 0x10000
+      let l:remaining -= 1
+    endif
+    let l:str = l:str . l:rune
+  endfor
+
+  return len(l:str)
+endfunction
+
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/autoload/go/lsp/lsp_test.vim
+++ b/autoload/go/lsp/lsp_test.vim
@@ -1,0 +1,32 @@
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+scriptencoding utf-8
+
+function! Test_PositionOf_Simple()
+  let l:actual = go#lsp#lsp#PositionOf("just ascii", 3)
+  call assert_equal(4, l:actual)
+endfunc
+
+
+function! Test_PositionOf_MultiByte()
+  " ⌘ is U+2318, which encodes to three bytes in utf-8 and 1 code unit in
+  " utf-16.
+  let l:actual = go#lsp#lsp#PositionOf("⌘⌘ foo", 3)
+  call assert_equal(8, l:actual)
+endfunc
+
+function! Test_PositionOf_MultipleCodeUnit()
+    " 𐐀 is U+10400, which encodes to 4 bytes in utf-8 and 2 code units in
+    " utf-16.
+    let l:actual = go#lsp#lsp#PositionOf("𐐀 bar", 3)
+    call assert_equal(6, l:actual)
+endfunction
+
+
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/lsp_test.vim
+++ b/autoload/go/lsp_test.vim
@@ -4,19 +4,19 @@ set cpo&vim
 
 scriptencoding utf-8
 
-func! Test_GetSimpleTextPosition()
+function! Test_GetSimpleTextPosition()
     call s:getinfo('lsp text position should align with cursor position after ascii only')
 endfunction
 
-func! Test_GetMultiByteTextPosition()
+function! Test_GetMultiByteTextPosition()
     call s:getinfo('lsp text position should align with cursor position after two place of interest symbols ⌘⌘')
 endfunction
 
-func! Test_GetMultipleCodeUnitTextPosition()
+function! Test_GetMultipleCodeUnitTextPosition()
     call s:getinfo('lsp text position should align with cursor position after Deseret Capital Letter Long I 𐐀')
 endfunction
 
-func! s:getinfo(str)
+function! s:getinfo(str)
   if !go#util#has_job()
     return
   endif


### PR DESCRIPTION
Convert LSP text positions to the Vim column correctly even when the
dealing with runes that span more than one utf-16 code unit and runes
that are encoded as more than one byte in utf-8.