### PR TITLE
Add syntax support for binary literals

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -166,11 +166,15 @@ syn match       goDecimalInt        "\<-\=\d\+\%([Ee][-+]\=\d\+\)\=\>"
 syn match       goHexadecimalInt    "\<-\=0[xX]\x\+\>"
 syn match       goOctalInt          "\<-\=0\o\+\>"
 syn match       goOctalError        "\<-\=0\o*[89]\d*\>"
+syn match       goBinaryInt         "\<-\=0[bB][01]\+\>"
+syn match       goBinaryError       "\<-\=0[bB][01]*[2-9]\+[01]*\>"
 
 hi def link     goDecimalInt        Integer
 hi def link     goHexadecimalInt    Integer
 hi def link     goOctalInt          Integer
 hi def link     goOctalError        Error
+hi def link     goBinaryInt         Integer
+hi def link     goBinaryError       Error
 hi def link     Integer             Number
 
 " Floating point


### PR DESCRIPTION
Adds syntax support for binary literals, [introduced in go 1.3](https://golang.org/doc/go1.13#language).

These will literals will now be highlighted as integers:

```go
x := 0b1100
y := 0B0100
```

And these will be marked as errors for obvious reasons:

```
x := 0b1102
y := 0B8001
```
