### PR TITLE
define text property types in syntax/go.vim

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -553,6 +553,10 @@ endfunction
 
 function! go#util#ClearHighlights(group) abort
   if exists('*prop_remove')
+    " the property type may not exist when syntax highlighting is not enabled.
+    if empty(prop_type_get(a:group))
+      return
+    endif
     if !has('patch-8.1.1035')
       return prop_remove({'type': a:group, 'all': 1}, 1, line('$'))
     endif

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -74,18 +74,6 @@ if get(g:, "go_textobj_enabled", 1)
   xnoremap <buffer> <silent> [[ :<c-u>call go#textobj#FunctionJump('v', 'prev')<cr>
 endif
 
-if exists('*prop_type_add')
-  if empty(prop_type_get('goSameId'))
-    call prop_type_add('goSameId', {'highlight': 'goSameId'})
-  endif
-  if empty(prop_type_get('goDiagnosticError'))
-    call prop_type_add('goDiagnosticError', {'highlight': 'goDiagnosticError'})
-  endif
-  if empty(prop_type_get('goDiagnosticWarning'))
-    call prop_type_add('goDiagnosticWarning', {'highlight': 'goDiagnosticWarning'})
-  endif
-endif
-
 " Autocommands
 " ============================================================================
 "
@@ -131,7 +119,7 @@ augroup vim-go-buffer
   " window doesn't highlight th previously loaded buffer's diagnostics.
   autocmd BufWinLeave <buffer> call go#lsp#ClearDiagnosticHighlights()
   " clear diagnostics when a new buffer is loaded in the window so that the
-  " previous buffer's diagnostcs aren't used.
+  " previous buffer's diagnostics aren't used.
   autocmd BufWinEnter <buffer> call go#lsp#ClearDiagnosticHighlights()
 
   autocmd BufEnter <buffer>

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -393,6 +393,24 @@ function! s:hi()
   hi def link goDiagnosticError SpellBad
   hi def link goDiagnosticWarning SpellRare
 
+  " TODO(bc): is it appropriate to define text properties in a syntax file?
+  " The highlight groups need to be defined before the text properties types
+  " are added, and when users have syntax enabled in their vimrc after
+  " filetype plugin on, the highlight groups won't be defined when
+  " ftplugin/go.vim is executed when the first go file is opened.
+  " See https://github.com/fatih/vim-go/issues/2658.
+  if exists('*prop_type_add')
+    if empty(prop_type_get('goSameId'))
+      call prop_type_add('goSameId', {'highlight': 'goSameId'})
+    endif
+    if empty(prop_type_get('goDiagnosticError'))
+      call prop_type_add('goDiagnosticError', {'highlight': 'goDiagnosticError'})
+    endif
+    if empty(prop_type_get('goDiagnosticWarning'))
+      call prop_type_add('goDiagnosticWarning', {'highlight': 'goDiagnosticWarning'})
+    endif
+  endif
+
   hi def link goDeclsFzfKeyword        Keyword
   hi def link goDeclsFzfFunction       Function
   hi def link goDeclsFzfSpecialComment SpecialComment


### PR DESCRIPTION
Define text property types in syntax/go.vim so that they won't be added
until the syntax file is loaded; syntax files will be loaded after
ftplugins when `syntax on` or `syntax enable` is called after `filetype
plugin on`.

Do not try to remove a text property whose type does not exist in order
to avoid errors when syntax highlighting is not enabled.

Fixes #2658