### PR TITLE
rename g:go_debug_breakpoint_symbol

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -489,8 +489,8 @@ function! go#config#HighlightDebug() abort
   return get(g:, 'go_highlight_debug', 1)
 endfunction
 
-function! go#config#DebugBreakpointSymbol() abort
-  return get(g:, 'go_debug_breakpoint_symbol', '>')
+function! go#config#DebugBreakpointSignText() abort
+  return get(g:, 'go_debug_breakpoint_sign_text', '>')
 endfunction
 
 function! go#config#FoldEnable(...) abort

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -1116,7 +1116,7 @@ function! s:list_breakpoints()
   return l:signs
 endfunction
 
-exe 'sign define godebugbreakpoint text='.go#config#DebugBreakpointSymbol().' texthl=GoDebugBreakpoint'
+exe 'sign define godebugbreakpoint text='.go#config#DebugBreakpointSignText().' texthl=GoDebugBreakpoint'
 sign define godebugcurline    text== texthl=GoDebugCurrent    linehl=GoDebugCurrent
 
 " restore Vi compatibility settings

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2333,12 +2333,12 @@ Highlight the current line and breakpoints in the debugger.
   let g:go_highlight_debug = 1
 <
 
-                                            *'go:go_debug_breakpoint_symbol'*
+                                         *'go:go_debug_breakpoint_sign_text'*
 
-Set the symbol used for breakpints in the debugger. By default it's '>'.
+Set the sign text used for breakpoints in the debugger. By default it's '>'.
 
 >
-  let g:go_debug_breakpoint_symbol = '>'
+  let g:go_debug_breakpoint_sign_text = '>'
 <
 
 ==============================================================================


### PR DESCRIPTION
Rename g:go_debug_breakpoint_symbol to g:go_debug_breakpoint_sign_text