### PR TITLE
lsp: fix off by one in go#complete#Complete

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -281,7 +281,7 @@ function! go#complete#Complete(findstart, base) abort
 
     let s:completions = l:state.matches
 
-    return go#lsp#lsp#PositionOf(getline(l:line+1), l:state.start)
+    return go#lsp#lsp#PositionOf(getline(l:line+1), l:state.start-1)
 
   else "findstart = 0 when we need to return the list of completions
     return s:completions


### PR DESCRIPTION
Now that go#complete#Complete handles LSP's expression of the position
as utf-16 code units, return the start position correctly. The start
position provided by LSP is the index of the first code unit that starts
the completion text, while Vim expect to be provided with the number of
leading columns before the start of the text to be replaced with the
completion item. Therefore, go#lsp#lsp#PositionOf is given the LSP start
position - 1 code unit so that all the characters prior to the start of
the completion text will left in place by Vim.

Fixes #2403