### PR TITLE
toggle whether term closes

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -47,19 +47,12 @@ function! go#config#TermMode() abort
   return get(g:, 'go_term_mode', 'vsplit')
 endfunction
 
-function! go#config#TermExit() abort
-  return get(g:, 'go_term_exit', 1)
+function! go#config#TermCloseOnExit() abort
+  return get(g:, 'go_term_close_on_exit', 1)
 endfunction
 
-function! go#config#ToggleTermExit() abort 
-  let l:cur = get(g:, 'go_term_exit', 0)
-  if l:cur == 0
-    silent! unlet g:go_term_exit
-    let g:go_term_exit = 1
-  else 
-    silent! unlet g:go_term_exit
-    let g:go_term_exit = 0
-  endif
+function! go#config#SetTermCloseOnExit(value) abort
+  let g:go_term_close_on_exit = a:value
 endfunction
 
 function! go#config#TermEnabled() abort

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -47,6 +47,21 @@ function! go#config#TermMode() abort
   return get(g:, 'go_term_mode', 'vsplit')
 endfunction
 
+function! go#config#TermExit() abort
+  return get(g:, 'go_term_exit', 1)
+endfunction
+
+function! go#config#ToggleTermExit() abort 
+  let l:cur = get(g:, 'go_term_exit', 0)
+  if l:cur == 0
+    silent! unlet g:go_term_exit
+    let g:go_term_exit = 1
+  else 
+    silent! unlet g:go_term_exit
+    let g:go_term_exit = 0
+  endif
+endfunction
+
 function! go#config#TermEnabled() abort
   return has('nvim') && get(g:, 'go_term_enabled', 0)
 endfunction

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -137,8 +137,10 @@ function! s:on_exit(job_id, exit_status, event) dict abort
   endif
 
   " close terminal; we don't need it anymore
-  call win_gotoid(self.termwinid)
-  close!
+  if go#config#TermExit() ==  1
+    call win_gotoid(self.termwinid)
+    close!
+  endif
 
   if self.bang
     call win_gotoid(l:winid)

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -137,7 +137,7 @@ function! s:on_exit(job_id, exit_status, event) dict abort
   endif
 
   " close terminal; we don't need it anymore
-  if go#config#TermExit() ==  1
+  if go#config#TermCloseOnExit()
     call win_gotoid(self.termwinid)
     close!
   endif
@@ -152,6 +152,18 @@ function! s:on_exit(job_id, exit_status, event) dict abort
 
   " change back to original working directory 
   execute l:cd l:dir
+endfunction
+
+function! go#term#ToggleCloseOnExit() abort
+  if go#config#TermCloseOnExit()
+    call go#config#SetTermCloseOnExit(0)
+    call go#util#EchoProgress("term close on exit disabled")
+    return
+  endif
+
+  call go#config#SetTermCloseOnExit(1)
+  call go#util#EchoProgress("term close on exit enabled")
+  return
 endfunction
 
 " restore Vi compatibility settings

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1636,6 +1636,13 @@ just like `:GoBuild`. By default it is disabled.
 >
   let g:go_term_enabled = 0
 <
+                                                   *'g:go_term_close_on_exit'*
+
+This option is Neovim only. If set to 1 it closes the terminal after the
+command run in it exits. By default it is enabled.
+>
+  let g:go_term_close_on_exit = 1
+<
                                                        *'g:go_alternate_mode'*
 
 Specifies the command that |:GoAlternate| uses to open the alternate file.

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -119,4 +119,7 @@ command! -nargs=0 GoIfErr call go#iferr#Generate()
 " -- lsp
 command! -nargs=+ -complete=dir GoAddWorkspace call go#lsp#AddWorkspace(<f-args>)
 
+" -- term
+command! GoToggleTermExit call go#config#ToggleTermExit()
+
 " vim: sw=2 ts=2 et

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -120,6 +120,6 @@ command! -nargs=0 GoIfErr call go#iferr#Generate()
 command! -nargs=+ -complete=dir GoAddWorkspace call go#lsp#AddWorkspace(<f-args>)
 
 " -- term
-command! GoToggleTermExit call go#config#ToggleTermExit()
+command! GoToggleTermCloseOnExit call go#term#ToggleCloseOnExit()
 
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
This PR introduces a way to quickly toggle whether the nvim terminal is closed after a quickfix menu is populated. 

I found this helpful when needing to add `log.Printf()` statements in my tests as the term formatter function does not capture stdout. 

I am open to discussion here. 