### PR TITLE
lsp: use gopls defaults by default

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -501,23 +501,23 @@ function! go#config#ReferrersMode() abort
 endfunction
 
 function! go#config#GoplsCompleteUnimported() abort
-  return get(g:, 'go_gopls_complete_unimported', 1)
+  return get(g:, 'go_gopls_complete_unimported', v:null)
 endfunction
 
 function! go#config#GoplsDeepCompletion() abort
-  return get(g:, 'go_gopls_deep_completion', 1)
+  return get(g:, 'go_gopls_deep_completion', v:null)
 endfunction
 
 function! go#config#GoplsFuzzyMatching() abort
-  return get(g:, 'go_gopls_fuzzy_matching', 1)
+  return get(g:, 'go_gopls_fuzzy_matching', v:null)
 endfunction
 
 function! go#config#GoplsStaticCheck() abort
-  return get(g:, 'go_gopls_staticcheck', 0)
+  return get(g:, 'go_gopls_staticcheck', v:null)
 endfunction
 
 function! go#config#GoplsUsePlaceholders() abort
-  return get(g:, 'go_gopls_use_placeholders', 0)
+  return get(g:, 'go_gopls_use_placeholders', v:null)
 endfunction
 
 function! go#config#GoplsEnabled() abort

--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -197,15 +197,56 @@ function! go#lsp#message#ConfigurationResult(items) abort
     let l:config = {
           \ 'buildFlags': [],
           \ 'hoverKind': 'NoDocumentation',
-          \ 'deepCompletion': go#config#GoplsDeepCompletion() ? v:true : v:false,
-          \ 'fuzzyMatching': go#config#GoplsFuzzyMatching() ? v:true : v:false,
-          \ 'completeUnimported': go#config#GoplsCompleteUnimported() ? v:true : v:false,
-          \ 'staticcheck': go#config#GoplsStaticCheck() ? v:true : v:false,
-          \ 'usePlaceholders': go#config#GoplsUsePlaceholders() ? v:true : v:false,
           \ }
     let l:buildtags = go#config#BuildTags()
     if buildtags isnot ''
       let l:config.buildFlags = extend(l:config.buildFlags, ['-tags', go#config#BuildTags()])
+    endif
+
+    let l:deepCompletion = go#config#GoplsDeepCompletion()
+    let l:fuzzyMatching = go#config#GoplsFuzzyMatching()
+    let l:completeUnimported = go#config#GoplsCompleteUnimported()
+    let l:staticcheck = go#config#GoplsStaticCheck()
+    let l:usePlaceholder = go#config#GoplsUsePlaceholders()
+
+    if l:deepCompletion isnot v:null
+      if l:deepCompletion
+        let l:config.deepCompletion = v:true
+      else
+        let l:config.deepCompletion = v:false
+      endif
+    endif
+
+    if l:fuzzyMatching isnot v:null
+      if l:fuzzyMatching
+        let l:config.fuzzyMatching = v:true
+      else
+        let l:config.fuzzyMatching = v:false
+      endif
+    endif
+
+    if l:completeUnimported isnot v:null
+      if l:completeUnimported
+        let l:config.completeUnimported = v:true
+      else
+        let l:config.completeUnimported = v:false
+      endif
+    endif
+
+    if l:staticcheck isnot v:null
+      if l:staticcheck
+        let l:config.staticcheck = v:true
+      else
+        let l:config.staticcheck = v:false
+      endif
+    endif
+
+    if l:usePlaceholder isnot v:null
+      if l:usePlaceholder
+        let l:config.usePlaceholders = v:true
+      else
+        let l:config.usePlaceholders = v:false
+      endif
     endif
 
     let l:result = add(l:result, l:config)

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1718,33 +1718,34 @@ options may also need to be adjusted.
                                             *'g:go_gopls_complete_unimported'*
 
 Specifies whether `gopls` should include suggestions from unimported packages.
-By default it is enabled.
+When it is v:null, `gopls`' defaults will be used. By default it is v:null.
 >
-  let g:go_gopls_complete_unimported = 0
+  let g:go_gopls_complete_unimported = v:null
 <
 
                                                 *'g:go_gopls_deep_completion'*
 
-Specifies whether `gopls` should use deep completion. By default it is
-enabled.
+Specifies whether `gopls` should use deep completion. When it is v:null,
+`gopls`' defaults will be used. By default it is v:null.
+
 >
-  let g:go_gopls_deep_completion = 1
+  let g:go_gopls_deep_completion = v:null
 <
 
                                                  *'g:go_gopls_fuzzy_matching'*
 
-Specifies whether `gopls` should use fuzzy matching for completions.
-By default it is enabled.
+Specifies whether `gopls` should use fuzzy matching for completions. When it
+is v:null, `gopls`' defaults will be used.
 >
-  let g:go_gopls_fuzzy_matching = 1
+  let g:go_gopls_fuzzy_matching = v:null
 <
 
                                                    *'g:go_gopls_staticcheck'*
 
-Specifies whether `gopls` should run staticcheck checks. By default it is
-disabled.
+Specifies whether `gopls` should run staticcheck checks. When it is v:null,
+`gopls`' defaults will be used.
 >
-  let g:go_gopls_staticcheck = 0
+  let g:go_gopls_staticcheck = v:null
 <
 
                                                *'g:go_gopls_use_placeholders'*
@@ -1752,9 +1753,10 @@ disabled.
 Specifies whether `gopls` can provide placeholders for function parameters and
 struct fields. When set, completion items will be treated as anonymous
 snippets if UltiSnips is installed and configured to be used as
-|'g:go_snippet_engine'|. By default it is disabled.
+|'g:go_snippet_engine'|. When it is v:null, `gopls`' defaults will be used. By
+default it is disabled.
 >
-  let g:go_gopls_use_placeholders = 0
+  let g:go_gopls_use_placeholders = v:null
 <
 
                                                  *'g:go_diagnostics_enabled'*


### PR DESCRIPTION
Refactor gopls configurations to use gopls' defaults by default so that
users can take advantage of any changes to an updated gopls without
modifying vim-go's configuration.