### PR TITLE
syntax: improve highlighting of erroneous numerics

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -165,9 +165,9 @@ syn match       goSingleDecl        /\%(import\|var\|const\) [^(]\@=/ contains=g
 syn match       goDecimalInt        "\<-\=\d\+\%([Ee][-+]\=\d\+\)\=\>"
 syn match       goHexadecimalInt    "\<-\=0[xX]\x\+\>"
 syn match       goOctalInt          "\<-\=0\o\+\>"
-syn match       goOctalError        "\<-\=0\o*[89]\d*\>"
+syn match       goOctalError        "\<-\=0\o*[^ \t0-7]\S*\>"
 syn match       goBinaryInt         "\<-\=0[bB][01]\+\>"
-syn match       goBinaryError       "\<-\=0[bB][01]*[2-9]\+[01]*\>"
+syn match       goBinaryError       "\<-\=0[bB][01]*[^ \t01]\S*\>"
 
 hi def link     goDecimalInt        Integer
 hi def link     goHexadecimalInt    Integer


### PR DESCRIPTION
Highlight octal numbers that contain non-octal characters that are not
digits.

Highlight binary numbers that contain non-binary characters that are not
digits.