### PR TITLE
clear matches when a buffer is removed from a window

### DIFF
--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -415,7 +415,6 @@ function! go#guru#Referrers(selected) abort
 endfunction
 
 function! go#guru#SameIds(showstatus) abort
-
   " check if the version of Vim being tested supports matchaddpos()
   if !exists("*matchaddpos")
     call go#util#EchoError("GoSameIds requires 'matchaddpos'. Update your Vim/Neovim version.")
@@ -478,7 +477,7 @@ function! s:same_ids_highlight(exit_val, output, mode) abort
     let l:matches = add(l:matches, [str2nr(pos[-2]), str2nr(pos[-1]), str2nr(poslen)])
   endfor
 
-  call matchaddpos('goSameId', l:matches)
+  call go#util#MatchAddPos('goSameId', l:matches)
 
   if go#config#AutoSameids()
     " re-apply SameIds at the current cursor position at the time the buffer

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -589,6 +589,26 @@ endfunction
 function! s:noop(...) abort dict
 endfunction
 
+" go#util#MatchAddPos works around matchaddpos()'s limit of only 8 positions
+" per call by calling matchaddpos() with no more than 8 positions per call.
+function! go#util#MatchAddPos(group, pos)
+  let l:partitions = []
+  let l:partitionsIdx = 0
+  let l:posIdx = 0
+  for l:pos in a:pos
+    if l:posIdx % 8 == 0
+      let l:partitions = add(l:partitions, [])
+      let l:partitionsIdx = len(l:partitions) - 1
+    endif
+    let l:partitions[l:partitionsIdx] = add(l:partitions[l:partitionsIdx], l:pos)
+    let l:posIdx = l:posIdx + 1
+  endfor
+
+  for l:positions in l:partitions
+    call matchaddpos(a:group, l:positions)
+  endfor
+endfunction
+
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -13,8 +13,8 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-let b:undo_ftplugin = "setl fo< com< cms<
-      \ | exe 'au! vim-go-buffer * <buffer>'"
+let b:undo_ftplugin = "setl fo< com< cms<"
+      \ . "| exe 'au! vim-go-buffer * <buffer>'"
 
 setlocal formatoptions-=t
 
@@ -102,10 +102,25 @@ augroup vim-go-buffer
   autocmd BufWritePre <buffer> call go#auto#fmt_autosave()
   autocmd BufWritePost <buffer> call go#auto#metalinter_autosave()
 
-  " clear SameIds when the buffer is unloaded so that loading another buffer
-  " in the same window doesn't highlight the most recently matched
-  " identifier's positions.
+  "TODO(bc): how to clear sameids and diagnostics when a non-go buffer is
+  " loaded into a window and the previously loaded buffer is still loaded in
+  " another window?
+
+  " clear SameIds when the buffer is unloaded from its last window so that
+  " loading another buffer (especially of a different filetype) in the same
+  " window doesn't highlight the most recently matched identifier's positions.
+  autocmd BufWinLeave <buffer> call go#guru#ClearSameIds()
+  " clear SameIds when a new buffer is loaded in the window so that the
+  " previous buffer's highlighting isn't used.
   autocmd BufWinEnter <buffer> call go#guru#ClearSameIds()
+
+  " clear diagnostics when the buffer is unloaded from its last window so that
+  " loading another buffer (especially of a different filetype) in the same
+  " window doesn't highlight th previously loaded buffer's diagnostics.
+  autocmd BufWinLeave <buffer> call go#lsp#ClearDiagnosticMatches()
+  " clear diagnostics when a new buffer is loaded in the window so that the
+  " previous buffer's diagnostcs aren't used.
+  autocmd BufWinEnter <buffer> call go#lsp#ClearDiagnosticMatches()
 
   autocmd BufEnter <buffer>
         \  if go#config#AutodetectGopath() && !exists('b:old_gopath')


### PR DESCRIPTION
Clear diagnostic and sameid matches when a new buffer is loaded into a
window. The matches are not yet cleared when the previous buffer is also
loaded into another window; I'm looking for a clean way to do that that
isn't too heavy, but I haven't found it yet.

Highlight diagnostic errors and warnings when an existing buffer whose
errors and warnings are known is loaded into a window.

Work around matchaddpos() limitation of only supporting 8 positions per
call by introducing a new wrapper function, go#util#MatchAddPos(), that
will make multiple calls to matchaddpos().

Fixes #2631