### PR TITLE
add a feature to generate return statement

### DIFF
--- a/autoload/go/return.vim
+++ b/autoload/go/return.vim
@@ -1,0 +1,26 @@
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+function! go#return#Generate()
+  let [l:out, l:err] = go#util#Exec(['goreturn',
+        \ '-pos=' . go#util#OffsetCursor()], go#util#GetLines())
+  if len(l:out) == 1
+    return
+  endif
+  if getline('.') =~ '^\s*$'
+    silent delete _
+    silent normal! k
+  endif
+  let l:pos = getcurpos()
+  call append(l:pos[1], split(l:out, "\n"))
+  silent normal! j=2j
+  call setpos('.', l:pos)
+  silent normal! 4j
+endfunction
+
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -899,6 +899,25 @@ CTRL-t
           }
       }
 <
+
+                                                                    *:GoReturn
+:GoReturn
+
+    Generate return statement automatically which infer the type of return
+    values and the numbers.
+
+    For example:
+>
+      func doSomething() (string, error) {
+      }
+<
+    Becomes:
+>
+      func doSomething() (string, error) {
+          return "", nil
+      }
+
+<
                                                                   *:GoModFmt*
 :GoModFmt
 
@@ -1127,6 +1146,10 @@ Calls `:GoImport` for the current package
 
 Generate if err != nil { return ... } automatically which infer the type of
 return values and the numbers.
+                                                                 *(go-return)*
+
+Generate return statement automatically which infer the type of return
+values and the numbers.
 
                                                                 *(go-mod-fmt)*
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -116,6 +116,9 @@ command! -nargs=0 GoReportGitHubIssue call go#issue#New()
 " -- iferr
 command! -nargs=0 GoIfErr call go#iferr#Generate()
 
+" -- goreturn
+command! -nargs=0 GoReturn call go#return#Generate()
+
 " -- lsp
 command! -nargs=+ -complete=dir GoAddWorkspace call go#lsp#AddWorkspace(<f-args>)
 

--- a/ftplugin/go/mappings.vim
+++ b/ftplugin/go/mappings.vim
@@ -83,4 +83,6 @@ nnoremap <silent> <Plug>(go-alternate-split) :<C-u>call go#alternate#Switch(0, "
 
 nnoremap <silent> <Plug>(go-iferr) :<C-u>call go#iferr#Generate()<CR>
 
+nnoremap <silent> <Plug>(go-return) :<C-u>call go#return#Generate()<CR>
+
 " vim: sw=2 ts=2 et

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -67,6 +67,7 @@ let s:packages = {
       \ 'keyify':        ['honnef.co/go/tools/cmd/keyify'],
       \ 'motion':        ['github.com/fatih/motion'],
       \ 'iferr':         ['github.com/koron/iferr'],
+      \ 'goreturn':      ['github.com/110y/goreturn'],
 \ }
 
 " These commands are available on any filetypes


### PR DESCRIPTION
Add a new command `GoReturn` which generates `return` statement with zero values for current function. 
The command uses [goreturn](https://github.com/110y/goreturn) which was also created by me based on [iferr](https://github.com/koron/iferr).

### e.g.

```go
func doSomething() (string, error) {
}
```

becomes:

```go
func doSomething() (string, error) {
    return "", nil
}
```