### PR TITLE
lsp: add tests, especially to validate multi-code unit position handling

### DIFF
--- a/autoload/go/def_test.vim
+++ b/autoload/go/def_test.vim
@@ -5,16 +5,16 @@ set cpo&vim
 func! Test_jump_to_declaration_guru() abort
   try
     let l:filename = 'def/jump.go'
-    let lnum = 5
-    let col = 6
+    let l:lnum = 5
+    let l:col = 6
     let l:tmp = gotest#load_fixture(l:filename)
 
-    let guru_out = printf("%s:%d:%d: defined here as func main", filename, lnum, col)
-    call go#def#jump_to_declaration(guru_out, "", 'guru')
+    let l:guru_out = printf("%s:%d:%d: defined here as func main", l:filename, l:lnum, l:col)
+    call go#def#jump_to_declaration(l:guru_out, "", 'guru')
 
-    call assert_equal(filename, bufname("%"))
-    call assert_equal(lnum, getcurpos()[1])
-    call assert_equal(col, getcurpos()[2])
+    call assert_equal(l:filename, bufname("%"))
+    call assert_equal(l:lnum, getcurpos()[1])
+    call assert_equal(l:col, getcurpos()[2])
   finally
     call delete(l:tmp, 'rf')
   endtry
@@ -22,17 +22,17 @@ endfunc
 
 func! Test_jump_to_declaration_godef() abort
   try
-    let filename = 'def/jump.go'
-    let lnum = 5
-    let col = 6
+    let l:filename = 'def/jump.go'
+    let l:lnum = 5
+    let l:col = 6
     let l:tmp = gotest#load_fixture(l:filename)
 
-    let godef_out = printf("%s:%d:%d\ndefined here as func main", filename, lnum, col)
+    let l:godef_out = printf("%s:%d:%d\ndefined here as func main", l:filename, l:lnum, l:col)
     call go#def#jump_to_declaration(godef_out, "", 'godef')
 
-    call assert_equal(filename, bufname("%"))
-    call assert_equal(lnum, getcurpos()[1])
-    call assert_equal(col, getcurpos()[2])
+    call assert_equal(l:filename, bufname("%"))
+    call assert_equal(l:lnum, getcurpos()[1])
+    call assert_equal(l:col, getcurpos()[2])
   finally
     call delete(l:tmp, 'rf')
   endtry
@@ -40,13 +40,13 @@ endfunc
 
 func! Test_Jump_leaves_lists() abort
   try
-    let filename = 'def/jump.go'
+    let l:filename = 'def/jump.go'
     let l:tmp = gotest#load_fixture(l:filename)
 
-    let expected = [{'lnum': 10, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'quux'}]
+    let l:expected = [{'lnum': 10, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'quux'}]
 
-    call setloclist(winnr(), copy(expected), 'r' )
-    call setqflist(copy(expected), 'r' )
+    call setloclist(winnr(), copy(l:expected), 'r' )
+    call setqflist(copy(l:expected), 'r' )
 
     let l:bufnr = bufnr('%')
     call cursor(6, 7)
@@ -60,16 +60,16 @@ func! Test_Jump_leaves_lists() abort
       unlet g:go_def_mode
     endif
 
-    let start = reltime()
-    while bufnr('%') == l:bufnr && reltimefloat(reltime(start)) < 10
+    let l:start = reltime()
+    while bufnr('%') == l:bufnr && reltimefloat(reltime(l:start)) < 10
       sleep 100m
     endwhile
 
-    let actual = getloclist(winnr())
-    call gotest#assert_quickfix(actual, expected)
+    let l:actual = getloclist(winnr())
+    call gotest#assert_quickfix(l:actual, l:expected)
 
-    let actual = getqflist()
-    call gotest#assert_quickfix(actual, expected)
+    let l:actual = getqflist()
+    call gotest#assert_quickfix(l:actual, l:expected)
   finally
     call delete(l:tmp, 'rf')
   endtry

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -93,31 +93,33 @@ func! s:gometaautosave(metalinter) abort
 endfunc
 
 func! Test_Vet() abort
