### PR TITLE
fix off by one error in text placement

### DIFF
--- a/autoload/go/lsp/lsp.vim
+++ b/autoload/go/lsp/lsp.vim
@@ -38,7 +38,7 @@ function! go#lsp#lsp#PositionOf(content, units) abort
   let l:remaining = a:units
   let l:str = ""
   for l:rune in split(a:content, '\zs')
-    if l:remaining < 0
+    if l:remaining <= 0
       break
     endif
     let l:remaining -= 1

--- a/autoload/go/lsp/lsp_test.vim
+++ b/autoload/go/lsp/lsp_test.vim
@@ -6,7 +6,7 @@ scriptencoding utf-8
 
 function! Test_PositionOf_Simple()
   let l:actual = go#lsp#lsp#PositionOf("just ascii", 3)
-  call assert_equal(4, l:actual)
+  call assert_equal(3, l:actual)
 endfunc
 
 
@@ -14,14 +14,14 @@ function! Test_PositionOf_MultiByte()
   " ⌘ is U+2318, which encodes to three bytes in utf-8 and 1 code unit in
   " utf-16.
   let l:actual = go#lsp#lsp#PositionOf("⌘⌘ foo", 3)
-  call assert_equal(8, l:actual)
+  call assert_equal(7, l:actual)
 endfunc
 
 function! Test_PositionOf_MultipleCodeUnit()
     " 𐐀 is U+10400, which encodes to 4 bytes in utf-8 and 2 code units in
     " utf-16.
     let l:actual = go#lsp#lsp#PositionOf("𐐀 bar", 3)
-    call assert_equal(6, l:actual)
+    call assert_equal(5, l:actual)
 endfunction
 
 


### PR DESCRIPTION
This fixes issue where autocomplete would not replace the first character after a "."

For example when attempting to auto complete `assert.Equals`
```
assert.E<auto complete>
```
You'd wind up with:
```
assert.EEqual
```

Looks like this was an 0 index issue. 