### PR TITLE
require vim >= 8.0.1453

### DIFF
--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -72,9 +72,7 @@ function! go#job#Options(args)
         \ 'statustype' : ''
       \ }
 
-  if has("patch-8.0.0902") || has('nvim')
-    let cbs.cwd = state.jobdir
-  endif
+  let cbs.cwd = state.jobdir
 
   if has_key(a:args, 'bang')
     let state.bang = a:args.bang
@@ -295,11 +293,6 @@ function! go#job#Start(cmd, options)
     let l:manualcd = 1
     let dir = getcwd()
     execute l:cd fnameescape(filedir)
-  elseif !(has("patch-8.0.0902") || has('nvim'))
-    let l:manualcd = 1
-    let l:dir = l:options.cwd
-    execute l:cd fnameescape(l:dir)
-    call remove(l:options, 'cwd')
   endif
 
   if has_key(l:options, '_start')

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -62,18 +62,7 @@ endfunction
 " The (optional) first parameter can be added to indicate the 'cwd' or 'env'
 " parameters will be used, which wasn't added until a later version.
 function! go#util#has_job(...) abort
-  if has('nvim')
-    return 1
-  endif
-
-  " cwd and env parameters to job_start was added in this version.
-  if a:0 > 0 && a:1 is 1
-    return has('job') && has("patch-8.0.0902")
-  endif
-
-  " job was introduced in 7.4.xxx however there are multiple bug fixes and one
-  " of the latest is 8.0.0087 which is required for a stable async API.
-  return has('job') && has("patch-8.0.0087")
+  return has('job') || has('nvim')
 endfunction
 
 let s:env_cache = {}

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -77,7 +77,7 @@ experience.
 ==============================================================================
 INSTALL                                                           *go-install*
 
-vim-go requires at least Vim 8.0.1542 or Neovim 0.3.2. On macOS, if you are
+vim-go requires at least Vim 8.0.1453 or Neovim 0.3.2. On macOS, if you are
 still using your system version of vim, you can use homebrew to keep your
 version of Vim up-to-date with the following terminal command:
 >

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -14,17 +14,17 @@ function! s:checkVersion() abort
     if has('nvim')
       let l:unsupported = !has('nvim-0.3.2')
     else
-      let l:unsupported = v:version < 800
+      let l:unsupported = !has('patch-8.0.1453')
     endif
 
     if l:unsupported == 1
       echohl Error
-      echom "vim-go requires Vim 8+ or Neovim 0.3.2, but you're using an older version."
+      echom "vim-go requires at least Vim 8.0.1453 or Neovim 0.3.2, but you're using an older version."
       echom "Please update your Vim for the best vim-go experience."
       echom "If you really want to continue you can set this to make the error go away:"
       echom "    let g:go_version_warning = 0"
       echom "Note that some features may error out or behave incorrectly."
-      echom "Please do not report bugs unless you're using Vim 8+ or Neovim 0.3.2."
+      echom "Please do not report bugs unless you're using at least Vim 8.0.1453 or Neovim 0.3.2."
       echohl None
 
       " Make sure people see this.

--- a/scripts/install-vim
+++ b/scripts/install-vim
@@ -16,10 +16,10 @@ vim=${1:-}
 
 case "$vim" in
   "vim-8.0")
-    # This follows the version in Arch Linux. Vim's master branch isn't always
+    # This follows the version in Ubuntu LTS. Vim's master branch isn't always
     # stable, and we don't want to have the build fail because Vim introduced a
     # bug.
-    tag="v8.0.1542"
+    tag="v8.0.1453"
     giturl="https://github.com/vim/vim"
     ;;
 


### PR DESCRIPTION
Update the minimum required version of Vim to 8.0.1453. 8.0.1453 is the
current version that comes with Ubuntu LTS.

Since 8.0.1453 satifies all the patch requirements for vim-go, remove
the checks for patches that will be present in 8.0.1453.