### PR TITLE
lsp: handle completions with placeholders as snippets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ install:
   - ./scripts/install-vim $VIM_VERSION
   - |
     if [ "$ENV" = "vimlint" ]; then
-      pip install vim-vint covimerage==0.1.6 codecov pathlib
+      pip install vim-vint covimerage==0.2.1 codecov pathlib
     else
-      pip install --user vim-vint covimerage==0.1.6 codecov pathlib
+      pip install --user vim-vint covimerage==0.2.1 codecov pathlib
     fi
 script:
   - ./scripts/$SCRIPT $VIM_VERSION

--- a/autoload/go/auto.vim
+++ b/autoload/go/auto.vim
@@ -11,7 +11,43 @@ function! go#auto#template_autocreate()
   call go#template#create()
 endfunction
 
-function! go#auto#echo_go_info()
+function! go#auto#complete_done()
+  call s:echo_go_info()
+  call s:ExpandSnippet()
+endfunction
+
+function! s:ExpandSnippet() abort
+  if !exists('v:completed_item') || empty(v:completed_item) || !go#config#GoplsUsePlaceholders()
+    return
+  endif
+
+
+  let l:engine = go#config#SnippetEngine()
+
+  if l:engine is 'ultisnips'
+    if !get(g:, 'did_plugin_ultisnips', 0)
+      return
+    endif
+    " the snippet may have a '{\}' in it. For UltiSnips, that should be spelled
+    " \{}. fmt.Printf is such a snippet that can be used to demonstrate.
+    let l:snippet = substitute(v:completed_item.word, '{\\}', '\{}', 'g')
+    call UltiSnips#Anon(l:snippet, v:completed_item.word, '', 'i')
+"  elseif l:engine is 'neosnippet'
+"    " TODO(bc): make the anonymous expansion for neosnippet work
+"
+"    if !get(g:, 'loaded_neosnippet') is 1
+"      return
+"    endif
+"
+"    " neosnippet#anonymous doesn't need a trigger, so replace the
+"    " completed_item.word with an empty string before calling neosnippet#anonymous
+"    let l:snippet = substitute(v:completed_item.word, '{\\}', '\{\}', 'g')
+"    call setline('.', substitute(getline('.'), substitute(v:completed_item.word, '\', '\\', 'g'), '', ''))
+"    call neosnippet#anonymous(l:snippet)
+  endif
+endfunction
+
+function! s:echo_go_info()
   if !go#config#EchoGoInfo()
     return
   endif

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -82,7 +82,18 @@ function! go#config#StatuslineDuration() abort
 endfunction
 
 function! go#config#SnippetEngine() abort
-  return get(g:, 'go_snippet_engine', 'automatic')
+  let l:engine = get(g:, 'go_snippet_engine', 'automatic')
+  if l:engine is? "automatic"
+    if get(g:, 'did_plugin_ultisnips') is 1
+      let l:engine = 'ultisnips'
+    elseif get(g:, 'loaded_neosnippet') is 1
+      let l:engine = 'neosnippet'
+    elseif get(g:, 'loaded_minisnip') is 1
+      let l:engine = 'minisnip'
+    endif
+  endif
+
+  return l:engine
 endfunction
 
 function! go#config#PlayBrowserCommand() abort

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1764,7 +1764,9 @@ By default it is enabled.
                                                *'g:go_gopls_use_placeholders'*
 
 Specifies whether `gopls` can provide placeholders for function parameters and
-struct fields. By default it is disabled.
+struct fields. When set, completion items will be treated as anonymous
+snippets if UltiSnips is installed and configured to be used as
+|'g:go_snippet_engine'|. By default it is disabled.
 >
   let g:go_gopls_use_placeholders = 0
 <

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -96,7 +96,7 @@ augroup vim-go-buffer
   " Echo the identifier information when completion is done. Useful to see
   " the signature of a function, etc...
   if exists('##CompleteDone')
-    autocmd CompleteDone <buffer> call go#auto#echo_go_info()
+    autocmd CompleteDone <buffer> call go#auto#complete_done()
   endif
 
   autocmd BufWritePre <buffer> call go#auto#fmt_autosave()

--- a/ftplugin/go/snippets.vim
+++ b/ftplugin/go/snippets.vim
@@ -52,19 +52,11 @@ endfunction
 
 
 let s:engine = go#config#SnippetEngine()
-if s:engine is? "automatic"
-  if get(g:, 'did_plugin_ultisnips') is 1
-    call s:GoUltiSnips()
-  elseif get(g:, 'loaded_neosnippet') is 1
-    call s:GoNeosnippet()
-  elseif get(g:, 'loaded_minisnip') is 1
-    call s:GoMinisnip()
-  endif
-elseif s:engine is? "ultisnips"
+if s:engine is? 'ultisnips'
   call s:GoUltiSnips()
-elseif s:engine is? "neosnippet"
+elseif s:engine is? 'neosnippet'
   call s:GoNeosnippet()
-elseif s:engine is? "minisnip"
+elseif s:engine is? 'minisnip'
   call s:GoMinisnip()
 endif
 


### PR DESCRIPTION
Handle completions from gopls with placeholders as anonymous snippets
with UltiSnips.

Change go#config#SnippetEngine to return the snippet engine to be used
instead of just the raw value of g:go_snippet_engine so that it can be
more effectively reused instead of interpreting the return value in both
ftplugin/go/snippets.vim and autoload/go/auto.vim.