-  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
-  silent exe 'e ' . $GOPATH . '/src/vet/vet.go'
-  compiler go
+  let l:tmp = gotest#load_fixture('lint/src/vet/vet.go')
 
-  let expected = [
-        \ {'lnum': 7, 'bufnr': bufnr('%'), 'col': 2, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '',
-        \ 'text': 'Printf format %d has arg str of wrong type string'}
-      \ ]
+  try
 
-  let winnr = winnr()
+    let expected = [
+          \ {'lnum': 7, 'bufnr': bufnr('%'), 'col': 2, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '',
+          \ 'text': 'Printf format %d has arg str of wrong type string'}
+        \ ]
 
-  " clear the location lists
-  call setqflist([], 'r')
+    let winnr = winnr()
 
-  call go#lint#Vet(1)
+    " clear the location lists
+    call setqflist([], 'r')
 
-  let actual = getqflist()
-  let start = reltime()
-  while len(actual) == 0 && reltimefloat(reltime(start)) < 10
-    sleep 100m
+    call go#lint#Vet(1)
+
     let actual = getqflist()
-  endwhile
+    let start = reltime()
+    while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+      sleep 100m
+      let actual = getqflist()
+    endwhile
 
-  call gotest#assert_quickfix(actual, expected)
-  call call(RestoreGOPATH, [])
+    call gotest#assert_quickfix(actual, expected)
+  finally
+    call delete(l:tmp, 'rf')
+  endtry
 endfunc
 
 func! Test_Lint_GOPATH() abort

--- a/autoload/go/lsp_test.vim
+++ b/autoload/go/lsp_test.vim
@@ -5,18 +5,18 @@ set cpo&vim
 scriptencoding utf-8
 
 function! Test_GetSimpleTextPosition()
-    call s:getinfo('lsp text position should align with cursor position after ascii only')
+    call s:getinfo('lsp text position should align with cursor position after ascii only', 'ascii')
 endfunction
 
 function! Test_GetMultiByteTextPosition()
-    call s:getinfo('lsp text position should align with cursor position after two place of interest symbols ⌘⌘')
+    call s:getinfo('lsp text position should align with cursor position after two place of interest symbols ⌘⌘', 'multi-byte')
 endfunction
 
 function! Test_GetMultipleCodeUnitTextPosition()
-    call s:getinfo('lsp text position should align with cursor position after Deseret Capital Letter Long I 𐐀')
+    call s:getinfo('lsp text position should align with cursor position after Deseret Capital Letter Long I 𐐀', 'multi-code-units')
 endfunction
 
-function! s:getinfo(str)
+function! s:getinfo(str, name)
   if !go#util#has_job()
     return
   endif
@@ -24,7 +24,7 @@ function! s:getinfo(str)
   try
     let g:go_info_mode = 'gopls'
 
-    let l:tmp = gotest#write_file('position/position.go', [
+    let l:tmp = gotest#write_file(a:name . '/position/position.go', [
           \ 'package position',
           \ '',
           \ 'func Example() {',

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -468,7 +468,7 @@ function! go#util#tempdir(prefix) abort
   endif
 
   " Not great randomness, but "good enough" for our purpose here.
-  let l:rnd = sha256(printf('%s%s', localtime(), fnamemodify(bufname(''), ":p")))
+  let l:rnd = sha256(printf('%s%s', reltimestr(reltime()), fnamemodify(bufname(''), ":p")))
   let l:tmp = printf("%s/%s%s", l:dir, a:prefix, l:rnd)
   call mkdir(l:tmp, 'p', 0700)
   return l:tmp

--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -30,6 +30,8 @@ fun! gotest#write_file(path, contents) abort
       let l:byte = line2byte(l:lnum) + l:m
       exe 'goto '. l:byte
       call setline('.', substitute(getline('.'), "\x1f", '', ''))
+      silent noautocmd w!
+
       break
     endif
 

