### PR TITLE
fix: stepOut typo to stepout

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,4 @@ of the information needed when creating a new issue.
 ## License
 
 The BSD 3-Clause License - see [`LICENSE`](LICENSE) for more details
+

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -459,7 +459,7 @@ function! s:start_cb() abort
   nnoremap <silent> <Plug>(go-debug-breakpoint) :<C-u>call go#debug#Breakpoint()<CR>
   nnoremap <silent> <Plug>(go-debug-next)       :<C-u>call go#debug#Stack('next')<CR>
   nnoremap <silent> <Plug>(go-debug-step)       :<C-u>call go#debug#Stack('step')<CR>
-  nnoremap <silent> <Plug>(go-debug-stepout)    :<C-u>call go#debug#Stack('stepout')<CR>
+  nnoremap <silent> <Plug>(go-debug-stepout)    :<C-u>call go#debug#Stack('stepOut')<CR>
   nnoremap <silent> <Plug>(go-debug-continue)   :<C-u>call go#debug#Stack('continue')<CR>
   nnoremap <silent> <Plug>(go-debug-stop)       :<C-u>call go#debug#Stop()<CR>
   nnoremap <silent> <Plug>(go-debug-print)      :<C-u>call go#debug#Print(expand('<cword>'))<CR>


### PR DESCRIPTION
which cause go-debug-stepout not work