### PR TITLE
feat/#2338: support debug multi goroutine

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -205,10 +205,10 @@ endfunction
 
 function! go#config#DebugWindows() abort
   return get(g:, 'go_debug_windows', {
-            \ 'goroutines':  'split 60vnew',
-            \ 'out':   'botright 100new',
-            \ 'vars':  'leftabove 40vnew',
-            \ 'stack': 'leftabove 40vnew',
+            \ 'vars':  'leftabove 30vnew',
+            \ 'stack': 'leftabove 20new',
+            \ 'goroutines': 'botright 10new',
+            \ 'out':        'botright 5new',
             \ }
          \ )
 

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -205,9 +205,10 @@ endfunction
 
 function! go#config#DebugWindows() abort
   return get(g:, 'go_debug_windows', {
-            \ 'stack': 'leftabove 20vnew',
-            \ 'out':   'botright 10new',
-            \ 'vars':  'leftabove 30vnew',
+            \ 'goroutines':  'split 60vnew',
+            \ 'out':   'botright 100new',
+            \ 'vars':  'leftabove 40vnew',
+            \ 'stack': 'leftabove 40vnew',
             \ }
          \ )
 

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -941,12 +941,14 @@ function! go#debug#Stack(name) abort
     endif
     let s:stack_name = l:name
     try
-      let l:res =  s:call_jsonrpc('RPCServer.Command', {'name': l:name})
+      let l:res = s:call_jsonrpc('RPCServer.Command', {'name': l:name})
+
       if l:name is# 'next'
+          let l:res2 = l:res
           let l:w = 0
           while l:w < 1
-            if l:res.result.State.NextInProgress == v:true
-              let l:res = s:call_jsonrpc('RPCServer.Command', {'name': 'continue'})
+            if l:res2.result.State.NextInProgress == v:true
+              let l:res2 = s:call_jsonrpc('RPCServer.Command', {'name': 'continue'})
             else
               break
             endif

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -947,7 +947,7 @@ function! go#debug#Goroutine(goroutineId) abort
   try
     let l:res = s:call_jsonrpc('RPCServer.Command', {'Name': 'switchGoroutine', 'GoroutineID': str2nr(l:goroutineId)})
     call s:stack_cb(l:res)
-    echom "Switched Goroutine to:" . a:1
+    echom "Switched Goroutine to: " . l:goroutineId
   catch
     call go#util#EchoError(v:exception)
   endtry

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -865,13 +865,14 @@ function! go#debug#Stack(name) abort
     try
       let l:res =  s:call_jsonrpc('RPCServer.Command', {'name': l:name})
       if l:name is# 'next'
-          for i in range(99999)
+          let l:w = 0
+          while l:w < 1
             if l:res.result.State.NextInProgress == v:true
               let l:res = s:call_jsonrpc('RPCServer.Command', {'name': 'continue'})
             else
               break
             endif
-          endfor
+          endwhile
       endif
       call s:stack_cb(l:res)
     catch

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -504,7 +504,7 @@ endfunction
 
 function! s:err_cb(ch, msg) abort
   if get(s:state, 'ready', 0) != 0
-    call call('s:logger', ['ERR: ', a:ch, a:msg])
+    call s:logger('ERR: ', a:ch, a:msg)
     return
   endif
 
@@ -513,7 +513,7 @@ endfunction
 
 function! s:out_cb(ch, msg) abort
   if get(s:state, 'ready', 0) != 0
-    call call('s:logger', ['OUT: ', a:ch, a:msg])
+    call s:logger('OUT: ', a:ch, a:msg)
     return
   endif
 

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -455,8 +455,8 @@ function! s:start_cb() abort
   command! -nargs=0 GoDebugStop       call go#debug#Stop()
   command! -nargs=* GoDebugSet        call go#debug#Set(<f-args>)
   command! -nargs=1 GoDebugPrint      call go#debug#Print(<q-args>)
-  command! -nargs=0 GoDebugGoroutines      call go#debug#Goroutines()
-  command! -nargs=1 GoDebugGoroutine      call go#debug#Goroutine(<f-args>)
+  command! -nargs=0 GoDebugGoroutines call go#debug#Goroutines()
+  command! -nargs=1 GoDebugGoroutine  call go#debug#Goroutine(<f-args>)
 
   nnoremap <silent> <Plug>(go-debug-breakpoint) :<C-u>call go#debug#Breakpoint()<CR>
   nnoremap <silent> <Plug>(go-debug-next)       :<C-u>call go#debug#Stack('next')<CR>
@@ -912,28 +912,28 @@ function! s:isActive()
 endfunction
 
 " List All Goroutines Running
