### PR TITLE
Simplify Windows check, has('win32') is enough

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -36,15 +36,9 @@ function! go#util#Join(...) abort
 endfunction
 
 " IsWin returns 1 if current OS is Windows or 0 otherwise
+" Note that has('win32') is always 1 when has('win64') is 1, so has('win32') is enough.
 function! go#util#IsWin() abort
-  let win = ['win16', 'win32', 'win64', 'win95']
-  for w in win
-    if (has(w))
-      return 1
-    endif
-  endfor
-
-  return 0
+  return has('win32')
 endfunction
 
 " IsMac returns 1 if current OS is macOS or 0 otherwise.


### PR DESCRIPTION
Thank you for maintaining this great plugin. This pull request simplifies `go#util#IsWin()` function (and probably improve the performance a bit) by checking only `win32`.

- `has('win16')` and `has('win95')` was removed long ago and always returns 0. The patch where the code for win16 was removed was 7.4.1364 but no one  could not check the behavior at that time already. This plugin declares the minimum version to Vim 7.4.2009 in the document anyway.
- When `has('win64')` is 1, `has('win32')` is always 1. The help of Vim says `win32	Win32 version of Vim (MS-Windows 95 and later, 32 or 64 bits)`. The flag `win32` is related to `_WIN32` and this is defined as 1 on both architectures (see https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros).