### PR TITLE
Add build tags to GoVet, surface vet invocation errors

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -125,15 +125,20 @@ function! go#lint#Vet(bang, ...) abort
     call go#util#EchoProgress('calling vet...')
   endif
 
-  if a:0 == 0
-    let [l:out, l:err] = go#util#Exec(['go', 'vet', '-tags', go#config#BuildTags(), go#package#ImportPath()])
-  else
-    if empty(go#config#BuildTags())
-      let [l:out, l:err] = go#util#Exec(['go', 'vet'] + a:000 + [go#package#ImportPath()])
-    else
-      let [l:out, l:err] = go#util#Exec(['go', 'vet', '-tags', go#config#BuildTags()] + a:000 + [go#package#ImportPath()])
-    endif
+  let l:cmd = ['go', 'vet']
+
+  let buildtags = go#config#BuildTags()
+  if buildtags isnot ''
+    let cmd += ['-tags', buildtags]
   endif
+
+  if a:0 != 0
+    call extend(cmd, a:000)
+  endif
+
+  let cmd += [go#package#ImportPath()]
+
+  let [l:out, l:err] = go#util#Exec(l:cmd)
 
   let l:listtype = go#list#Type("GoVet")
   if l:err != 0


### PR DESCRIPTION
:wave: 
It doesn't look like values set in `:GoBuildTags` were being used with `:GoVet`. This should fix that. 

Since it didn't seem to surface elsewhere, I also added an echo for `vet` output if it returns a non-zero exit code but no code related diagnostics. 

This should help users if they both set `:GoBuildTags` and call `:GoVet -tags sometag`
```
vim-go: calling vet...
vim-go: go vet: tags flag may be set only once
```