### PR TITLE
Add support for DocPopupWindow in Neovim

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -107,9 +107,9 @@ function! s:GodocView(newposition, position, content) abort
             \ 'col': 0,
             \ 'width': width,
             \ 'height': height,
-            \ 'style': 'minimal'
             \ }
       call nvim_open_win(buf, v:true, opts)
+      setlocal nonumber norelativenumber nomodified nomodifiable syntax=go
 
       " close easily with CR, Esc and q
       noremap <buffer> <silent> <CR> :<C-U>close<CR>

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -77,14 +77,45 @@ endfunction
 
 function! s:GodocView(newposition, position, content) abort
   " popup window
-  if go#config#DocPopupWindow() && exists('*popup_atcursor') && exists('*popup_clear')
-    call popup_clear()
+  if go#config#DocPopupWindow()
+    if exists('*popup_atcursor') && exists('*popup_clear')
+      call popup_clear()
 
-    call popup_atcursor(split(a:content, '\n'), {
-          \ 'padding': [1, 1, 1, 1],
-          \ 'borderchars': ['-','|','-','|','+','+','+','+'],
-          \ "border": [1, 1, 1, 1],
-          \ })
+      call popup_atcursor(split(a:content, '\n'), {
+            \ 'padding': [1, 1, 1, 1],
+            \ 'borderchars': ['-','|','-','|','+','+','+','+'],
+            \ "border": [1, 1, 1, 1],
+            \ })
+    elseif has('nvim') && exists('*nvim_win_set_config')
+      let lines = split(a:content, '\n')
+      let height = 0
+      let width = 0
+      for line in lines
+        let lw = strdisplaywidth(line)
+        if lw > width
+          let width = lw
+        endif
+        let height += 1
+      endfor
+      let width += 1 " right margin
+
+      let buf = nvim_create_buf(v:false, v:true)
+      call nvim_buf_set_lines(buf, 0, -1, v:true, lines)
+      let opts = {
+            \ 'relative': 'cursor',
+            \ 'row': 1,
+            \ 'col': 0,
+            \ 'width': width,
+            \ 'height': height,
+            \ 'style': 'minimal'
+            \ }
+      call nvim_open_win(buf, v:true, opts)
+
+      " close easily with CR, Esc and q
+      noremap <buffer> <silent> <CR> :<C-U>close<CR>
+      noremap <buffer> <silent> <Esc> :<C-U>close<CR>
+      noremap <buffer> <silent> q :<C-U>close<CR>
+    endif
     return
   endif
 

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -98,6 +98,10 @@ function! s:GodocView(newposition, position, content) abort
         let height += 1
       endfor
       let width += 1 " right margin
+      let max_height = go#config#DocMaxHeight()
+      if height > max_height
+        let height = max_height
+      endif
 
       let buf = nvim_create_buf(v:false, v:true)
       call nvim_buf_set_lines(buf, 0, -1, v:true, lines)

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -86,7 +86,7 @@ function! s:GodocView(newposition, position, content) abort
             \ 'borderchars': ['-','|','-','|','+','+','+','+'],
             \ "border": [1, 1, 1, 1],
             \ })
-    elseif has('nvim') && exists('*nvim_win_set_config')
+    elseif has('nvim') && exists('*nvim_open_win')
       let lines = split(a:content, '\n')
       let height = 0
       let width = 0

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -109,7 +109,7 @@ function! s:GodocView(newposition, position, content) abort
             \ 'height': height,
             \ }
       call nvim_open_win(buf, v:true, opts)
-      setlocal nonumber norelativenumber nomodified nomodifiable syntax=go
+      setlocal nonumber norelativenumber nomodified nomodifiable filetype=godoc
 
       " close easily with CR, Esc and q
       noremap <buffer> <silent> <CR> :<C-U>close<CR>


### PR DESCRIPTION
Basic support for floating windows in Neovim. It's using minimal style to disable some UI components like end-of-buffer region or special columns.

![Imgur](https://i.imgur.com/LRPQO1v.jpg)