### PR TITLE
rename: use the correct variable to execute gopls

### DIFF
--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -42,7 +42,7 @@ function! go#rename#Rename(bang, ...) abort
     call go#util#EchoWarning('unexpected rename command')
   endif
 
-  let l:cmd = extend([l:bin], l:args)
+  let l:cmd = extend([l:bin_path], l:args)
 
   if go#util#has_job()
     call s:rename_job({


### PR DESCRIPTION
Use l:bin_path instead of l:bin to execute gopls so that the full path
to the command will be used.

Fixes #2691