### PR TITLE
impl: expect new TODO comment

### DIFF
--- a/autoload/go/impl_test.vim
+++ b/autoload/go/impl_test.vim
@@ -12,7 +12,7 @@ func! Test_impl() abort
     call go#impl#Impl('r', 'reader', 'io.Reader')
     call gotest#assert_buffer(1, [
           \ 'func (r reader) Read(p []byte) (n int, err error) {',
-          \ '	panic("not implemented")',
+          \ '	panic("not implemented") // TODO: Implement',
           \ '}'])
   finally
     call delete(l:tmp, 'rf')
@@ -33,7 +33,7 @@ func! Test_impl_get() abort
           \ 'type reader struct {}',
           \ '',
           \ 'func (r *reader) Read(p []byte) (n int, err error) {',
-          \ '	panic("not implemented")',
+          \ '	panic("not implemented") // TODO: Implement',
           \ '}'])
   finally
     call delete(l:tmp, 'rf')


### PR DESCRIPTION
Adjust the tests for go#impl#Impl to expect the new TODO comment added
by impl. (see
https://github.com/josharian/impl/commit/62b7c33fbc5165753d0cdab1a582b1b506df38da)