### PR TITLE
def: wrap switching buffers in a try/catch

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -162,9 +162,9 @@ function! go#def#jump_to_declaration(out, mode, bin_name) abort
   if filename != fnamemodify(expand("%"), ':p:gs?\\?/?')
     " jump to existing buffer if, 1. we have enabled it, 2. the buffer is loaded
     " and 3. there is buffer window number we switch to
-    if go#config#DefReuseBuffer() && bufloaded(filename) != 0 && bufwinnr(filename) != -1
-      " jumpt to existing buffer if it exists
-      execute bufwinnr(filename) . 'wincmd w'
+    if go#config#DefReuseBuffer() && bufwinnr(filename) != -1
+      " jump to existing buffer if it exists
+      call win_gotoid(bufwinnr(filename))
     else
       if &modified
         let cmd = 'hide edit'
@@ -186,7 +186,13 @@ function! go#def#jump_to_declaration(out, mode, bin_name) abort
       endif
 
       " open the file and jump to line and column
-      exec cmd fnameescape(fnamemodify(filename, ':.'))
+      try
+        exec cmd fnameescape(fnamemodify(filename, ':.'))
+      catch
+        if stridx(v:exception, ':E325:') < 0
+          call go#util#EchoError(v:exception)
+        endif
+      endtry
     endif
   endif
   call cursor(line, col)


### PR DESCRIPTION
Wrap the loading of the target buffer in a try/catch so that the
function doesn't abort if the buffer is loaded in another Vim session.

Unforunately, even with this solution there are problems. Namely, the
buffer ends up being empty, but at least executing `:edit` immediately
afterwards solves the problem.