### PR TITLE
lsp: send initialized notification

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -193,7 +193,8 @@ function! s:newlsp() abort
     call go#statusline#Update(self.wd, status)
 
     let self.ready = 1
-    " TODO(bc): send initialized message to the server?
+    let  l:msg = self.newMessage(go#lsp#message#Initialized())
+    call self.write(l:msg)
 
     " send messages queued while waiting for ready.
     for l:item in self.queue
@@ -233,6 +234,7 @@ function! s:newlsp() abort
 
       let l:state = s:newHandlerState('')
       let l:state.handleResult = funcref('self.handleInitializeResult', [], l:self)
+
       let self.handlers[l:msg.id] = l:state
 
       call l:state.start()

--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -23,6 +23,14 @@ function! go#lsp#message#Initialize(wd) abort
        \ }
 endfunction
 
+function! go#lsp#message#Initialized() abort
+  return {
+          \ 'notification': 1,
+          \ 'method': 'initialized',
+          \ 'params': {},
+       \ }
+endfunction
+
 function! go#lsp#message#workspaceFolders(dirs) abort
   return map(copy(a:dirs), function('s:workspaceFolderToURI', []))
 endfunction


### PR DESCRIPTION
Send the initialized notifcation to gopls after receiving its initialize
response so that configuration will be processed and the message
indicating where the gopls diagnostic server is available will be
output.