-function! go#debug#Goroutines(...) abort
+function! go#debug#Goroutines() abort
   try
     let l:currentGoroutineId = 0
     try
       let l:currentGoroutineId = s:groutineID()
     catch 
-      echom "current goroutineId not found..."
+      call go#util#EchoWarning("current goroutineId not found...")
     endtry
 
     let l:res = s:call_jsonrpc('RPCServer.ListGoroutines')
     let l:goroutines = l:res.result.Goroutines
     if len(l:goroutines) == 0
-      echom "No Goroutines Running Now..."
+      call go#util#EchoWarning("No Goroutines Running Now...")
       return
     endif
 
     for l:idx in range(len(l:goroutines))
       let l:goroutine = l:goroutines[l:idx]
       if l:goroutine.id == l:currentGoroutineId
-        echom "* Goroutine " . l:goroutine.id . " - " . l:goroutine.userCurrentLoc.file . ":" . l:goroutine.userCurrentLoc.line .  " " l:goroutine.userCurrentLoc.function.name . " " . " (thread: " . l:goroutine.threadID . ")"
+        call go#util#EchoInfo("* Goroutine " . l:goroutine.id . " - " . l:goroutine.userCurrentLoc.file . ":" . l:goroutine.userCurrentLoc.line .  " " . l:goroutine.userCurrentLoc.function.name . " " . " (thread: " . l:goroutine.threadID . ")")
       else
-        echom "  Goroutine " . l:goroutine.id . " - " . l:goroutine.userCurrentLoc.file . ":" . l:goroutine.userCurrentLoc.line .  " " l:goroutine.userCurrentLoc.function.name . " " . " (thread: " . l:goroutine.threadID . ")"
+        call go#util#EchoInfo("  Goroutine " . l:goroutine.id . " - " . l:goroutine.userCurrentLoc.file . ":" . l:goroutine.userCurrentLoc.line .  " " . l:goroutine.userCurrentLoc.function.name . " " . " (thread: " . l:goroutine.threadID . ")")
       endif
     endfor
 
@@ -948,7 +948,7 @@ function! go#debug#Goroutine(goroutineId) abort
   try
     let l:res = s:call_jsonrpc('RPCServer.Command', {'Name': 'switchGoroutine', 'GoroutineID': str2nr(l:goroutineId)})
     call s:stack_cb(l:res)
-    echom "Switched Goroutine to: " . l:goroutineId
+    call go#util#EchoInfo("Switched Goroutine to: " . l:goroutineId)
   catch
     call go#util#EchoError(v:exception)
   endtry

--- a/autoload/go/debug_test.vim
+++ b/autoload/go/debug_test.vim
@@ -24,14 +24,15 @@ function! Test_GoDebugStart_Errors() abort
   endif
 
   try
+    let l:tmp = gotest#load_fixture('debug/compilerror/main.go')
+
     let l:expected = [
           \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': '# debug/compilerror'},
-          \ {'lnum': 6, 'bufnr': 7, 'col': 22, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': ' syntax error: unexpected newline, expecting comma or )'},
+          \ {'lnum': 6, 'bufnr': bufnr('%'), 'col': 22, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': ' syntax error: unexpected newline, expecting comma or )'},
           \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exit status 2'}
           \]
     call setqflist([], 'r')
 
-    let l:tmp = gotest#load_fixture('debug/compilerror/main.go')
     call assert_false(exists(':GoDebugStop'))
 
     let l:cd = exists('*haslocaldir') && haslocaldir() ? 'lcd' : 'cd'

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2170,17 +2170,20 @@ DEBUGGER SETTINGS~
 
                                                         *'g:go_debug_windows'*
 
-Controls the window layout for debugging mode. This is a |dict| with three
-possible keys: "stack", "out", and "vars"; the windows will created in that
-order with the commands in the value.
+Controls the window layout for debugging mode. This is a |dict| with four
+possible keys: "vars", "stack", "goroutines", and "out"; each of the new
+windows will be created in that that order with the commands in the value. The
+current window is made the only window before creating the debug windows.
+
 A window will not be created if a key is missing or empty.
 
 Defaults:
 >
   let g:go_debug_windows = {
-        \ 'stack': 'leftabove 20vnew',
-        \ 'out':   'botright 10new',
-        \ 'vars':  'leftabove 30vnew',
+            \ 'vars':       'leftabove 30vnew',
+            \ 'stack':      'leftabove 20new',
+            \ 'goroutines': 'botright 10new',
+            \ 'out':        'botright 5new',
   \ }
 <
 Show only variables on the right-hand side: >


### PR DESCRIPTION
Now vim-go support  multi goroutine debug

Add two command: GoDebugGoroutines to show all goroutines running, GoDebugGoroutine + goroutineId to switch between goroutines

with this request: #2338