### PR TITLE
lsp: add support for highlighting areas identified by gopls diagnostics

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -461,6 +461,14 @@ function! go#config#HighlightVariableDeclarations() abort
   return get(g:, 'go_highlight_variable_declarations', 0)
 endfunction
 
+function! go#config#HighlightDiagnosticErrors() abort
+  return get(g:, 'go_highlight_diagnostic_errors', 1)
+endfunction
+
+function! go#config#HighlightDiagnosticWarnings() abort
+  return get(g:, 'go_highlight_diagnostic_warnings', 1)
+endfunction
+
 function! go#config#HighlightDebug() abort
   return get(g:, 'go_highlight_debug', 1)
 endfunction

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -482,11 +482,15 @@ function! s:same_ids_highlight(exit_val, output, mode) abort
   endif
 
   let same_ids = result['sameids']
+
   " highlight the lines
+  let l:matches = []
   for item in same_ids
     let pos = split(item, ':')
-    call matchaddpos('goSameId', [[str2nr(pos[-2]), str2nr(pos[-1]), str2nr(poslen)]])
+    let l:matches = add(l:matches, [str2nr(pos[-2]), str2nr(pos[-1]), str2nr(poslen)])
   endfor
+
+  call matchaddpos('goSameId', l:matches)
 
   if go#config#AutoSameids()
     " re-apply SameIds at the current cursor position at the time the buffer
@@ -501,15 +505,7 @@ endfunction
 " ClearSameIds returns 0 when it removes goSameId groups and non-zero if no
 " goSameId groups are found.
 function! go#guru#ClearSameIds() abort
-  let l:cleared = 0
-
-  let m = getmatches()
-  for item in m
-    if item['group'] == 'goSameId'
-      call matchdelete(item['id'])
-      let l:cleared = 1
-    endif
-  endfor
+  let l:cleared = go#util#ClearGroupFromMatches('goSameId')
 
   if !l:cleared
     return 1

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -551,6 +551,24 @@ function! go#util#SetEnv(name, value) abort
   return function('go#util#SetEnv', [a:name, l:oldvalue], l:state)
 endfunction
 
+function! go#util#ClearGroupFromMatches(group) abort
+  if !exists("*matchaddpos")
+    return 0
+  endif
+
+  let l:cleared = 0
+
+  let m = getmatches()
+  for item in m
+    if item['group'] == a:group
+      call matchdelete(item['id'])
+      let l:cleared = 1
+    endif
+  endfor
+
+  return l:cleared
+endfunction
+
 function! s:unset(name) abort
   try
     " unlet $VAR was introducted in Vim 8.0.1832, which is newer than the

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2016,6 +2016,18 @@ Highlight variable names in variable assignments (`x` in `x =`).
 >
   let g:go_highlight_variable_assignments = 0
 <
+                                          *'g:go_highlight_diagnostic_errors'*
+
+Highlight diagnostic errors.
+>
+  let g:go_highlight_diagnostic_errors = 1
+<
+                                        *'g:go_highlight_diagnostic_warnings'*
+
+Highlight diagnostic warnings.
+>
+  let g:go_highlight_diagnostic_warnings = 1
+<
 
 ==============================================================================
                                            *gohtmltmpl* *ft-gohtmltmpl-syntax*

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -382,6 +382,8 @@ hi def link goCoverageNormalText Comment
 
 function! s:hi()
   hi def link goSameId Search
+  hi def link goDiagnosticError SpellBad
+  hi def link goDiagnosticWarning SpellRare
 
   " :GoCoverage commands
   hi def      goCoverageCovered    ctermfg=green guifg=#A6E22E


### PR DESCRIPTION
##### lsp: highlight text ranges reported in diagnostics

##### refactor same id highlighting to be more efficient

Call matchaddpos() only once per request instead of once on each match
in the results.

Factor the clearing of matches into its own function.

