### PR TITLE
plugin: redraw before updating/installing each binary

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -137,6 +137,7 @@ function! s:GoInstallBinaries(updateBinaries, ...)
   endif
 
   for [binary, pkg] in items(l:packages)
+    redraw
     let l:importPath = pkg[0]
 
     " TODO(bc): how to support this with modules? Do we have to clone and then
@@ -221,6 +222,7 @@ function! s:GoInstallBinaries(updateBinaries, ...)
     set shellslash
   endif
 
+  redraw
   if a:updateBinaries == 1
     call go#util#EchoInfo('updating finished!')
   else


### PR DESCRIPTION
Redraw before updating or installing each binary so that users of small
terminals don't get prompted to hit Enter a bunch.