### PR TITLE
Dropping support for the depreciated gometalinter tool

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -11,7 +11,7 @@ function! go#lint#Gometa(bang, autosave, ...) abort
 
   let l:metalinter = go#config#MetalinterCommand()
 
-  if l:metalinter == 'gometalinter' || l:metalinter == 'golangci-lint'
+  if l:metalinter == 'golangci-lint'
     let cmd = s:metalintercmd(l:metalinter)
     if empty(cmd)
       return
@@ -32,14 +32,7 @@ function! go#lint#Gometa(bang, autosave, ...) abort
     " will be cleared
     redraw
 
-    if l:metalinter == "gometalinter"
-      " Include only messages for the active buffer for autosave.
-      let include = [printf('--include=^%s:.*$', fnamemodify(expand('%:p'), ":."))]
-      if go#util#has_job()
-        let include = [printf('--include=^(vet: \.[\\/])?%s:.*$', expand('%:p:t'))]
-      endif
-      let cmd += include
-    elseif l:metalinter == "golangci-lint"
+    if l:metalinter == "golangci-lint"
       let goargs[0] = expand('%:p:h')
     endif
   endif
@@ -52,18 +45,10 @@ function! go#lint#Gometa(bang, autosave, ...) abort
 
   let cmd += goargs
 
-  if l:metalinter == "gometalinter"
-    " Gometalinter can output one of the two, so we look for both:
-    "   <file>:<line>:<column>:<severity>: <message> (<linter>)
-    "   <file>:<line>::<severity>: <message> (<linter>)
-    " This can be defined by the following errorformat:
-    let errformat = "%f:%l:%c:%t%*[^:]:\ %m,%f:%l::%t%*[^:]:\ %m"
-  else
-    " Golangci-lint can output the following:
-    "   <file>:<line>:<column>: <message> (<linter>)
-    " This can be defined by the following errorformat:
-    let errformat = "%f:%l:%c:\ %m"
-  endif
+  " Golangci-lint can output the following:
+  "   <file>:<line>:<column>: <message> (<linter>)
+  " This can be defined by the following errorformat:
+  let errformat = "%f:%l:%c:\ %m"
 
   if go#util#has_job()
     call s:lint_job({'cmd': cmd, 'statustype': l:metalinter, 'errformat': errformat}, a:bang, a:autosave)
@@ -232,9 +217,7 @@ function! s:lint_job(args, bang, autosave)
 
   if a:autosave
     let l:opts.for = "GoMetaLinterAutoSave"
-    " s:metalinterautosavecomplete is really only needed for golangci-lint,
-    " but s:lint_job doesn't know whether golangci-lint is being called or
-    " whether gometalinter is being called, so hook it up in either case.
+    " s:metalinterautosavecomplete is really only needed for golangci-lint
     let l:opts.complete = funcref('s:metalinterautosavecomplete', [expand('%:p:t')])
   endif
 
@@ -248,26 +231,11 @@ function! s:metalintercmd(metalinter)
   let l:cmd = []
   let bin_path = go#path#CheckBinPath(a:metalinter)
   if !empty(bin_path)
-    if a:metalinter == "gometalinter"
-      let l:cmd = s:gometalintercmd(bin_path)
-    elseif a:metalinter == "golangci-lint"
+    if a:metalinter == "golangci-lint"
       let l:cmd = s:golangcilintcmd(bin_path)
     endif
   endif
 
-  return cmd
-endfunction
-
-function! s:gometalintercmd(bin_path)
-  let cmd = [a:bin_path]
-  let cmd += ["--disable-all"]
-
-  " gometalinter has a --tests flag to tell its linters whether to run
-  " against tests. While not all of its linters respect this flag, for those
-  " that do, it means if we don't pass --tests, the linter won't run against
-  " test files. One example of a linter that will not run against tests if
-  " we do not specify this flag is errcheck.
-  let cmd += ["--tests"]
   return cmd
 endfunction
 

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -2,10 +2,6 @@
 let s:cpo_save = &cpo
 set cpo&vim
 
-func! Test_Gometa() abort
-  call s:gometa('gometalinter')
-endfunc
-
 func! Test_GometaGolangciLint() abort
   call s:gometa('golangci-lint')
 endfunc
@@ -44,10 +40,6 @@ func! s:gometa(metalinter) abort
       call call(RestoreGOPATH, [])
       unlet g:go_metalinter_enabled
   endtry
