### PR TITLE
Add simple use of interfunc tool

### DIFF
--- a/autoload/go/inter.vim
+++ b/autoload/go/inter.vim
@@ -1,0 +1,19 @@
+let s:cpo_save = &cpo
+set cpo&vim
+
+function! go#inter#InterFunc(...) abort
+  let pos = getpos('.')
+  let [result, err] = go#util#Exec(['interfunc', "-dir", fnameescape(expand('%:p:h')), a:1])
+  if err
+    call go#util#EchoError(result)
+    return
+  endif
+  silent put =result
+  call setpos('.', pos)
+endfunction
+
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -94,6 +94,8 @@ command! -nargs=? -complete=dir GoDeclsDir call go#decls#Decls(1, <q-args>)
 " -- impl
 command! -nargs=* -complete=customlist,go#impl#Complete GoImpl call go#impl#Impl(<f-args>)
 
+command! -nargs=1 GoInterFunc call go#inter#InterFunc(<f-args>)
+
 " -- template
 command! -nargs=0 GoTemplateAutoCreateToggle call go#template#ToggleAutoCreate()
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -61,6 +61,7 @@ let s:packages = {
       \ 'keyify':        ['honnef.co/go/tools/cmd/keyify@master'],
       \ 'motion':        ['github.com/fatih/motion@master'],
       \ 'iferr':         ['github.com/koron/iferr@master'],
+      \ 'interfunc':     ['github.com/andrewstuart/interfunc@master'],
 \ }
 
 " These commands are available on any filetypes


### PR DESCRIPTION
I got tired of hand-typing interface function implementations, a pattern I use often, so I wrote a quick and simple tool, and then vim-go hook to insert a known interface func signature at the cursor.