### PR TITLE
highlight function calls as functions

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -288,7 +288,7 @@ hi def link     goFunction          Function
 if go#config#HighlightFunctionCalls()
   syn match goFunctionCall      /\w\+\ze(/ contains=goBuiltins,goDeclaration
 endif
-hi def link     goFunctionCall      Type
+hi def link     goFunctionCall      Function
 
 " Fields;
 if go#config#HighlightFields()


### PR DESCRIPTION
To me, it makes more sense to highlight goFunctionCall as Function instead of Type.

https://github.com/fatih/vim-go/blob/ed63c87496c030d436507c4eb211a923aa5dc90b/syntax/go.vim#L291

My expectation would be: 
`hi def link     goFunctionCall      Function`