### PR TITLE
term: change to originating window earlier

### DIFF
--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -96,6 +96,9 @@ function! s:on_stdout(job_id, data, event) dict abort
 endfunction
 
 function! s:on_exit(job_id, exit_status, event) dict abort
+  let l:winid = win_getid(winnr())
+  call win_gotoid(self.winid)
+
   " change to directory where test were run. if we do not do this
   " the quickfix items will have the incorrect paths. 
   " see: https://github.com/fatih/vim-go/issues/2400
@@ -103,8 +106,6 @@ function! s:on_exit(job_id, exit_status, event) dict abort
   let l:dir = getcwd()
   execute l:cd . fnameescape(expand("%:p:h"))
 
-  let l:winid = win_getid(winnr())
-  call win_gotoid(self.winid)
   let l:listtype = go#list#Type("_term")
 
   if a:exit_status == 0

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1641,7 +1641,7 @@ just like `:GoBuild`. By default it is disabled.
                                                    *'g:go_term_close_on_exit'*
 
 This option is Neovim only. If set to 1 it closes the terminal after the
-command run in it exits. By default it is enabled.
+command run in it exits when the command fails. By default it is enabled.
 >
   let g:go_term_close_on_exit = 1
 <


### PR DESCRIPTION
Change to the originating window before trying to change directories.

Clarify when the terminal window is closed in the help file.