### PR TITLE
lint: handle Go syntax errors from errcheck

### DIFF
--- a/autoload/go/def_test.vim
+++ b/autoload/go/def_test.vim
@@ -47,7 +47,7 @@ func! Test_Jump_leaves_lists() abort
 
     let l:expected = [{'lnum': 10, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'quux'}]
 
-    call setloclist(winnr(), copy(l:expected), 'r' )
+    call setloclist(0, copy(l:expected), 'r' )
     call setqflist(copy(l:expected), 'r' )
 
     let l:bufnr = bufnr('%')
@@ -67,7 +67,7 @@ func! Test_Jump_leaves_lists() abort
       sleep 100m
     endwhile
 
-    let l:actual = getloclist(winnr())
+    let l:actual = getloclist(0)
     call gotest#assert_quickfix(l:actual, l:expected)
 
     let l:actual = getqflist()

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -239,10 +239,12 @@ function! go#lint#Errcheck(bang, ...) abort
   let l:listtype = go#list#Type("GoErrCheck")
   if l:err != 0
     let l:winid = win_getid(winnr())
-    let errformat = "%f:%l:%c:\ %m, %f:%l:%c\ %#%m"
+    " the first entry in l:errformat is to get messages related to syntax
+    " errors.
+    let l:errformat = "%.%#[%f:%l:%c:\ %m],%f:%l:%c:\ %m,%f:%l:%c\ %#%m"
 
     " Parse and populate our location list
-    call go#list#ParseFormat(l:listtype, errformat, split(out, "\n"), 'Errcheck')
+    call go#list#ParseFormat(l:listtype, l:errformat, split(out, "\n"), 'Errcheck')
 
     let l:errors = go#list#Get(l:listtype)
     if empty(l:errors)

--- a/autoload/go/test-fixtures/lint/src/errcheck/compilererror/compilererror.go
+++ b/autoload/go/test-fixtures/lint/src/errcheck/compilererror/compilererror.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("vim-go"
+}


### PR DESCRIPTION
Fixes #2661