### PR TITLE
fmt: respect buffer-level go_fmt_options

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -351,7 +351,7 @@ function! go#config#FmtCommand() abort
 endfunction
 
 function! go#config#FmtOptions() abort
-  return get(g:, "go_fmt_options", {})
+  return get(b:, "go_fmt_options", get(g:, "go_fmt_options", {}))
 endfunction
 
 function! go#config#FmtFailSilently() abort

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1343,9 +1343,12 @@ The dictionary version allows you to define options for multiple binaries:
                                                           *'b:go_fmt_options'*
 
 This option is identical to |'g:go_fmt_options'|, but a buffer-level setting.
-If present, it's used instead of the global setting.  >
+If present, it's used instead of the global setting. By default it is not set.
 
-  au BufRead,BufNewFile *.go let b:go_fmt_options = {
+As an example, the following autocmd will configure goimports to put imports
+of packages from the current module in their own group:
+>
+  autocmd FileType go let b:go_fmt_options = {
     \ 'goimports': '-local ' .
       \ trim(system('{cd '. shellescape(expand('%:h')) .' && go list -m;}')),
     \ }

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1340,6 +1340,16 @@ The dictionary version allows you to define options for multiple binaries:
     \ 'goimports': '-local mycompany.com',
     \ }
 <
+                                                          *'b:go_fmt_options'*
+
+This option is identical to |'g:go_fmt_options'|, but a buffer-level setting.
+If present, it's used instead of the global setting.  >
+
+  au BufRead,BufNewFile *.go let b:go_fmt_options = {
+    \ 'goimports': '-local ' .
+      \ trim(system('{cd '. shellescape(expand('%:h')) .' && go list -m;}')),
+    \ }
+<
                                                     *'g:go_fmt_fail_silently'*
 
 Use this option to disable showing a location list when |'g:go_fmt_command'|


### PR DESCRIPTION
This commit enables looking at the buffer-level fmt_options variable.
An example use is provided in the documentation.

Signed-off-by: Hank Donnay <hdonnay@gmail.com>