### PR TITLE
lsp: support build tags

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -21,10 +21,12 @@ endfunction
 function! go#config#SetBuildTags(value) abort
   if a:value is ''
     silent! unlet g:go_build_tags
+    call go#lsp#ResetWorkspaceDirectories()
     return
   endif
 
   let g:go_build_tags = a:value
+  call go#lsp#ResetWorkspaceDirectories()
 endfunction
 
 function! go#config#TestTimeout() abort

--- a/autoload/go/def_test.vim
+++ b/autoload/go/def_test.vim
@@ -85,8 +85,8 @@ func! Test_DefJump_gopls_simple_first() abort
   try
     let g:go_def_mode = 'gopls'
 
-    let l:tmp = gotest#write_file('simple/firstposition/position.go', [
-          \ 'package position',
+    let l:tmp = gotest#write_file('simple/firstposition/firstposition.go', [
+          \ 'package firstposition',
           \ '',
           \ 'func Example() {',
           \ "\tid := " . '"foo"',
@@ -120,8 +120,8 @@ func! Test_DefJump_gopls_simple_last() abort
   try
     let g:go_def_mode = 'gopls'
 
-    let l:tmp = gotest#write_file('simple/lastposition/position.go', [
-          \ 'package position',
+    let l:tmp = gotest#write_file('simple/lastposition/lastposition.go', [
+          \ 'package lastposition',
           \ '',
           \ 'func Example() {',
           \ "\tid := " . '"foo"',
@@ -155,8 +155,8 @@ func! Test_DefJump_gopls_MultipleCodeUnit_first() abort
   try
     let g:go_def_mode = 'gopls'
 
-    let l:tmp = gotest#write_file('multiplecodeunit/firstposition/position.go', [
-          \ 'package position',
+    let l:tmp = gotest#write_file('multiplecodeunit/firstposition/firstposition.go', [
+          \ 'package firstposition',
           \ '',
           \ 'func Example() {',
           \ "\t𐐀, id := " . '"foo", "bar"',
@@ -190,8 +190,8 @@ func! Test_DefJump_gopls_MultipleCodeUnit_last() abort
   try
     let g:go_def_mode = 'gopls'
 
-    let l:tmp = gotest#write_file('multiplecodeunit/lastposition/position.go', [
-          \ 'package position',
+    let l:tmp = gotest#write_file('multiplecodeunit/lastposition/lastposition.go', [
+          \ 'package lastposition',
           \ '',
           \ 'func Example() {',
           \ "\t𐐀, id := " . '"foo", "bar"',

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -132,7 +132,7 @@ function! s:newlsp() abort
       let l:resp = go#lsp#message#workspaceFolders(self.workspaceDirectories)
     endif
 
-    let l:msg = self.newResponse(l:resp)
+    let l:msg = self.newResponse(a:req.id, l:resp)
     call self.write(l:msg)
   endfunction
 
@@ -281,6 +281,8 @@ function! s:newlsp() abort
           \ 'id': a:id,
           \ 'result': a:result,
         \ }
+
+    return l:msg
   endfunction
 
   function! l:lsp.write(msg) dict abort

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -130,6 +130,8 @@ function! s:newlsp() abort
   function! l:lsp.handleRequest(req) dict abort
     if a:req.method == 'workspace/workspaceFolders'
       let l:resp = go#lsp#message#WorkspaceFoldersResult(self.workspaceDirectories)
+    elseif a:req.method == 'workspace/configuration' && has_key(a:req, 'params') && has_key(a:req.params, 'items')
+      let l:resp = go#lsp#message#ConfigurationResult(a:req.params.items)
     else
       return
     endif

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -740,6 +740,23 @@ function! go#lsp#CleanWorkspaces() abort
   return 0
 endfunction
 
+" go#lsp#ResetWorkspaceDiretories removes and then re-adds all workspace
+" folders to cause gopls to send configuration requests for all of them again.
+" This is useful, for instance, when build tags have been added and gopls
+" needs to use them.
+function! go#lsp#ResetWorkspaceDirectories() abort
+  call go#lsp#CleanWorkspaces()
+
+  let l:lsp = s:lspfactory.get()
+
+  let l:state = s:newHandlerState('')
+  let l:state.handleResult = funcref('s:noop')
+  let l:msg = go#lsp#message#ChangeWorkspaceFolders(l:lsp.workspaceDirectories, l:lsp.workspaceDirectories)
+  call l:lsp.sendMessage(l:msg, l:state)
+
+  return 0
+endfunction
+
 function! s:debug(event, data) abort
   if !go#util#HasDebug('lsp')
     return

--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -31,12 +31,8 @@ function! go#lsp#message#Initialized() abort
        \ }
 endfunction
 
-function! go#lsp#message#workspaceFolders(dirs) abort
-  return map(copy(a:dirs), function('s:workspaceFolderToURI', []))
-endfunction
-
-function s:workspaceFolderToURI(key, val) abort
-  return go#path#ToURI(a:val)
+function! go#lsp#message#WorkspaceFoldersResult(dirs) abort
+  return map(copy(a:dirs), function('s:workspaceFolder', []))
 endfunction
 
 function! go#lsp#message#Definition(file, line, col) abort
@@ -134,22 +130,24 @@ function! go#lsp#message#Hover(file, line, col) abort
        \ }
 endfunction
 
