### PR TITLE
config: default g:go_metalinter_comand to golangci-lint

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -258,7 +258,7 @@ function! go#config#SetTemplateAutocreate(value) abort
 endfunction
 
 function! go#config#MetalinterCommand() abort
-  return get(g:, "go_metalinter_command", "gometalinter")
+  return get(g:, "go_metalinter_command", "golangci-lint")
 endfunction
 
 function! go#config#MetalinterAutosaveEnabled() abort


### PR DESCRIPTION
gometalinter is deprecated and archived, so make golangci-lint the
default.