### PR TITLE
Add custom symbol for breakpoint.

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -490,7 +490,7 @@ function! go#config#HighlightDebug() abort
 endfunction
 
 function! go#config#DebugBreakpointSymbol() abort
-  return get( g:, 'go_debug_breakpoint_symbol', '>' )
+  return get(g:, 'go_debug_breakpoint_symbol', '>')
 endfunction
 
 function! go#config#FoldEnable(...) abort

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -489,6 +489,10 @@ function! go#config#HighlightDebug() abort
   return get(g:, 'go_highlight_debug', 1)
 endfunction
 
+function! go#config#DebugBreakpointSymbol() abort
+  return get( g:, 'go_debug_breakpoint_symbol', '>' )
+endfunction
+
 function! go#config#FoldEnable(...) abort
   if a:0 > 0
     return index(go#config#FoldEnable(), a:1) > -1

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -1116,7 +1116,7 @@ function! s:list_breakpoints()
   return l:signs
 endfunction
 
-sign define godebugbreakpoint text=> texthl=GoDebugBreakpoint
+exe 'sign define godebugbreakpoint text='.go#config#DebugBreakpointSymbol().' texthl=GoDebugBreakpoint'
 sign define godebugcurline    text== texthl=GoDebugCurrent    linehl=GoDebugCurrent
 
 " restore Vi compatibility settings

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2333,6 +2333,14 @@ Highlight the current line and breakpoints in the debugger.
   let g:go_highlight_debug = 1
 <
 
+                                            *'go:go_debug_breakpoint_symbol'*
+
+change default symbol for breakpoints in the debugger.
+
+>
+  let g:go_debug_breakpoint_symbol = '>'
+<
+
 ==============================================================================
 FAQ TROUBLESHOOTING                                     *go-troubleshooting*
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2335,7 +2335,7 @@ Highlight the current line and breakpoints in the debugger.
 
                                             *'go:go_debug_breakpoint_symbol'*
 
-change default symbol for breakpoints in the debugger.
+Set the symbol used for breakpints in the debugger. By default it's '>'.
 
 >
   let g:go_debug_breakpoint_symbol = '>'


### PR DESCRIPTION
use `let g:go_debug_break_point_symbol='>>' ` to add custom symbol for break point.