### PR TITLE
Add new g:go_addtags_skip_private option

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -244,6 +244,10 @@ function! go#config#AddtagsTransform() abort
   return get(g:, 'go_addtags_transform', "snakecase")
 endfunction
 
+function! go#config#AddtagsSkipPrivate() abort
+  return get(g:, 'go_addtags_skip_private', 0)
+endfunction
+
 function! go#config#TemplateAutocreate() abort
   return get(g:, "go_template_autocreate", 1)
 endfunction

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -244,8 +244,8 @@ function! go#config#AddtagsTransform() abort
   return get(g:, 'go_addtags_transform', "snakecase")
 endfunction
 
-function! go#config#AddtagsSkipPrivate() abort
-  return get(g:, 'go_addtags_skip_private', 0)
+function! go#config#AddtagsSkipUnexported() abort
+  return get(g:, 'go_addtags_skip_unexported', 0)
 endfunction
 
 function! go#config#TemplateAutocreate() abort

--- a/autoload/go/tags.vim
+++ b/autoload/go/tags.vim
@@ -124,12 +124,17 @@ func s:create_cmd(args) abort
   let l:mode = a:args.mode
   let l:cmd_args = a:args.cmd_args
   let l:modifytags_transform = go#config#AddtagsTransform()
+  let l:modifytags_skip_private = go#config#AddtagsSkipPrivate()
 
   " start constructing the command
   let cmd = [bin_path]
   call extend(cmd, ["-format", "json"])
   call extend(cmd, ["-file", a:args.fname])
   call extend(cmd, ["-transform", l:modifytags_transform])
+
+  if l:modifytags_skip_private != 0
+    call extend(cmd, ["-skip-private"])
+  endif
 
   if has_key(a:args, "modified")
     call add(cmd, "-modified")

--- a/autoload/go/tags.vim
+++ b/autoload/go/tags.vim
@@ -124,7 +124,7 @@ func s:create_cmd(args) abort
   let l:mode = a:args.mode
   let l:cmd_args = a:args.cmd_args
   let l:modifytags_transform = go#config#AddtagsTransform()
-  let l:modifytags_skip_private = go#config#AddtagsSkipPrivate()
+  let l:modifytags_skip_unexported = go#config#AddtagsSkipUnexported()
 
   " start constructing the command
   let cmd = [bin_path]
@@ -132,8 +132,8 @@ func s:create_cmd(args) abort
   call extend(cmd, ["-file", a:args.fname])
   call extend(cmd, ["-transform", l:modifytags_transform])
 
-  if l:modifytags_skip_private != 0
-    call extend(cmd, ["-skip-private"])
+  if l:modifytags_skip_unexported != 0
+    call extend(cmd, ["-skip-unexported"])
   endif
 
   if has_key(a:args, "modified")

--- a/autoload/go/tags.vim
+++ b/autoload/go/tags.vim
@@ -132,7 +132,7 @@ func s:create_cmd(args) abort
   call extend(cmd, ["-file", a:args.fname])
   call extend(cmd, ["-transform", l:modifytags_transform])
 
-  if l:modifytags_skip_unexported != 0
+  if l:modifytags_skip_unexported
     call extend(cmd, ["-skip-unexported"])
   endif
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1883,12 +1883,16 @@ By default "snakecase" is used. Current values are: ["snakecase",
                                               *'g:go_addtags_skip_unexported'*
 
 Sets the `skip-unexported` option for `gomodifytags` when using |:GoAddTags|.
-If set it will prevent from adding tags to private fields:
+If set it will prevent `gomodifytags` from adding tags to unexported fields:
 >
   type T struct {
     FooBar string `json:"foo_bar"`
     quz    string
   }
+<
+By default it is disabled.
+>
+      let g:go_addtags_skip_unexported = 0
 <
                                                                 *'g:go_debug'*
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1880,6 +1880,16 @@ By default "snakecase" is used. Current values are: ["snakecase",
 >
       let g:go_addtags_transform = 'snakecase'
 <
+                                                 *'g:go_addtags_skip_private'*
+
+Sets the `skip-private` option for `gomodifytags` when using |:GoAddTags|.
+If set it will prevent from adding tags to private fields:
+>
+  type T struct {
+    FooBar string `json:"foo_bar"`
+    quz    string
+  }
+<
                                                                 *'g:go_debug'*
 
 A list of options to debug; useful for development and/or reporting bugs.

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1880,7 +1880,7 @@ By default "snakecase" is used. Current values are: ["snakecase",
 >
       let g:go_addtags_transform = 'snakecase'
 <
-                                                 *'g:go_addtags_skip_unexported'*
+                                              *'g:go_addtags_skip_unexported'*
 
 Sets the `skip-unexported` option for `gomodifytags` when using |:GoAddTags|.
 If set it will prevent from adding tags to private fields:

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1880,9 +1880,9 @@ By default "snakecase" is used. Current values are: ["snakecase",
 >
       let g:go_addtags_transform = 'snakecase'
 <
-                                                 *'g:go_addtags_skip_private'*
+                                                 *'g:go_addtags_skip_unexported'*
 
-Sets the `skip-private` option for `gomodifytags` when using |:GoAddTags|.
+Sets the `skip-unexported` option for `gomodifytags` when using |:GoAddTags|.
 If set it will prevent from adding tags to private fields:
 >
   type T struct {


### PR DESCRIPTION
Tool gomodifytags now has -skip-private option for adding tags only to public fields

This PR mirrors this option in vim config

For example you may have following struct

    type Struct struct {
        Public  int
        private int
    }

Currently GoAddTags command would add these tags

    type Struct struct {
        Public  int `json:"public"`
        private int `json:"private"`
    }

With new option it would add

    type Struct struct {
        Public  int `json:"public"`
        private int
    }