### PR TITLE
Use `minimal` style for GoDoc popup windows in Neovim

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -111,9 +111,10 @@ function! s:GodocView(newposition, position, content) abort
             \ 'col': 0,
             \ 'width': width,
             \ 'height': height,
+            \ 'style': 'minimal',
             \ }
       call nvim_open_win(buf, v:true, opts)
-      setlocal nonumber norelativenumber nomodified nomodifiable filetype=godoc
+      setlocal nomodified nomodifiable filetype=godoc
 
       " close easily with CR, Esc and q
       noremap <buffer> <silent> <CR> :<C-U>close<CR>


### PR DESCRIPTION
This patch uses “minimal” style for floating windows to introduce more readability on `:GoDoc`.

See [:h nvim_open_win()](https://neovim.io/doc/user/api.html#nvim_open_win()).
See https://github.com/fatih/vim-go/pull/2451#discussion_r321139543