### PR TITLE
lint: do not echo on failure

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -97,13 +97,11 @@ function! go#lint#Gometa(bang, autosave, ...) abort
     let errors = go#list#Get(l:listtype)
     call go#list#Window(l:listtype, len(errors))
 
-
     if a:autosave || a:bang
       call win_gotoid(l:winid)
     else
       call go#list#JumpToFirst(l:listtype)
     endif
-    call go#util#EchoError('[metalinter] FAIL')
   endif
 endfunction
 
@@ -142,7 +140,6 @@ function! go#lint#Diagnostics(bang, ...) abort
     else
       call go#list#JumpToFirst(l:listtype)
     endif
-    call go#util#EchoError('[diagnostics] FAIL')
   endif
 endfunction
 
@@ -171,7 +168,6 @@ function! go#lint#Golint(bang, ...) abort
   else
     call go#list#JumpToFirst(l:listtype)
   endif
-  call go#util#EchoError('[lint] FAIL')
 endfunction
 
 " Vet calls 'go vet' on the current directory. Any warnings are populated in
@@ -216,7 +212,6 @@ function! go#lint#Vet(bang, ...) abort
     else
       call win_gotoid(l:winid)
     endif
-    call go#util#EchoError('[vet] FAIL')
   else
     call go#list#Clean(l:listtype)
     call go#util#EchoSuccess('[vet] PASS')
@@ -264,7 +259,6 @@ function! go#lint#Errcheck(bang, ...) abort
         call win_gotoid(l:winid)
       endif
     endif
-    call go#util#EchoError('[errcheck] FAIL')
   else
     call go#list#Clean(l:listtype)
     call go#util#EchoSuccess('[errcheck] PASS')


### PR DESCRIPTION
Don't echo failure status messages from code quality check tools; it
just ends up causing the user to have to hit enter due to multiple
messages being shown since the last redraw. Since the quickfix list is
populated, echoing the failure message is redundant.