### PR TITLE
config: remove space in g:go_debug_log_output default value

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -224,7 +224,7 @@ function! go#config#DebugCommands() abort
 endfunction
 
 function! go#config#DebugLogOutput() abort
-  return get(g:, 'go_debug_log_output', 'debugger, rpc')
+  return get(g:, 'go_debug_log_output', 'debugger,rpc')
 endfunction
 
 function! go#config#LspLog() abort


### PR DESCRIPTION
Remove a space in the comma separated values of g:go_debug_log_output to
avoid problems that it causes on Windows.

Fixes #2469.