### PR TITLE
use go#util#Echo* functions consistently

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -148,9 +148,11 @@ function! go#cmd#Run(bang, ...) abort
     endif
 
     if v:shell_error
-      redraws! | echon "vim-go: [run] " | echohl ErrorMsg | echon "FAILED"| echohl None
+      redraws!
+      call go#util#EchoError('[run] FAILED')
     else
-      redraws! | echon "vim-go: [run] " | echohl Function | echon "SUCCESS"| echohl None
+      redraws!
+      call go#util#EchoSuccess('[run] SUCCESS')
     endif
 
     return
@@ -257,7 +259,9 @@ function! go#cmd#Generate(bang, ...) abort
 
   let l:listtype = go#list#Type("GoGenerate")
 
-  echon "vim-go: " | echohl Identifier | echon "generating ..."| echohl None
+  if go#config#EchoCommandInfo()
+    call go#util#EchoProgress('generating ...')
+  endif
 
   try
     if l:listtype == "locationlist"
@@ -277,7 +281,8 @@ function! go#cmd#Generate(bang, ...) abort
       call go#list#JumpToFirst(l:listtype)
     endif
   else
-    redraws! | echon "vim-go: " | echohl Function | echon "[generate] SUCCESS"| echohl None
+    redraws!
+    call go#util#EchoSuccess('[generate] SUCCESS')
   endif
 
 endfunction

--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -221,7 +221,6 @@ function! s:info_complete(echo, result) abort
 endfunction
 
 function! s:trim_bracket(val) abort
-  echom a:val
   let a:val.word = substitute(a:val.word, '[(){}\[\]]\+$', '', '')
   return a:val
 endfunction

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -82,7 +82,7 @@ endfunction
 
 function! s:call_jsonrpc(method, ...) abort
   if go#util#HasDebug('debugger-commands')
-    echom 'sending to dlv ' . a:method
+    call go#util#EchoInfo('sending to dlv ' . a:method)
   endif
 
   let l:args = a:000

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -196,7 +196,6 @@ function! s:show_errors(errors) abort
   let l:listtype = go#list#Type("GoFmt")
   if !empty(a:errors)
     call go#list#Populate(l:listtype, a:errors, 'Format')
-    echohl Error | echomsg "Gofmt returned error" | echohl None
   endif
 
   " this closes the window if there are no errors or it opens

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -80,7 +80,7 @@ function! go#lint#Gometa(bang, autosave, ...) abort
 
   if l:err == 0
     call go#list#Clean(l:listtype)
-    echon "vim-go: " | echohl Function | echon "[metalinter] PASS" | echohl None
+    call go#util#EchoSuccess('[metalinter] PASS')
   else
     let l:winid = win_getid(winnr())
     " Parse and populate our location list

--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -39,7 +39,7 @@ function! s:paths() abort
     if executable('go')
       let s:goroot = go#util#env("goroot")
       if go#util#ShellError() != 0
-        echomsg '''go env GOROOT'' failed'
+        call go#util#EchoError('`go env GOROOT` failed')
       endif
     else
       let s:goroot = $GOROOT

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -28,11 +28,11 @@ function! go#path#GoPath(...) abort
       let s:initial_go_path = ""
     endif
 
-    echon "vim-go: " | echohl Function | echon "GOPATH restored to ". $GOPATH | echohl None
+    call go#util#EchoInfo("GOPATH restored to ". $GOPATH)
     return
   endif
 
-  echon "vim-go: " | echohl Function | echon "GOPATH changed to ". a:1 | echohl None
+  call go#util#EchoInfo("GOPATH changed to ". a:1)
   let s:initial_go_path = $GOPATH
   let $GOPATH = a:1
 endfunction

--- a/autoload/go/play.vim
+++ b/autoload/go/play.vim
@@ -4,7 +4,7 @@ set cpo&vim
 
 function! go#play#Share(count, line1, line2) abort
   if !executable('curl')
-    echohl ErrorMsg | echomsg "vim-go: require 'curl' command" | echohl None
+    call go#util#EchoError('cannot share: curl cannot be found')
     return
   endif
 
@@ -20,8 +20,7 @@ function! go#play#Share(count, line1, line2) abort
   call delete(share_file)
 
   if l:err != 0
-    echom 'A error has occurred. Run this command to see what the problem is:'
-    echom go#util#Shelljoin(l:cmd)
+    call go#util#EchoError(['A error has occurred. Run this command to see what the problem is:', go#util#Shelljoin(l:cmd)])
     return
   endif
 
@@ -38,7 +37,7 @@ function! go#play#Share(count, line1, line2) abort
     call go#util#OpenBrowser(url)
   endif
 
-  echo "vim-go: snippet uploaded: ".url
+  call go#util#EchoInfo('snippet uploaded: ' . url)
 endfunction
 
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -90,9 +90,7 @@ function! s:GoInstallBinaries(updateBinaries, ...)
   endif
 
   if go#path#Default() == ""
-    echohl Error
-    echomsg "vim.go: $GOPATH is not set and 'go env GOPATH' returns empty"
-    echohl None
+    call go#util#EchoError('$GOPATH is not set and `go env GOPATH` returns empty')
     return
   endif
 
@@ -176,7 +174,7 @@ function! s:GoInstallBinaries(updateBinaries, ...)
           " first download the binary
           let [l:out, l:err] = go#util#Exec(l:get_cmd + [l:importPath])
           if l:err
-            echom "Error installing " . l:importPath . ": " . l:out
+            call go#util#EchoError(printf('Error installing %s: %s', l:importPath, l:out))
           endif
 
           call call(Restore_modules, [])
@@ -197,7 +195,7 @@ function! s:GoInstallBinaries(updateBinaries, ...)
         " first download the binary
         let [l:out, l:err] = go#util#Exec(l:get_cmd + [l:importPath])
         if l:err
-          echom "Error downloading " . l:importPath . ": " . l:out
+          call go#util#EchoError(printf('Error downloading %s: %s', l:importPath, l:out))
         endif
 
         " and then build and install it
@@ -208,7 +206,7 @@ function! s:GoInstallBinaries(updateBinaries, ...)
 
         let [l:out, l:err] = go#util#Exec(l:build_cmd)
         if l:err
-          echom "Error installing " . l:importPath . ": " . l:out
+          call go#util#EchoError(printf('Error installing %s: %s', l:importPath, l:out))
         endif
 
 
@@ -241,12 +239,12 @@ endfunction
 " commands are available.
 function! s:CheckBinaries()
   if !executable('go')
-    echohl Error | echomsg "vim-go: go executable not found." | echohl None
+    call go#util#EchoError('go executable not found.')
     return -1
   endif
 
   if !executable('git')
-    echohl Error | echomsg "vim-go: git executable not found." | echohl None
+    call go#util#EchoError('git executable not found.')
     return -1
   endif
 endfunction


### PR DESCRIPTION
##### complete: remove debugging message

Remove an echo statement that only existed for debugging purposes.


##### debug: use go#util#EchoInfo for debugging message

replace echom with go#util#EchoInfo for debugging message.


##### fmt: remove unneeded echomsg statement


##### package: use go#util#EchoError instead of echomsg

Replace echomsg with go#util#EchoError for displaying an error message.


##### play: use go#util#Echo* instead of echom or echo

Replaces uses of echomsg and echo with the appropriate go#util#Echo*
message for consistency.


##### plugin: use go#util#Echo* functions

Use go#util#Echo* functions instead of calling echom directly.


