### PR TITLE
lint: do not call go tool vet

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -143,7 +143,7 @@ function! go#lint#Vet(bang, ...) abort
   if a:0 == 0
     let [l:out, l:err] = go#util#Exec(['go', 'vet', go#package#ImportPath()])
   else
-    let [l:out, l:err] = go#util#ExecInDir(['go', 'tool', 'vet'] + a:000)
+    let [l:out, l:err] = go#util#Exec(['go', 'vet'] + a:000 + [go#package#ImportPath()])
   endif
 
   let l:listtype = go#list#Type("GoVet")

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -249,9 +249,7 @@ COMMANDS                                                         *go-commands*
     not guarantee all reports are genuine problems, but it can find errors not
     caught by the compilers.
 
-    You may optionally pass any valid go tool vet flags/options. In this case,
-    `go tool vet` is run in place of `go vet`. For a full list please see
-    `go tool vet -h`.
+    You may optionally pass any valid go vet flags/options.
 
     If [!] is not given the first error is jumped to.
 


### PR DESCRIPTION
Go 1.13's `go tool vet` cannot be invoked from the command line, so call
`go vet` instead.