--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -19,6 +19,7 @@ fun! gotest#write_file(path, contents) abort
   call mkdir(fnamemodify(l:full_path, ':h'), 'p')
   call writefile(a:contents, l:full_path)
   exe 'cd ' . l:dir . '/src'
+  call go#lsp#AddWorkspace(fnamemodify(l:full_path, ':p:h'))
   silent exe 'e! ' . a:path
 
   " Set cursor.
@@ -52,6 +53,7 @@ fun! gotest#load_fixture(path) abort
   silent exe 'noautocmd e ' . a:path
   silent exe printf('read %s/test-fixtures/%s', g:vim_go_root, a:path)
   silent noautocmd w!
+  call go#lsp#AddWorkspace(fnamemodify(l:full_path, ':p:h'))
 
   return l:dir
 endfun

--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -19,7 +19,11 @@ fun! gotest#write_file(path, contents) abort
   call mkdir(fnamemodify(l:full_path, ':h'), 'p')
   call writefile(a:contents, l:full_path)
   exe 'cd ' . l:dir . '/src'
-  call go#lsp#AddWorkspace(fnamemodify(l:full_path, ':p:h'))
+
+  if go#util#has_job()
+    call go#lsp#AddWorkspace(fnamemodify(l:full_path, ':p:h'))
+  endif
+
   silent exe 'e! ' . a:path
 
   " Set cursor.
@@ -55,7 +59,9 @@ fun! gotest#load_fixture(path) abort
   silent exe 'noautocmd e ' . a:path
   silent exe printf('read %s/test-fixtures/%s', g:vim_go_root, a:path)
   silent noautocmd w!
-  call go#lsp#AddWorkspace(fnamemodify(l:full_path, ':p:h'))
+  if go#util#has_job()
+    call go#lsp#AddWorkspace(fnamemodify(l:full_path, ':p:h'))
+  endif
 
   return l:dir
 endfun

--- a/scripts/runtest.vim
+++ b/scripts/runtest.vim
@@ -76,17 +76,18 @@ for s:test in sort(s:tests)
   let s:elapsed_time = substitute(reltimestr(reltime(s:started)), '^\s*\(.\{-}\)\s*$', '\1', '')
   let s:done += 1
 
-  call s:logmessages()
 
   if len(v:errors) > 0
     let s:fail += 1
     call add(s:logs, printf("--- FAIL %s (%ss)", s:test[:-3], s:elapsed_time))
+    call s:logmessages()
     call extend(s:logs, map(v:errors, '"        ".  v:val'))
 
     " Reset so we can capture failures of the next test.
     let v:errors = []
   else
     if g:test_verbose is 1
+      call s:logmessages()
       call add(s:logs, printf("--- PASS %s (%ss)", s:test[:-3], s:elapsed_time))
     endif
   endif


### PR DESCRIPTION
##### reposition messages from tests for clarity

Only output messages from tests if tests failed or if using -v.

Output the messages for tests after the test delimiter instead of before
it, so that it's clear from which test the messages originated.

##### add test fixtures to gopls workspace

Add new workspaces to gopls' workspaces in gotest#load_fixture and
gotest#write_file so that code that depends on LSP functionality will
work in tests, too. It's not perfect and there are some limitations:
code that uses gotest#loadfixture may need the fixture to have a go.mod
file and slightly modify the directory structure of the fixture when
there are multiple packages in the new GOPATH.

##### use reltime() for for uniqueness

Modify go#util#tempdir to use reltime() instead of localtime() for
generating a unique directory name to reduce likelihood of collisions
when go#util#tempdir is called multiple times within the same second.

##### write file after removing cursor position

Write file after removing cursor position character, 0x1f, in
gotest#write_file so that subsequent calls to gotest#load_fixture will
succeed.

##### lint: refactor Test_Vet to use gotest#load_fixture

Refactor Test_Vet to use gotest#loadfixture to avoid errors that
sometimes seem to occur when loading the test fixture and setting GOPATH
manually.

##### use unique directory prefixes for lsp tests


##### def: prefix local variables with l: in tests


##### def: add tests for gopls mode


