### PR TITLE
change to appropriate dir before quickfix parse

### DIFF
--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -96,6 +96,12 @@ function! s:on_stdout(job_id, data, event) dict abort
 endfunction
 
 function! s:on_exit(job_id, exit_status, event) dict abort
+  " change to directory where test were run. if we do not do this
+  " and the commands are ran from root of the codebase the quickfix location will be wrong
+  let l:cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
+  let l:dir = getcwd()
+  execute l:cd . fnameescape(expand("%:p:h"))
+
   let l:winid = win_getid(winnr())
   call win_gotoid(self.winid)
   let l:listtype = go#list#Type("_term")
@@ -140,6 +146,9 @@ function! s:on_exit(job_id, exit_status, event) dict abort
 
   call win_gotoid(self.winid)
   call go#list#JumpToFirst(l:listtype)
+
+  " change back to original working directory before this method start
+  execute l:cd l:dir
 endfunction
 
 " restore Vi compatibility settings

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -97,7 +97,8 @@ endfunction
 
 function! s:on_exit(job_id, exit_status, event) dict abort
   " change to directory where test were run. if we do not do this
-  " and the commands are ran from root of the codebase the quickfix location will be wrong
+  " the quickfix items will have the incorrect paths. 
+  " see: https://github.com/fatih/vim-go/issues/2400
   let l:cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
   let l:dir = getcwd()
   execute l:cd . fnameescape(expand("%:p:h"))
@@ -147,7 +148,7 @@ function! s:on_exit(job_id, exit_status, event) dict abort
   call win_gotoid(self.winid)
   call go#list#JumpToFirst(l:listtype)
 
-  " change back to original working directory before this method start
+  " change back to original working directory 
   execute l:cd l:dir
 endfunction
 


### PR DESCRIPTION
Fixes: https://github.com/fatih/vim-go/issues/2400

We now CD into the same directory builds and test are ran before populating the QuickFix or LocationList items. This fixes a problem where the hyperlinked path in the quickfix menu pointed to "./file_name" and your vim current directory is not in "./" 