### PR TITLE
lint: handle compiler errors when calling errcheck

### DIFF
--- a/autoload/go/def_test.vim
+++ b/autoload/go/def_test.vim
@@ -47,7 +47,7 @@ func! Test_Jump_leaves_lists() abort
 
     let l:expected = [{'lnum': 10, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'quux'}]
 
-    call setloclist(winnr(), copy(l:expected), 'r' )
+    call setloclist(0, copy(l:expected), 'r' )
     call setqflist(copy(l:expected), 'r' )
 
     let l:bufnr = bufnr('%')
@@ -67,7 +67,7 @@ func! Test_Jump_leaves_lists() abort
       sleep 100m
     endwhile
 
-    let l:actual = getloclist(winnr())
+    let l:actual = getloclist(0)
     call gotest#assert_quickfix(l:actual, l:expected)
 
     let l:actual = getqflist()

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -239,10 +239,12 @@ function! go#lint#Errcheck(bang, ...) abort
   let l:listtype = go#list#Type("GoErrCheck")
   if l:err != 0
     let l:winid = win_getid(winnr())
-    let errformat = "%f:%l:%c:\ %m, %f:%l:%c\ %#%m"
 
-    " Parse and populate our location list
-    call go#list#ParseFormat(l:listtype, errformat, split(out, "\n"), 'Errcheck')
+    if l:err == 1
+      let l:errformat = "%f:%l:%c:\ %m,%f:%l:%c\ %#%m"
+      " Parse and populate our location list
+      call go#list#ParseFormat(l:listtype, l:errformat, split(out, "\n"), 'Errcheck')
+    endif
 
     let l:errors = go#list#Get(l:listtype)
     if empty(l:errors)
@@ -251,8 +253,8 @@ function! go#lint#Errcheck(bang, ...) abort
     endif
 
     if !empty(errors)
-      call go#list#Populate(l:listtype, errors, 'Errcheck')
-      call go#list#Window(l:listtype, len(errors))
+      call go#list#Populate(l:listtype, l:errors, 'Errcheck')
+      call go#list#Window(l:listtype, len(l:errors))
       if !a:bang
         call go#list#JumpToFirst(l:listtype)
       else

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -61,20 +61,18 @@ func! s:gometaautosave(metalinter) abort
           \ ]
     endif
 
-    let winnr = winnr()
-
     " clear the location lists
-    call setloclist(l:winnr, [], 'r')
+    call setloclist(0, [], 'r')
 
     let g:go_metalinter_autosave_enabled = ['golint']
 
     call go#lint#Gometa(0, 1)
 
-    let actual = getloclist(l:winnr)
+    let actual = getloclist(0)
     let start = reltime()
     while len(actual) == 0 && reltimefloat(reltime(start)) < 10
       sleep 100m
-      let actual = getloclist(l:winnr)
+      let actual = getloclist(0)
     endwhile
 
     call gotest#assert_quickfix(actual, expected)
@@ -151,7 +149,7 @@ func! Test_Lint_GOPATH() abort
 
   let expected = [
           \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported'},
-          \ {'lnum': 5, 'bufnr': 6, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
+          \ {'lnum': 5, 'bufnr': bufnr('%')+4, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
       \ ]
 
   let winnr = winnr()
@@ -179,7 +177,7 @@ func! Test_Lint_NullModule() abort
 
   let expected = [
           \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported'},
-          \ {'lnum': 5, 'bufnr': 6, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
+          \ {'lnum': 5, 'bufnr': bufnr('%')+4, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
       \ ]
 
   let winnr = winnr()

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -197,6 +197,25 @@ func! Test_Lint_NullModule() abort
   call gotest#assert_quickfix(actual, expected)
 endfunc
 
+func! Test_Errcheck_compilererror() abort
+  let l:tmp = gotest#load_fixture('lint/src/errcheck/compilererror/compilererror.go')
+
+  try
+    let l:bufnr = bufnr('')
+    let expected = []
+
+    " clear the location lists
+    call setqflist([], 'r')
+
+    call go#lint#Errcheck(1)
+
+    call gotest#assert_quickfix(getqflist(), expected)
+    call assert_equal(l:bufnr, bufnr(''))
+  finally
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/autoload/go/test-fixtures/lint/src/errcheck/compilererror/compilererror.go
+++ b/autoload/go/test-fixtures/lint/src/errcheck/compilererror/compilererror.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("vim-go"
+}


### PR DESCRIPTION
##### lint: handle Go syntax errors from errcheck

Fixes #2661


##### minor refactors to some tests

* use a window id of 0 for getloclist and setloclist to get the current
  winow id instead of using winid().
* derive buffer number in some tests expectations so the tests are less
  brittle when other tests are introduced.


