### PR TITLE
Add an option to choose between guru and gopls for :GoReferrers

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -485,6 +485,10 @@ function! go#config#Updatetime() abort
   return go_updatetime == 0 ? &updatetime : go_updatetime
 endfunction
 
+function! go#config#ReferrersMode() abort
+  return get(g:, 'go_referrers_mode', 'gopls')
+endfunction
+
 " Set the default value. A value of "1" is a shortcut for this, for
 " compatibility reasons.
 if exists("g:go_gorename_prefill") && g:go_gorename_prefill == 1

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -404,10 +404,26 @@ endfunction
 
 " Show all refs to entity denoted by selected identifier
 function! go#guru#Referrers(selected) abort
-  let [l:line, l:col] = getpos('.')[1:2]
-  let [l:line, l:col] = go#lsp#lsp#Position(l:line, l:col)
-  let l:fname = expand('%:p')
-  call go#lsp#Referrers(l:fname, l:line, l:col, funcref('s:parse_guru_output'))
+  let l:mode = go#config#ReferrersMode()
+  if l:mode == 'guru'
+    let args = {
+            \ 'mode': 'referrers',
+            \ 'format': 'plain',
+            \ 'selected': a:selected,
+            \ 'needs_scope': 0,
+            \ }
+
+    call s:run_guru(args)
+    return
+  elseif l:mode == 'gopls'
+    let [l:line, l:col] = getpos('.')[1:2]
+    let [l:line, l:col] = go#lsp#lsp#Position(l:line, l:col)
+    let l:fname = expand('%:p')
+    call go#lsp#Referrers(l:fname, l:line, l:col, funcref('s:parse_guru_output'))
+    return
+  else
+    call go#util#EchoWarning('unknown value for g:go_referrers_mode')
+  endif
 endfunction
 
 function! go#guru#SameIds(showstatus) abort

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -685,13 +685,20 @@ function! s:referencesHandler(next, msg) abort dict
     let l:fname = go#path#FromURI(l:loc.uri)
     let l:line = l:loc.range.start.line+1
     let l:bufnr = bufnr(l:fname)
+    let l:bufinfo = getbufinfo(l:fname)
 
     try
-      if l:bufnr == -1
-        let l:content = readfile(l:fname, '', l:line)[-1]
+      if l:bufnr == -1 || len(l:bufinfo) == 0 || l:bufinfo[0].loaded == 0
+        let l:filecontents = readfile(l:fname, '', l:line)
       else
-        let l:content = getbufline(l:fname, l:line)[-1]
+        let l:filecontents = getbufline(l:fname, l:line)
       endif
+
+      if len(l:filecontents) == 0
+        continue
+      endif
+
+      let l:content = l:filecontents[-1]
     catch
       call go#util#EchoError(printf('%s (line %s): %s at %s', l:fname, l:line, v:exception, v:throwpoint))
     endtry

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -681,6 +681,8 @@ endfunction
 function! s:referencesHandler(next, msg) abort dict
   let l:result = []
 
+  call sort(a:msg, funcref('s:compareLocations'))
+
   for l:loc in a:msg
     let l:fname = go#path#FromURI(l:loc.uri)
     let l:line = l:loc.range.start.line+1
@@ -974,6 +976,26 @@ endfunction
 
 function! s:debug(event, data, ...) abort
   call timer_start(10, function('s:debugasync', [a:event, a:data]))
+endfunction
+
+function! s:compareLocations(left, right) abort
+  if a:left.uri < a:right.uri
+    return -1
+  endif
+
+  if a:left.uri == a:right.uri && a:left.range.start.line < a:right.range.start.line
+    return -1
+  endif
+
+  if a:left.uri == a:right.uri && a:left.range.start.line == a:right.range.start.line && a:left.range.start.character < a:right.range.start.character
+    return -1
+  endif
+
+  if a:left.uri == a:right.uri && a:left.range.start.line == a:right.range.start.line && a:left.range.start.character == a:right.range.start.character
+    return 0
+  endif
+
+  return 1
 endfunction
 
 " restore Vi compatibility settings

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1407,11 +1407,11 @@ and `guru`.
 <
                                                        *'g:go_referrers_mode'*
 
-Use this option to define the command to be used for |:GoReferrers|. By default
-`gopls` is used, because it is the fastest and works with Go modules. One
-might also use `guru` for its ability to show references from other packages.
-This option will be removed after `gopls` can show references from other
-packages. Valid options are `gopls` and `guru`.
+Use this option to define the command to be used for |:GoReferrers|. By
+default `gopls` is used, because it is the fastest and works with Go modules.
+One might also use `guru` for its ability to show references from other
+packages.  This option will be removed after `gopls` can show references from
+other packages. Valid options are `gopls` and `guru`.
 >
   let g:go_referrers_mode = 'gopls'
 <

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1405,6 +1405,16 @@ and `guru`.
 >
   let g:go_def_mode = 'gopls'
 <
+                                                       *'g:go_referrers_mode'*
+
+Use this option to define the command to be used for |:GoReferrers|. By default
+`gopls` is used, because it is the fastest and works with Go modules. One
+might also use `guru` for its ability to show references from other packages.
+This option will be removed after `gopls` can show references from other
+packages. Valid options are `gopls` and `guru`.
+>
+  let g:go_referrers_mode = 'gopls'
+<
                                                   *'g:go_def_mapping_enabled'*
 
 Use this option to enable/disable the default mapping of CTRL-],


### PR DESCRIPTION
##### add g:go_referrers_mode

Add a new option, g:go_referrers_mode, so that users can choose to use
either guru or gopls for :GoReferrers, because gopls currently has a bug
that causes its textDocument/references implementation to only return
references from within the package of the identifier.

gopls is still the default, because guru doesn't work outside of GOPATH.


##### resolve :GoReferrers errors

Fix errors that occurred when running :GoReferrers more than once when
one of the references is in a file that is not loaded. On the first run,
readline() would be used to get the contents, but then on the second run
there is a buffer for the file that was previously not assigned a buffer
number, but it's an unloaded buffer, so getbufline() returned an empty
list.


##### sort references

Sort references so that the list will be in order based on filename,
line number, and start position. Prior to this, multiple invocations of
:GoReferrers would reorder the references and any given invocation may
find that references from the same file may not be in the document
order.

Fixes #2565 