### PR TITLE
Add GoAddBinaryToInstall() to install extra tools.

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -510,6 +510,15 @@ CTRL-t
 
     Set |'g:go_get_update'| to disable updating dependencies.
 
+                                                      *GoAddBinaryToInstall()*
+    You can add extra binaries to install using 'GoAddBinaryToInstall()', e.g.
+    to install 'gotype' and 'goimports' for use by Syntastic:
+    >
+        :call GoAddBinaryToInstall('gotype', 'golang.org/x/tools/cmd/gotype')
+        :call GoAddBinaryToInstall('goimports', 'golang.org/x/tools/cmd/goimports')
+        :GoInstallBinaries
+<
+
                                                            *:GoUpdateBinaries*
 :GoUpdateBinaries [binaries]
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -511,8 +511,8 @@ CTRL-t
     Set |'g:go_get_update'| to disable updating dependencies.
 
                                                       *GoAddBinaryToInstall()*
-    You can add extra binaries to install using 'GoAddBinaryToInstall()', e.g.
-    to install 'gotype' and 'goimports' for use by Syntastic:
+    You can add extra binaries to install using GoAddBinaryToInstall(), e.g.
+    to install gotype and goimports for use by Syntastic:
     >
         :call GoAddBinaryToInstall('gotype', 'golang.org/x/tools/cmd/gotype')
         :call GoAddBinaryToInstall('goimports', 'golang.org/x/tools/cmd/goimports')

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -515,7 +515,8 @@ CTRL-t
     to install gotype and goimports for use by Syntastic:
     >
         :call GoAddBinaryToInstall('gotype', 'golang.org/x/tools/cmd/gotype')
-        :call GoAddBinaryToInstall('goimports', 'golang.org/x/tools/cmd/goimports')
+        :call GoAddBinaryToInstall('goimports',
+          \ 'golang.org/x/tools/cmd/goimports')
         :GoInstallBinaries
 <
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -242,6 +242,19 @@ function! s:CheckBinaries()
   endif
 endfunction
 
+" GoAddBinaryToInstall adds another binary to s:packages so it can be installed
+" using GoInstallBinaries.
+fun! GoAddBinaryToInstall(name, url)
+  if exists("s:packages[a:name]")
+    echohl Error
+    echomsg "GoAddBinaryToInstall: " . a:name . " already exists: "
+      \ . string(s:packages[a:name])
+    echohl None
+    return -1
+  endif
+  let s:packages[a:name] = [a:url]
+endfunction
+
 " Autocommands
 " ============================================================================
 "


### PR DESCRIPTION
I'd like to use GoInstallBinaries to install other Golang tools, e.g.
goimports for use by Syntastic.  This commit adds a function
GoAddBinaryToInstall() that extends s:packages with more tools to
install so that GoInstallBinaries can install them.