### PR TITLE
Check function exists

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -93,7 +93,7 @@ function! go#util#env(key) abort
     return s:env_cache[l:key]
   endif
 
-  if executable('go')
+  if executable('go') && exists('*go#util#'.l:key)
     let l:var = call('go#util#'.l:key, [])
     if go#util#ShellError() != 0
       call go#util#EchoError(printf("'go env %s' failed", toupper(l:key)))


### PR DESCRIPTION
```
:let $XXX = 1
:echo go#util#env("XXX")
```
Does not work since does not check function `go#util#xxx` exists.