### PR TITLE
util: work around prop_remove bug in vim < 8.1.1035

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -553,6 +553,9 @@ endfunction
 
 function! go#util#ClearHighlights(group) abort
   if exists('*prop_remove')
+    if !has('patch-8.1.1035')
+      return prop_remove({'type': a:group, 'all': 1}, 1, line('$'))
+    endif
     return prop_remove({'type': a:group, 'all': 1})
   endif
 


### PR DESCRIPTION
Pass a line range to prop_remove in Vim <8.1.1035. Until Vim 8.1.1035,
prop_remove's optional arguments were incorrectly implemented as
required.