### PR TITLE
lsp: adjust the regex for getting the debug port

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -351,7 +351,7 @@ function! s:newlsp() abort
 
   function! l:lsp.err_cb(ch, msg) dict abort
     if a:msg =~ '^\tPort = \d\+$' && !get(self, 'debugport', 0)
-      let self.debugport = substitute(a:msg, '^\tPort = \(\d\+\).*$', '\1', '')
+      let self.debugport = substitute(a:msg, 'debug server listening on port \(\d\+\).*$', '\1', '')
     endif
 
     call s:debug('stderr', a:msg)


### PR DESCRIPTION
Adjust the regular expression used for getting the debug port. The
previous expression worked until commit
github.com/golang/tools/commit/5b08f89bfc0c897ed953833a79912ec3b0afad02
and the new expression will only work at or after
github.com/golang/tools/commit/6f9e13bbec44ce9d95b8776df8ef7466fc76bcb0.