### PR TITLE
Update README to new GoMetaLinter

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This plugin adds Go language support for Vim, with the following main features:
 * Precise type-safe renaming of identifiers with `:GoRename`.
 * See which code is covered by tests with `:GoCoverage`.
 * Add or remove tags on struct fields with `:GoAddTags` and `:GoRemoveTags`.
-* Call `gometalinter` with `:GoMetaLinter` to invoke all possible linters
+* Call `golangci-lint` with `:GoMetaLinter` to invoke all possible linters
   (`golint`, `vet`, `errcheck`, `deadcode`, etc.) and put the result in the
   quickfix or location list.
 * Lint your code with `:GoLint`, run your code through `:GoVet` to catch static


### PR DESCRIPTION
https://github.com/fatih/vim-go/pull/2494 dropped support for the deprecated gometalinter tool in favor of golangci-lint. The documentation at doc/vim-go.txt was updated but the README has not been updated yet.

This PR updates the documentation in README.