### PR TITLE
Implement logic to set gopls as a formatting tool for vim-go.

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -3,7 +3,7 @@
 " license that can be found in the LICENSE file.
 "
 " fmt.vim: Vim command to format Go files with gofmt (and gofmt compatible
-" toorls, such as goimports).
+" tools, such as goimports).
 
 " don't spam the user when Vim is started in Vi compatibility mode
 let s:cpo_save = &cpo
@@ -144,7 +144,14 @@ endfunction
 
 " fmt_cmd returns the command to run as a list.
 function! s:fmt_cmd(bin_name, source, target)
-  let l:cmd = [a:bin_name, '-w']
+
+  " if gopls then syntax is: gopls format -w /path/to/file.go,
+  " else for gofmt and goimports, simply add a -w flag
+  if a:bin_name is# 'gopls'
+    let l:cmd = [a:bin_name, 'format', '-w']
+  else
+    let l:cmd = [a:bin_name, '-w']
+  endif
 
   " add the options for binary (if any). go_fmt_options was by default of type
   " string, however to allow customization it's now a dictionary of binary

--- a/autoload/go/fmt_test.vim
+++ b/autoload/go/fmt_test.vim
@@ -50,6 +50,23 @@ func! Test_goimports() abort
   call assert_equal(expected, actual)
 endfunc
 
+func! Test_run_gopls() abort
+  " unlike gofmt or goimports, in gopls the temporary file used here in
+  " must end with a .go suffix otherwise it will throw an error message
+  let actual_file = tempname() . ".go"
+  call writefile(readfile("test-fixtures/fmt/gopls/gopls.go"), actual_file)
+
+  let expected = join(readfile("test-fixtures/fmt/gopls/gopls_golden.go"), "\n")
+
+  " run our code
+  call go#fmt#run("gopls", actual_file, "test-fixtures/fmt/gopls/gopls.go")
+
+  " this should now contain the formatted code
+  let actual = join(readfile(actual_file), "\n")
+
+  call assert_equal(expected, actual)
+endfunc
+
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/autoload/go/test-fixtures/fmt/gopls/gopls.go
+++ b/autoload/go/test-fixtures/fmt/gopls/gopls.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+"fmt"
+)
+
+func main() {
+fmt.Println("vim-go")
+}

--- a/autoload/go/test-fixtures/fmt/gopls/gopls_golden.go
+++ b/autoload/go/test-fixtures/fmt/gopls/gopls_golden.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("vim-go")
+}


### PR DESCRIPTION
As per #2483, this offers the ability of the end-user to set a variable like the below in their vimrc file to enable `gopls` code formatting:

```
let g:go_fmt_command = "gopls"
```

Essentially all this does is change the command used to format code into something like:

```
gopls format -w /path/to/whatever/file/you/are/editting.go
```

I have also included a test case, similar to how there are tests for `gofmt` and `goimports` and it seems to pass. I have also been testing this on my own go code and have yet to experience any problems. However, testing from others would also be welcome.

All of this said, the topic of the issue seems to mention other variables, so please let me know if I am overlooking something obvious :)