### PR TITLE
lsp: register for dynamic configuration

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -132,6 +132,8 @@ function! s:newlsp() abort
       let l:resp = go#lsp#message#WorkspaceFoldersResult(self.workspaceDirectories)
     elseif a:req.method == 'workspace/configuration' && has_key(a:req, 'params') && has_key(a:req.params, 'items')
       let l:resp = go#lsp#message#ConfigurationResult(a:req.params.items)
+    elseif a:req.method == 'client/registerCapability' && has_key(a:req, 'params') && has_key(a:req.params, 'registrations')
+      let l:resp = v:null
     else
       return
     endif

--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -12,6 +12,9 @@ function! go#lsp#message#Initialize(wd) abort
             \ 'capabilities': {
               \ 'workspace': {
                 \ 'workspaceFolders': v:true,
+                \ 'didChangeConfiguration': {
+                  \ 'dynamicRegistration': v:true,
+                \ },
                 \ 'configuration': v:true,
               \ },
               \ 'textDocument': {
@@ -19,7 +22,8 @@ function! go#lsp#message#Initialize(wd) abort
                   \ 'contentFormat': ['plaintext'],
                 \ },
               \ }
-            \ }
+            \ },
+            \ 'workspaceFolders': [s:workspaceFolder(0, a:wd)],
           \ }
        \ }
 endfunction


### PR DESCRIPTION
Register for dynamic configuration and also register workspace folders
explicitly during initialization so that gopls will query for their
configuration.