### PR TITLE
completion: fix off by one error in request

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -263,7 +263,8 @@ function! go#complete#Complete(findstart, base) abort
 
   "findstart = 1 when we need to get the start of the match
   if a:findstart == 1
-    let [l:line, l:col] = go#lsp#lsp#Position()
+    let [l:line, l:col] = getpos('.')[1:2]
+    let [l:line, l:col] = go#lsp#lsp#Position(l:line, l:col-1)
     let l:completion = go#lsp#Completion(expand('%:p'), l:line, l:col, funcref('s:handler', [l:state]))
     if l:completion
       return -3


### PR DESCRIPTION
The start position in a completion request should be the last code point
of the character just before the cursor position, because in insertion
mode, the cursor position includes the character immediately following
the cusor, which should _not_ be included in the match.

Fixes #2405