### PR TITLE
Bugfix - Job Fails Silently When Path Contains Spaces

### DIFF
--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -61,7 +61,7 @@ function! go#job#Options(args)
   let state = {
         \ 'winid': win_getid(winnr()),
         \ 'dir': getcwd(),
-        \ 'jobdir': fnameescape(expand("%:p:h")),
+        \ 'jobdir': expand("%:p:h"),
         \ 'messages': [],
         \ 'bang': 0,
         \ 'for': "_job",
@@ -195,7 +195,7 @@ function! go#job#Options(args)
     let l:cd = exists('*haslocaldir') && haslocaldir() ? 'lcd' : 'cd'
     try
       " parse the errors relative to self.jobdir
-      execute l:cd self.jobdir
+      execute l:cd fnameescape(self.jobdir)
       call go#list#ParseFormat(l:listtype, self.errorformat, out, self.for)
       let errors = go#list#Get(l:listtype)
     finally

--- a/autoload/go/job_test.vim
+++ b/autoload/go/job_test.vim
@@ -1,0 +1,53 @@
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+func! Test_JobDirWithSpaces()
+  if !go#util#has_job()
+    return
+  endif
+
+  try
+    let l:filename = 'job/dir has spaces/main.go'
+    let l:tmp = gotest#load_fixture(l:filename)
+    exe 'cd ' . fnameescape(l:tmp . '/src/job/dir has spaces')
+
+    " set the compiler type so that the errorformat option will be set
+    " correctly.
+    compiler go
+
+    let expected = [{'lnum': 4, 'bufnr': bufnr('%'), 'col': 2, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'undefined: notafunc'}]
+    " clear the quickfix lists
+    call setqflist([], 'r')
+
+    " go build discards any results when it compiles multiple packages. So we
+    " pass the `errors` package just as a placeholder with the current folder
+    " (indicated with '.').
+    let l:cmd = ['go', 'build', '.', 'errors']
+
+    let l:complete = go#promise#New(function('s:complete'), 10000, '')
+    call go#job#Spawn(l:cmd, {
+          \ 'for': 'GoBuild',
+          \ 'complete': l:complete.wrapper,
+          \ 'statustype': 'build'
+         \})
+
+    let l:out = l:complete.await()
+
+    let actual = getqflist()
+
+    call gotest#assert_quickfix(actual, l:expected)
+  finally
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
+func! s:complete(job, exit_code, messages)
+  return a:messages
+endfunc
+
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/test-fixtures/job/dir has spaces/main.go
+++ b/autoload/go/test-fixtures/job/dir has spaces/main.go
@@ -1,0 +1,6 @@
+package main
+
+func main() {
+	notafunc()
+	println("vim-go")
+}


### PR DESCRIPTION
# Identification

I noticed that certain commands, such as _all_ of the `GoTest` variants (`GoTest`, `GoTestCompile`, `GoTestFunc`, etc) weren't working for only **some** of my projects. Interestingly, when they failed, they failed silently, with no logs, messages, or errors.

After trying these commands in other projects, some in module mode, some in my GOPATH, etc, I realized that the consistent issue was for paths that had certain characters, such as spaces.

I narrowed the issue down to an over-eager escaping of a file-path in the `go#job#Options` function:

https://github.com/fatih/vim-go/blob/c6273c5ca6a67f02bd6afdba657194253a0e5d85/autoload/go/job.vim#L64

... which was causing the early return due to the condition that intends to squelch error messages for otherwise "virtual" files:

https://github.com/fatih/vim-go/blob/c6273c5ca6a67f02bd6afdba657194253a0e5d85/autoload/go/job.vim#L286-L287

I then noticed that not only was the escaping eager, but it was inconsistent with the later attempt to grab the same path, if one wasn't provided:

https://github.com/fatih/vim-go/blob/c6273c5ca6a67f02bd6afdba657194253a0e5d85/autoload/go/job.vim#L285


# Fix

This PR fixes the over-eager escaping of the file-path of the job directory in `go#job#Options` that caused paths with certain characters and spaces to fail (silently) to be able to execute a job.

I also made sure to properly escape the path later on, where it was necessary, as its potentially used in a raw command later on that would require this level of escaping.