### PR TITLE
Fix regex for structs when expanding vars in debug

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -326,10 +326,10 @@ endfunction
 
 function! s:expand_var() abort
   " Get name from struct line.
-  let name = matchstr(getline('.'), '^[^:]\+\ze: [a-zA-Z0-9\.·]\+{\.\.\.}$')
+  let name = matchstr(getline('.'), '^[^:]\+\ze: \*\?[a-zA-Z0-9-_/\.]\+\({\.\.\.}\)\?$')
   " Anonymous struct
   if name == ''
-    let name = matchstr(getline('.'), '^[^:]\+\ze: struct {.\{-}}$')
+    let name = matchstr(getline('.'), '^[^:]\+\ze: \*\?struct {.\{-}}$')
   endif
 
   if name != ''


### PR DESCRIPTION
- Allow pointers.
- Allow hyphens, underscores and forward slashes in struct names as
they might be coming from external packages.
- Make the `{...}` bit optional as it doesn't always appear.