### PR TITLE
Escape backslashes

### DIFF
--- a/autoload/go/package.vim
+++ b/autoload/go/package.vim
@@ -283,7 +283,7 @@ function! go#package#Complete(ArgLead, CmdLine, CursorPos) abort
         endif
 
         if dir !=# path
-          let candidate = substitute(candidate, '^' . dir, path, 'g')
+          let candidate = substitute(candidate, '^' . escape(dir, '\\'), path, 'g')
         else
           let candidate = candidate[len(dir)+1:]
         endif


### PR DESCRIPTION
Completion of `:GoImport` does not work since the path is not escaped.