### PR TITLE
fmt: reload with noautocmd

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -113,7 +113,7 @@ function! go#fmt#update_file(source, target)
   endif
 
   " reload buffer to reflect latest changes
-  silent edit!
+  noautocmd silent edit!
 
   let &fileformat = old_fileformat
   let &syntax = &syntax


### PR DESCRIPTION
Load the formatted buffer without running autocmds.

Fixes #2619