### PR TITLE
handle compiler errors from go vet

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -149,11 +149,11 @@ function! go#lint#Vet(bang, ...) abort
   let l:listtype = go#list#Type("GoVet")
   if l:err != 0
     let l:winid = win_getid(winnr())
-    let errorformat = "%-Gexit status %\\d%\\+," . &errorformat
+    let l:errorformat = "%-Gexit status %\\d%\\+," . &errorformat
     call go#list#ParseFormat(l:listtype, l:errorformat, out, "GoVet")
-    let errors = go#list#Get(l:listtype)
-    call go#list#Window(l:listtype, len(errors))
-    if !empty(errors) && !a:bang
+    let l:errors = go#list#Get(l:listtype)
+    call go#list#Window(l:listtype, len(l:errors))
+    if !empty(l:errors) && !a:bang
       call go#list#JumpToFirst(l:listtype)
     else
       call win_gotoid(l:winid)

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -122,6 +122,35 @@ func! Test_Vet() abort
   endtry
 endfunc
 
+func! Test_Vet_compilererror() abort
+  let l:tmp = gotest#load_fixture('lint/src/vet/compilererror/compilererror.go')
+
+  try
+
+    let expected = [
+          \ {'lnum': 6, 'bufnr': bufnr('%'), 'col': 22, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': "missing ',' before newline in argument list (and 1 more errors)"}
+        \ ]
+
+    let winnr = winnr()
+
+    " clear the location lists
+    call setqflist([], 'r')
+
+    call go#lint#Vet(1)
+
+    let actual = getqflist()
+    let start = reltime()
+    while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+      sleep 100m
+      let actual = getqflist()
+    endwhile
+
+    call gotest#assert_quickfix(actual, expected)
+  finally
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
 func! Test_Lint_GOPATH() abort
   let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
 

--- a/autoload/go/test-fixtures/lint/src/vet/compilererror/compilererror.go
+++ b/autoload/go/test-fixtures/lint/src/vet/compilererror/compilererror.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("vim-go"
+}

--- a/compiler/go.vim
+++ b/compiler/go.vim
@@ -31,14 +31,13 @@ endif
 " use a different output, for those we define them directly and modify the
 " errorformat ourselves. More information at:
 " http://vimdoc.sourceforge.net/htmldoc/quickfix.html#errorformat
-CompilerSet errorformat =%-G#\ %.%#                   " Ignore lines beginning with '#' ('# command-line-arguments' line sometimes appears?)
-CompilerSet errorformat+=%-G%.%#panic:\ %m            " Ignore lines containing 'panic: message'
-CompilerSet errorformat+=%Ecan\'t\ load\ package:\ %m " Start of multiline error string is 'can\'t load package'
-CompilerSet errorformat+=%A%f:%l:%c:\ %m              " Start of multiline unspecified string is 'filename:linenumber:columnnumber:'
-CompilerSet errorformat+=%A%f:%l:\ %m                 " Start of multiline unspecified string is 'filename:linenumber:'
-CompilerSet errorformat+=%C%*\\s%m                    " Continuation of multiline error message is indented
-CompilerSet errorformat+=%-G%.%#                      " All lines not matching any of the above patterns are ignored
-
+CompilerSet errorformat =%-G#\ %.%#                                 " Ignore lines beginning with '#' ('# command-line-arguments' line sometimes appears?)
+CompilerSet errorformat+=%-G%.%#panic:\ %m                          " Ignore lines containing 'panic: message'
+CompilerSet errorformat+=%Ecan\'t\ load\ package:\ %m               " Start of multiline error string is 'can\'t load package'
+CompilerSet errorformat+=%A%\\%%(%[%^:]%\\+:\ %\\)%\\?%f:%l:%c:\ %m " Start of multiline unspecified string is 'filename:linenumber:columnnumber:'
+CompilerSet errorformat+=%A%\\%%(%[%^:]%\\+:\ %\\)%\\?%f:%l:\ %m    " Start of multiline unspecified string is 'filename:linenumber:'
+CompilerSet errorformat+=%C%*\\s%m                                  " Continuation of multiline error message is indented
+CompilerSet errorformat+=%-G%.%#                                    " All lines not matching any of the above patterns are ignored
 let &cpo = s:save_cpo
 unlet s:save_cpo
 


### PR DESCRIPTION
##### adjust default errorformat

Adjust the default error format to handle compilation errors when
running `go vet`.


##### prefix local variables with l:


Fixes #2484 