### PR TITLE
gotest: cycle files for gopls after setting cursor

### DIFF
--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -39,6 +39,9 @@ fun! gotest#write_file(path, contents) abort
       call setline('.', substitute(getline('.'), "\x1f", '', ''))
       silent noautocmd w!
 
+      call go#lsp#DidClose(expand('%:p'))
+      call go#lsp#DidOpen(expand('%:p'))
+
       break
     endif
 


### PR DESCRIPTION
Tell gopls the file is closed and reopened after positioning the cursor
to work around a problem whereby gopls uses a foreshortened identifier
name for any identifier that originally has \x1f in its name.

Fixes a long standing issue that caused def_test.vim tests
(e.g.Test_DefJump_gopls_MultipleCodeUnit_first) to fail.