### PR TITLE
snippets: revert #2358

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -151,7 +151,7 @@ if err := ${1:condition}; err != nil {
 endsnippet
 
 # error snippet
-snippet err "Error return" !b
+snippet errn "Error return" !b
 if err != nil {
 	return err
 }


### PR DESCRIPTION
There were two of them, one is `errn` and `errn,` (note the coma at the
end). We didn't use `err` because that is sometimes a variable itself
and you don't want to autoexpand it. Or sometimes the completer catches
it.

We should revert it,  because `errn` is not in use at all,
so this change was wrong in the first place and this breaks things for
many people who were using `errn` before. It's not a backwards compatible
change.