-endfunc
-
-func! Test_GometaAutoSave() abort
-  call s:gometaautosave('gometalinter')
 endfunc
 
 func! Test_GometaAutoSaveGolangciLint() abort

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -17,7 +17,7 @@ func! s:gometa(metalinter) abort
         \ ]
     if a:metalinter == 'golangci-lint'
       let expected = [
-            \ {'lnum': 5, 'bufnr': bufnr('%')+1, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function `MissingFooDoc` should have comment or be unexported (golint)'}
+            \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function `MissingFooDoc` should have comment or be unexported (golint)'}
           \ ]
     endif
 

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -17,7 +17,7 @@ func! s:gometa(metalinter) abort
         \ ]
     if a:metalinter == 'golangci-lint'
       let expected = [
-            \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function `MissingFooDoc` should have comment or be unexported (golint)'}
+            \ {'lnum': 5, 'bufnr': bufnr('%')+2, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function `MissingFooDoc` should have comment or be unexported (golint)'}
           \ ]
     endif
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -51,7 +51,7 @@ experience.
   * Precise type-safe renaming of identifiers with |:GoRename|.
   * See which code is covered by tests with |:GoCoverage|.
   * Add or remove tags on struct fields with |:GoAddTags| and |:GoRemoveTags|.
-  * Call `gometalinter` with |:GoMetaLinter| to invoke all possible linters
+  * Call `golangci-lint` with |:GoMetaLinter| to invoke all possible linters
     (`golint`, `vet`, `errcheck`, `deadcode`, etc.) and put the result in the
     quickfix or location list.
   * Lint your code with |:GoLint|, run your code through |:GoVet| to catch
@@ -652,7 +652,7 @@ CTRL-t
                                                                *:GoMetaLinter*
 :GoMetaLinter! [path]
 
-    Calls the underlying `gometalinter` tool and displays all warnings and
+    Calls the underlying `golangci-lint` tool and displays all warnings and
     errors in the |quickfix| window. By default the following linters are
     enabled: `vet`, `golint`, and `errcheck`. This can be changed with the
     |'g:go_metalinter_enabled'| variable. To override the command completely
@@ -833,7 +833,7 @@ CTRL-t
 
     Toggles |'g:go_metalinter_autosave'|.
 
-    By default, `gometalinter` messages will be shown in the |location-list|
+    By default, `golangci-lint` messages will be shown in the |location-list|
     window. The list to use can be set using |'g:go_list_type_commands'|.
 
                                                  *:GoTemplateAutoCreateToggle*
@@ -1512,7 +1512,7 @@ function when using the `af` text object. By default it's enabled. >
 Use this option to auto |:GoMetaLinter| on save. Only linter messages for
 the active buffer will be shown.
 
-By default, `gometalinter` messages will be shown in the |location-list|
+By default, `golangci-lint` messages will be shown in the |location-list|
 window. The list to use can be set using |'g:go_list_type_commands'|.
 
  By default it's disabled >
@@ -1541,12 +1541,11 @@ it's empty
 <
                                                    *'g:go_metalinter_command'*
 
-Overrides the command to be executed when |:GoMetaLinter| is called.  By
-default it's `gometalinter`. `golangci-lint` is also supported. It can also be
-used as an advanced setting for users who want to have more control over
-the metalinter.
+Overrides the command to be executed when |:GoMetaLinter| is called. By
+default it's `golangci-lint`. It can also be used as an advanced setting
+for users who want to have more control over the metalinter.
 >
-  let g:go_metalinter_command = "gometalinter"
+  let g:go_metalinter_command = "golangci-lint"
 <
                                                   *'g:go_metalinter_deadline'*
 
@@ -2351,9 +2350,9 @@ while saving and opening files. The following fixes this:
  let g:syntastic_go_checkers = ['golint', 'govet']
  let g:syntastic_mode_map = { 'mode': 'active', 'passive_filetypes': ['go'] }
 <
-If you want to add errcheck you can use gometalinter as a wrapper
+If you want to add errcheck you can use golangci-lint as a wrapper:
 >
- let g:syntastic_go_checkers = ['golint', 'govet', 'gometalinter']
+ let g:syntastic_go_checkers = ['golint', 'govet', 'golangci-lint']
  let g:syntastic_go_gometalinter_args = ['--disable-all', '--enable=errcheck']
  let g:syntastic_mode_map = { 'mode': 'active', 'passive_filetypes': ['go'] }
 <

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -57,7 +57,6 @@ let s:packages = {
       \ 'goimports':     ['golang.org/x/tools/cmd/goimports'],
       \ 'golint':        ['golang.org/x/lint/golint'],
       \ 'gopls':         ['golang.org/x/tools/gopls@latest', {}, {'after': function('go#lsp#Restart', [])}],
-      \ 'gometalinter':  ['github.com/alecthomas/gometalinter'],
       \ 'golangci-lint': ['github.com/golangci/golangci-lint/cmd/golangci-lint'],
       \ 'gomodifytags':  ['github.com/fatih/gomodifytags'],
       \ 'gorename':      ['golang.org/x/tools/cmd/gorename'],
@@ -192,6 +191,8 @@ function! s:GoInstallBinaries(updateBinaries, ...)
         endif
 
         " GO111MODULE must be off to install gometalinter.
+        " TODO: determine if this line is still needed now that gometalinter
+        " has been depreciated
         let Restore_modules = go#util#SetEnv('GO111MODULE', 'off')
 
         " first download the binary

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -190,9 +190,6 @@ function! s:GoInstallBinaries(updateBinaries, ...)
           let l:get_cmd += ['-u']
         endif
 
-        " GO111MODULE must be off to install gometalinter.
-        " TODO: determine if this line is still needed now that gometalinter
-        " has been depreciated
         let Restore_modules = go#util#SetEnv('GO111MODULE', 'off')
 
         " first download the binary


### PR DESCRIPTION
As per issue #2489, since the gometalinter tool is deprecated and archived, I think a number of references to the gometalinter tool, as well as a number of lines of dedicated logic, can be removed. 

I believe additional logic could be taken out (see the TODO added to line 194 in the `plugin/go.vim` file), however, in the interest of keeping the changeset minimal and to avoid possible regressions, I have been conservative in the amount of lines deleted.

Also probably some of the documentation could be adjusted to mention that primary supported meta-linting tool is [golangci-lint](https://github.com/golangci/golangci-lint), but likely that can be left for a future ticket.

Let me know what you think or whether I overlooked anything :)