### PR TITLE
Removing logic needed to support Vim 7.4 as it has been dropped.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ notifications:
   email: false
 matrix:
   include:
-    - env: SCRIPT="test -c" VIM_VERSION=vim-7.4
     - env: SCRIPT="test -c" VIM_VERSION=vim-8.0
     - env: SCRIPT="test -c" VIM_VERSION=nvim
     - env: ENV=vimlint SCRIPT=lint VIM_VERSION=vim-8.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ USER vim-go
 COPY . /vim-go/
 WORKDIR /vim-go
 
-RUN scripts/install-vim vim-7.4
 RUN scripts/install-vim vim-8.0
 RUN scripts/install-vim nvim
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VIMS ?= vim-7.4 vim-8.0 nvim
+VIMS ?= vim-8.0 nvim
 
 all: install lint test
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This plugin adds Go language support for Vim, with the following main features:
 
 ## Install
 
-vim-go requires at least Vim 7.4.2009 or Neovim 0.3.1.
+vim-go requires at least Vim 8.0.1542 or Neovim 0.3.1.
 
 The [**latest stable release**](https://github.com/fatih/vim-go/releases/latest) is the
 recommended version to use. If you choose to use the master branch instead,

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -32,12 +32,47 @@ function! go#cmd#Build(bang, ...) abort
         \ map(copy(a:000), "expand(v:val)") +
         \ [".", "errors"]
 
-  call s:cmd_job({
-        \ 'cmd': ['go'] + args,
-        \ 'bang': a:bang,
-        \ 'for': 'GoBuild',
-        \ 'statustype': 'build'
-        \})
+  " Vim and Neovim async
+  if go#util#has_job()
+    call s:cmd_job({
+          \ 'cmd': ['go'] + args,
+          \ 'bang': a:bang,
+          \ 'for': 'GoBuild',
+          \ 'statustype': 'build'
+          \})
+
+  " Vim without async
+  else
+    let default_makeprg = &makeprg
+    let &makeprg = "go " . join(go#util#Shelllist(args), ' ')
+
+    let l:listtype = go#list#Type("GoBuild")
+    " execute make inside the source folder so we can parse the errors
+    " correctly
+    let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
+    let dir = getcwd()
+    try
+      execute cd . fnameescape(expand("%:p:h"))
+      if l:listtype == "locationlist"
+        silent! exe 'lmake!'
+      else
+        silent! exe 'make!'
+      endif
+      redraw!
+    finally
+      execute cd . fnameescape(dir)
+      let &makeprg = default_makeprg
+    endtry
+
+    let errors = go#list#Get(l:listtype)
+    call go#list#Window(l:listtype, len(errors))
+    if !empty(errors) && !a:bang
+      call go#list#JumpToFirst(l:listtype)
+    else
+      call go#util#EchoSuccess("[build] SUCCESS")
+    endif
+  endif
+
 endfunction
 
 

--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -32,46 +32,12 @@ function! go#cmd#Build(bang, ...) abort
         \ map(copy(a:000), "expand(v:val)") +
         \ [".", "errors"]
 
-  " Vim and Neovim async.
-  if go#util#has_job()
-    call s:cmd_job({
-          \ 'cmd': ['go'] + args,
-          \ 'bang': a:bang,
-          \ 'for': 'GoBuild',
-          \ 'statustype': 'build'
-          \})
-
-  " Vim 7.4 without async
-  else
-    let default_makeprg = &makeprg
-    let &makeprg = "go " . join(go#util#Shelllist(args), ' ')
-
-    let l:listtype = go#list#Type("GoBuild")
-    " execute make inside the source folder so we can parse the errors
-    " correctly
-    let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
-    let dir = getcwd()
-    try
-      execute cd . fnameescape(expand("%:p:h"))
-      if l:listtype == "locationlist"
-        silent! exe 'lmake!'
-      else
-        silent! exe 'make!'
-      endif
-      redraw!
-    finally
-      execute cd . fnameescape(dir)
-      let &makeprg = default_makeprg
-    endtry
-
-    let errors = go#list#Get(l:listtype)
-    call go#list#Window(l:listtype, len(errors))
-    if !empty(errors) && !a:bang
-      call go#list#JumpToFirst(l:listtype)
-    else
-      call go#util#EchoSuccess("[build] SUCCESS")
-    endif
-  endif
+  call s:cmd_job({
+        \ 'cmd': ['go'] + args,
+        \ 'bang': a:bang,
+        \ 'for': 'GoBuild',
+        \ 'statustype': 'build'
+        \})
 endfunction
 
 

--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -25,12 +25,6 @@ endfunction
 " the code. Calling it again reruns the tests and shows the last updated
 " coverage.
 function! go#coverage#Buffer(bang, ...) abort
-  " we use matchaddpos() which was introduce with 7.4.330, be sure we have
-  " it: http://ftp.vim.org/vim/patches/7.4/7.4.330
-  if !exists("*matchaddpos")
-    call go#util#EchoError("GoCoverage is supported with Vim version 7.4-330 or later")
-    return -1
-  endif
 
   " check if there is any test file, if not we just return
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '

--- a/autoload/go/coverage.vim
+++ b/autoload/go/coverage.vim
@@ -26,6 +26,12 @@ endfunction
 " coverage.
 function! go#coverage#Buffer(bang, ...) abort
 
+  " check if the version of Vim being tested supports matchaddpos()
+  if !exists("*matchaddpos")
+    call go#util#EchoError("GoCoverage is not supported by your version of Vim.")
+    return -1
+  endif
+
   " check if there is any test file, if not we just return
   let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
   let dir = getcwd()

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -120,18 +120,11 @@ function! go#fmt#update_file(source, target)
 
   let l:listtype = go#list#Type("GoFmt")
 
-  " the title information was introduced with 7.4-2200
-  " https://github.com/vim/vim/commit/d823fa910cca43fec3c31c030ee908a14c272640
-  if has('patch-7.4.2200')
-    " clean up previous list
-    if l:listtype == "quickfix"
-      let l:list_title = getqflist({'title': 1})
-    else
-      let l:list_title = getloclist(0, {'title': 1})
-    endif
+  " clean up previous list
+  if l:listtype == "quickfix"
+    let l:list_title = getqflist({'title': 1})
   else
-    " can't check the title, so assume that the list was for go fmt.
-    let l:list_title = {'title': 'Format'}
+    let l:list_title = getloclist(0, {'title': 1})
   endif
 
   if has_key(l:list_title, "title") && l:list_title['title'] == "Format"

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -232,6 +232,13 @@ function! go#guru#Describe(selected) abort
 endfunction
 
 function! go#guru#DescribeInfo(showstatus) abort
+
+  " check if the version of Vim being tested supports json_decode()
+  if !exists("*json_decode")
+    call go#util#EchoError("GoDescribeInfo requires 'json_decode'. Update your Vim/Neovim version.")
+    return
+  endif
+
   let args = {
         \ 'mode': 'describe',
         \ 'format': 'json',
@@ -408,6 +415,19 @@ function! go#guru#Referrers(selected) abort
 endfunction
 
 function! go#guru#SameIds(showstatus) abort
+
+  " check if the version of Vim being tested supports matchaddpos()
+  if !exists("*matchaddpos")
+    call go#util#EchoError("GoSameIds requires 'matchaddpos'. Update your Vim/Neovim version.")
+    return
+  endif
+
+  " check if the version of Vim being tested supports json_decode()
+  if !exists("*json_decode")
+    call go#util#EchoError("GoSameIds requires 'json_decode'. Update your Vim/Neovim version.")
+    return
+  endif
+
   let args = {
         \ 'mode': 'what',
         \ 'format': 'json',
@@ -576,6 +596,12 @@ endfunction
 function! go#guru#DescribeBalloon() abort
   " don't even try if async isn't available.
   if !go#util#has_job()
+    return
+  endif
+
+  " check if the version of Vim being tested supports json_decode()
+  if !exists("*json_decode")
+    call go#util#EchoError("GoDescribeBalloon requires 'json_decode'. Update your Vim/Neovim version.")
     return
   endif
 

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -232,14 +232,6 @@ function! go#guru#Describe(selected) abort
 endfunction
 
 function! go#guru#DescribeInfo(showstatus) abort
-  " json_encode() and friends are introduced with this patch (7.4.1304)
-  " vim: https://groups.google.com/d/msg/vim_dev/vLupTNhQhZ8/cDGIk0JEDgAJ
-  " nvim: https://github.com/neovim/neovim/pull/4131
-  if !exists("*json_decode")
-    call go#util#EchoError("requires 'json_decode'. Update your Vim/Neovim version.")
-    return
-  endif
-
   let args = {
         \ 'mode': 'describe',
         \ 'format': 'json',
@@ -416,21 +408,6 @@ function! go#guru#Referrers(selected) abort
 endfunction
 
 function! go#guru#SameIds(showstatus) abort
-  " we use matchaddpos() which was introduce with 7.4.330, be sure we have
-  " it: http://ftp.vim.org/vim/patches/7.4/7.4.330
-  if !exists("*matchaddpos")
-    call go#util#EchoError("GoSameIds requires 'matchaddpos'. Update your Vim/Neovim version.")
-    return
-  endif
-
-  " json_encode() and friends are introduced with this patch (7.4.1304)
-  " vim: https://groups.google.com/d/msg/vim_dev/vLupTNhQhZ8/cDGIk0JEDgAJ
-  " nvim: https://github.com/neovim/neovim/pull/4131
-  if !exists("*json_decode")
-    call go#util#EchoError("GoSameIds requires 'json_decode'. Update your Vim/Neovim version.")
-    return
-  endif
-
   let args = {
         \ 'mode': 'what',
         \ 'format': 'json',
@@ -599,14 +576,6 @@ endfunction
 function! go#guru#DescribeBalloon() abort
   " don't even try if async isn't available.
   if !go#util#has_job()
-    return
-  endif
-
-  " json_encode() and friends are introduced with this patch (7.4.1304)
-  " vim: https://groups.google.com/d/msg/vim_dev/vLupTNhQhZ8/cDGIk0JEDgAJ
-  " nvim: https://github.com/neovim/neovim/pull/4131
-  if !exists("*json_decode")
-    call go#util#EchoError("requires 'json_decode'. Update your Vim/Neovim version.")
     return
   endif
 

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -49,13 +49,10 @@ endfunction
 function! go#list#Populate(listtype, items, title) abort
   if a:listtype == "locationlist"
     call setloclist(0, a:items, 'r')
-
-    " The last argument ({what}) is introduced with 7.4.2200:
-    " https://github.com/vim/vim/commit/d823fa910cca43fec3c31c030ee908a14c272640
-    if has("patch-7.4.2200") | call setloclist(0, [], 'a', {'title': a:title}) | endif
+    call setloclist(0, [], 'a', {'title': a:title})
   else
     call setqflist(a:items, 'r')
-    if has("patch-7.4.2200") | call setqflist([], 'a', {'title': a:title}) | endif
+    call setqflist([], 'a', {'title': a:title})
   endif
 endfunction
 
@@ -80,10 +77,10 @@ endfunction
 function! go#list#Parse(listtype, items, title) abort
   if a:listtype == "locationlist"
     lgetexpr a:items
-    if has("patch-7.4.2200") | call setloclist(0, [], 'a', {'title': a:title}) | endif
+    call setloclist(0, [], 'a', {'title': a:title})
   else
     cgetexpr a:items
-    if has("patch-7.4.2200") | call setqflist([], 'a', {'title': a:title}) | endif
+    call setqflist([], 'a', {'title': a:title})
   endif
 endfunction
 

--- a/autoload/go/mod.vim
+++ b/autoload/go/mod.vim
@@ -83,18 +83,11 @@ function! go#mod#update_file(source, target)
 
   let l:listtype = go#list#Type("GoModFmt")
 
-  " the title information was introduced with 7.4-2200
-  " https://github.com/vim/vim/commit/d823fa910cca43fec3c31c030ee908a14c272640
-  if has('patch-7.4.2200')
-    " clean up previous list
-    if l:listtype == "quickfix"
-      let l:list_title = getqflist({'title': 1})
-    else
-      let l:list_title = getloclist(0, {'title': 1})
-    endif
+  " clean up previous list
+  if l:listtype == "quickfix"
+    let l:list_title = getqflist({'title': 1})
   else
-    " can't check the title, so assume that the list was for go fmt.
-    let l:list_title = {'title': 'Format'}
+    let l:list_title = getloclist(0, {'title': 1})
   endif
 
   if has_key(l:list_title, "title") && l:list_title['title'] == "Format"

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -77,7 +77,7 @@ experience.
 ==============================================================================
 INSTALL                                                           *go-install*
 
-vim-go requires at least Vim 7.4.2009 or Neovim 0.3.1. On macOS, if you are
+vim-go requires at least Vim 8.0.1542 or Neovim 0.3.2. On macOS, if you are
 still using your system version of vim, you can use homebrew to keep your
 version of Vim up-to-date with the following terminal command:
 >
@@ -1202,7 +1202,7 @@ for Vim8 and Neovim.
                                                 *go#complete#GocodeComplete()*
 
 Uses `gocode` for autocompletion. By default, it is hooked up to |'omnifunc'|
-for Vim 7.4.
+for Vim 8+.
 
                                                    *go#tool#DescribeBalloon()*
 
@@ -2427,7 +2427,7 @@ To run tests vim-go comes with three small helper scripts:
   `scripts/test`          Run all tests with a Vim from `/tmp/vim-go-test/`.
 
 All scripts accept a Vim version as the first argument, which can be
-`vim-7.4`, `vim-8.0`, or `nvim`. You will need to install a Vim version with
+`vim-8.0` or `nvim`. You will need to install a Vim version with
 `install-vim` before you can use `run-vim` or `test`.
 
 You can install and test all Vim versions by running `make`.

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -9,30 +9,22 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 function! s:checkVersion() abort
-  " Not using the has('patch-7.4.2009') syntax because that wasn't added until
-  " 7.4.237, and we want to be sure this works for everyone (this is also why
-  " we're not using utils#EchoError()).
-  "
-  " Version 7.4.2009 was chosen because that's greater than what the most recent Ubuntu LTS
-  " release (16.04) uses and has a couple of features we need (e.g. execute()
-  " and :message clear).
-
   let l:unsupported = 0
   if go#config#VersionWarning() != 0
     if has('nvim')
       let l:unsupported = !has('nvim-0.3.2')
     else
-      let l:unsupported = (v:version < 704 || (v:version == 704 && !has('patch2009')))
+      let l:unsupported = v:version < 800
     endif
 
     if l:unsupported == 1
       echohl Error
-      echom "vim-go requires Vim 7.4.2009 or Neovim 0.3.2, but you're using an older version."
+      echom "vim-go requires Vim 8+ or Neovim 0.3.2, but you're using an older version."
       echom "Please update your Vim for the best vim-go experience."
       echom "If you really want to continue you can set this to make the error go away:"
       echom "    let g:go_version_warning = 0"
       echom "Note that some features may error out or behave incorrectly."
-      echom "Please do not report bugs unless you're using Vim 7.4.2009 or newer or Neovim 0.3.2."
+      echom "Please do not report bugs unless you're using Vim 8+ or Neovim 0.3.2."
       echohl None
 
       " Make sure people see this.

--- a/scripts/bench-syntax
+++ b/scripts/bench-syntax
@@ -13,7 +13,7 @@ cd "$vimgodir"
 
 if [ -z "${1:-}" ]; then
   echo "unknown version: '${1:-}'"
-  echo "First argument must be 'vim-7.4', 'vim-8.0', or 'nvim'."
+  echo "First argument must be 'vim-8.0' or 'nvim'."
   exit 1
 fi
 

--- a/scripts/install-vim
+++ b/scripts/install-vim
@@ -15,11 +15,6 @@ cd "$vimgodir"
 vim=${1:-}
 
 case "$vim" in
-  "vim-7.4")
-    tag="v7.4.2009"
-    giturl="https://github.com/vim/vim"
-    ;;
-
   "vim-8.0")
     # This follows the version in Arch Linux. Vim's master branch isn't always
     # stable, and we don't want to have the build fail because Vim introduced a
@@ -36,7 +31,7 @@ case "$vim" in
 
   *)
     echo "unknown version: '${1:-}'"
-    echo "First argument must be 'vim-7.4', 'vim-8.0', or 'nvim'."
+    echo "First argument must be 'vim-8.0' or 'nvim'."
     exit 1
     ;;
 esac

--- a/scripts/lint
+++ b/scripts/lint
@@ -11,7 +11,7 @@ cd "$vimgodir"
 #####################################
 if [ -z "${1:-}" ]; then
   echo "unknown version: '${1:-}'"
-  echo "First argument must be 'vim-7.4', 'vim-8.0', or 'nvim'."
+  echo "First argument must be 'vim-8.0' or 'nvim'."
 	exit 1
 fi
 

--- a/scripts/run-vim
+++ b/scripts/run-vim
@@ -17,7 +17,7 @@ shift $((OPTIND - 1))
 
 if [ -z "${1:-}" ]; then
   echo "unknown version: '${1:-}'"
-  echo "First argument must be 'vim-7.4', 'vim-8.0', or 'nvim'."
+  echo "First argument must be 'vim-8.0' or 'nvim'."
   exit 1
 fi
 

--- a/scripts/test
+++ b/scripts/test
@@ -40,7 +40,7 @@ shift $((OPTIND - 1))
 #####################################
 if [ -z "${1:-}" ]; then
   echo "unknown version: '${1:-}'"
-  echo "First argument must be 'vim-7.4', 'vim-8.0', or 'nvim'."
+  echo "First argument must be 'vim-8.0' or 'nvim'."
   exit 1
 fi
 


### PR DESCRIPTION
As per issue #2488, this branch removes Vim 7.4 support by deleting a number of checks for features that the Vim 7.4 series did not support. This also adjusts the tests and the Makefile, as well as small tweaks to the documentation in order to clarify that Vim 8.0.1542 or newer is the supported version; with that particular version of Vim 8 being chosen on account of its prior use in the `scripts/install-vim` file.

Let me know what you think...