### PR TITLE
add  highlights for GoDecls + fzf

### DIFF
--- a/autoload/fzf/decls.vim
+++ b/autoload/fzf/decls.vim
@@ -121,10 +121,10 @@ function! s:source(mode,...) abort
           \ decl.col
           \)
     call add(ret_decls, printf("%s\t%s %s\t%s",
-          \ s:color(decl.ident . space, "Function"),
-          \ s:color(decl.keyword, "Keyword"),
-          \ s:color(pos, "SpecialComment"),
-          \ s:color(decl.full, "Comment"),
+          \ s:color(decl.ident . space, "goDeclsFzfFunction"),
+          \ s:color(decl.keyword, "goDeclsFzfKeyword"),
+          \ s:color(pos, "goDeclsFzfSpecialComment"),
+          \ s:color(decl.full, "goDeclsFzfComment"),
           \))
   endfor
 

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -383,6 +383,11 @@ hi def link goCoverageNormalText Comment
 function! s:hi()
   hi def link goSameId Search
 
+  hi def link goDeclsFzfKeyword        Keyword
+  hi def link goDeclsFzfFunction       Function
+  hi def link goDeclsFzfSpecialComment SpecialComment
+  hi def link goDeclsFzfComment        Comment
+
   " :GoCoverage commands
   hi def      goCoverageCovered    ctermfg=green guifg=#A6E22E
   hi def      goCoverageUncover    ctermfg=red guifg=#F92672


### PR DESCRIPTION
This PR enables us to change highlight color for fzf GoDecls as same as `goSameId` like below:

```vim
highlight! goDeclsFzfComment ctermbg=196 ctermfg=255 cterm=BOLD guibg=#ff0000 guifg=#eeeeee gui=BOLD
```

Even though  we can also change highlight color by modifying `Function` etc for now, I'd like to change the color just only fzf + GoDecls.