-function! go#lsp#message#AddWorkspaces(dirs) abort
-  let l:dirs = map(copy(a:dirs), function('s:workspaceFolderToAddURI', []))
+function! go#lsp#message#ChangeWorkspaceFolders(add, remove) abort
+  let l:addDirs = map(copy(a:add), function('s:workspaceFolder', []))
+  let l:removeDirs = map(copy(a:add), function('s:workspaceFolder', []))
 
   return {
           \ 'notification': 1,
           \ 'method': 'workspace/didChangeWorkspaceFolders',
           \ 'params': {
           \   'event': {
-          \     'added': l:dirs,
+          \     'removed': l:removeDirs,
+          \     'added': l:addDirs,
           \     },
           \ }
        \ }
 
 endfunction
 
-function s:workspaceFolderToAddURI(key, val) abort
+function s:workspaceFolder(key, val) abort
   return {'uri': go#path#ToURI(a:val), 'name': a:val}
 endfunction
 

--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -12,6 +12,7 @@ function! go#lsp#message#Initialize(wd) abort
             \ 'capabilities': {
               \ 'workspace': {
                 \ 'workspaceFolders': v:true,
+                \ 'configuration': v:true,
               \ },
               \ 'textDocument': {
                 \ 'hover': {
@@ -145,6 +146,26 @@ function! go#lsp#message#ChangeWorkspaceFolders(add, remove) abort
           \ }
        \ }
 
+endfunction
+
+function! go#lsp#message#ConfigurationResult(items) abort
+  let l:result = []
+
+  " results must be in the same order as the items
+  for l:item in a:items
+    let l:config = {
+          \ 'buildFlags': [],
+          \ 'hoverKind': 'NoDocumentation',
+          \ }
+    let l:buildtags = go#config#BuildTags()
+    if buildtags isnot ''
+      let l:config.buildFlags = extend(l:config.buildFlags, ['-tags', go#config#BuildTags()])
+    endif
+
+    let l:result = add(l:result, l:config)
+  endfor
+
+  return l:result
 endfunction
 
 function s:workspaceFolder(key, val) abort

--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -12,6 +12,9 @@ set cpo&vim
 " The full path to the created directory is returned, it is the caller's
 " responsibility to clean that up!
 fun! gotest#write_file(path, contents) abort
+  if go#util#has_job()
+    call go#lsp#CleanWorkspaces()
+  endif
   let l:dir = go#util#tempdir("vim-go-test/testrun/")
   let $GOPATH .= ':' . l:dir
   let l:full_path = l:dir . '/src/' . a:path
@@ -21,7 +24,7 @@ fun! gotest#write_file(path, contents) abort
   exe 'cd ' . l:dir . '/src'
 
   if go#util#has_job()
-    call go#lsp#AddWorkspace(fnamemodify(l:full_path, ':p:h'))
+    call go#lsp#AddWorkspaceDirectory(fnamemodify(l:full_path, ':p:h'))
   endif
 
   silent exe 'e! ' . a:path
@@ -50,6 +53,9 @@ endfun
 " The file will be copied to a new GOPATH-compliant temporary directory and
 " loaded as the current buffer.
 fun! gotest#load_fixture(path) abort
+  if go#util#has_job()
+    call go#lsp#CleanWorkspaces()
+  endif
   let l:dir = go#util#tempdir("vim-go-test/testrun/")
   let $GOPATH .= ':' . l:dir
   let l:full_path = l:dir . '/src/' . a:path
@@ -60,7 +66,7 @@ fun! gotest#load_fixture(path) abort
   silent exe printf('read %s/test-fixtures/%s', g:vim_go_root, a:path)
   silent noautocmd w!
   if go#util#has_job()
-    call go#lsp#AddWorkspace(fnamemodify(l:full_path, ':p:h'))
+    call go#lsp#AddWorkspaceDirectory(fnamemodify(l:full_path, ':p:h'))
   endif
 
   return l:dir

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -117,6 +117,6 @@ command! -nargs=0 GoReportGitHubIssue call go#issue#New()
 command! -nargs=0 GoIfErr call go#iferr#Generate()
 
 " -- lsp
-command! -nargs=+ -complete=dir GoAddWorkspace call go#lsp#AddWorkspace(<f-args>)
+command! -nargs=+ -complete=dir GoAddWorkspace call go#lsp#AddWorkspaceDirectory(<f-args>)
 
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
##### godef: make directory name match the package name

Make the directory name match the package name in godef tests.


##### lsp: fix response handling

* pass the request id to newResponse
* return the result message from newResponse


##### lsp: refactor managing workspace directories

* rename go#lsp#message#workspaceFolders to make it clear that it
  returns a request result message
* rename go#lsp#AddWorkspace to make it clear that it adds a directory
  and isn't necessarily related to any other context that may compose of
  workspace (of which there is none yet).
* rename go#lsp#message#AddWorkspaces to make it reflect the fact that
  it changes workspace folders and add a new parameter to specify the
  directories to be removed.


##### lsp: add support for configuration client capability

* Tell gopls that vim-go supports the workspace.configuration client
  capability.
* Respond to workspace/configuration requests with buildFlags and
  hoverKind. buildFlags is set to the build flags currently configured
  in vim-go build flags (e.g. g:go_build_flags). hoverKind is set to
  NoDocumentation so that hover responses won't return documentation.


##### lsp: reset workspaces when build flags are changed

Reset workspaces when build flags are changed via `:GoBuildFlags`. This
won't yet do anything. Once
https://go-review.googlesource.com/c/tools/+/187819 is merged, though,
build flags that gopls uses will be able to be changed using
`:GoBuildFlags` without requiring the Vim session to be restarted.


