### PR TITLE
rename: add support for gopls rename

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -366,6 +366,11 @@ function! go#config#PlayOpenBrowser() abort
   return get(g:, "go_play_open_browser", 1)
 endfunction
 
+function! go#config#GorenameCommand() abort
+  " delegate to go#config#GorenameBin for backwards compatability.
+  return get(g:, "go_gorename_command", go#config#GorenameBin())
+endfunction
+
 function! go#config#GorenameBin() abort
   return get(g:, "go_gorename_bin", "gorename")
 endfunction

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1670,6 +1670,14 @@ By default it is set to edit.
 >
   let g:go_alternate_mode = "edit"
 <
+                                                     *'g:go_gorename_command'*
+
+Use this option to define which tool is used to rename. By default `gorename`
+is used. Valid options are `gorename` and `gopls`. Warning: as of `gopls`
+v0.2.0, it will only rename identifiers in the current package.
+>
+  let g:go_gorename_command = 'gorename'
+<
                                                      *'g:go_gorename_prefill'*
 
 Expression to prefill the new identifier when using |:GoRename| without any


### PR DESCRIPTION
* Add a new option, g:go_rename_command, to control whether `gorename`
  or `gopls rename` is used to rename identifiers.

Fixes #2366