### PR TITLE
syntax: add tests for numeric highlighting

### DIFF
--- a/autoload/go/highlight_test.vim
+++ b/autoload/go/highlight_test.vim
@@ -98,6 +98,45 @@ function! Test_gomodVersion_incompatible_highlight() abort
   endtry
 endfunc
 
+function! Test_numeric_literal_highlight() abort
+  syntax on
+
+  let tests = {
+        \ 'integer': {'group': 'goDecimalInt', 'value': '1234567890'},
+        \ 'hexadecimal': {'group': 'goHexadecimalInt', 'value': '0x0123456789abdef'},
+        \ 'hexadecimalErrorLeading': {'group': 'goHexadecimalError', 'value': '0xg0123456789abdef'},
+        \ 'hexadecimalErrorTrailing': {'group': 'goHexadecimalError', 'value': '0x0123456789abdefg'},
+        \ 'heXadecimal': {'group': 'goHexadecimalInt', 'value': '0X0123456789abdef'},
+        \ 'heXadecimalErrorLeading': {'group': 'goHexadecimalError', 'value': '0Xg0123456789abdef'},
+        \ 'heXadecimalErrorTrailing': {'group': 'goHexadecimalError', 'value': '0X0123456789abdefg'},
+        \ 'octal': {'group': 'goOctalInt', 'value': '01234567'},
+        \ 'octalErrorLeading': {'group': 'goOctalError', 'value': '081234567'},
+        \ 'octalErrorTrailing': {'group': 'goOctalError', 'value': '012345678'},
+        \ 'binaryInt': {'group': 'goBinaryInt', 'value': '0b0101'},
+        \ 'binaryErrorLeading': {'group': 'goBinaryError', 'value': '0b20101'},
+        \ 'binaryErrorTrailing': {'group': 'goBinaryError', 'value': '0b01012'},
+        \ 'BinaryInt': {'group': 'goBinaryInt', 'value': '0B0101'},
+        \ 'BinaryErrorLeading': {'group': 'goBinaryError', 'value': '0B20101'},
+        \ 'BinaryErrorTrailing': {'group': 'goBinaryError', 'value': '0B01012'},
+        \ }
+
+  for kv in items(tests)
+    let l:dir = gotest#write_file(printf('numeric/%s.go', kv[0]), [
+          \ 'package numeric',
+          \ '',
+          \ printf("var v = %s\x1f", kv[1].value),
+          \ ])
+
+    try
+      let l:pos = getcurpos()
+      let l:actual = synIDattr(synID(l:pos[1], l:pos[2], 1), 'name')
+      call assert_equal(kv[1].group, l:actual, kv[0])
+    finally
+      " call delete(l:dir, 'rf')
+    endtry
+  endfor
+endfunction
+
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -162,11 +162,11 @@ endif
 syn match       goSingleDecl        /\%(import\|var\|const\) [^(]\@=/ contains=goImport,goVar,goConst
 
 " Integers
-syn match       goDecimalInt        "\<-\=\d\+\%([Ee][-+]\=\d\+\)\=\>"
+syn match       goDecimalInt        "\<-\=[1-9]\d*\%([Ee][-+]\=\d\+\)\=\>"
 syn match       goHexadecimalInt    "\<-\=0[xX]\x\+\>"
 syn match       goHexadecimalError  "\<-\=0[xX]\x*[^ \t0-9A-Fa-f]\S*\>"
 syn match       goOctalInt          "\<-\=0\o\+\>"
-syn match       goOctalError        "\<-\=0[^XxBb]\o*[^ \t0-7]\S*\>"
+syn match       goOctalError        "\<-\=0[XxBb]\@!\o*[^ \t0-7]\S*\>"
 syn match       goBinaryInt         "\<-\=0[bB][01]\+\>"
 syn match       goBinaryError       "\<-\=0[bB][01]*[^ \t01]\S*\>"
 

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -166,7 +166,7 @@ syn match       goDecimalInt        "\<-\=[1-9]\d*\%([Ee][-+]\=\d\+\)\=\>"
 syn match       goHexadecimalInt    "\<-\=0[xX]\x\+\>"
 syn match       goHexadecimalError  "\<-\=0[xX]\x*[^ \t0-9A-Fa-f]\S*\>"
 syn match       goOctalInt          "\<-\=0\o\+\>"
-syn match       goOctalError        "\<-\=0[XxBb]\@!\o*[^ \t0-7]\S*\>"
+syn match       goOctalError        "\<-\=0[XxBb\]]\@!\o*[^ \t0-7]\S*\>"
 syn match       goBinaryInt         "\<-\=0[bB][01]\+\>"
 syn match       goBinaryError       "\<-\=0[bB][01]*[^ \t01]\S*\>"
 


### PR DESCRIPTION
Add tests for numeric highlighting.

Fix a problem found by the tests in the highlighting of invalid octal
numbers.

Do not match octals as base10 integers.