### PR TITLE
test against Vim 8.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ notifications:
 matrix:
   include:
     - env: SCRIPT="test -c" VIM_VERSION=vim-8.0
+    - env: SCRIPT="test -c" VIM_VERSION=vim-8.2
     - env: SCRIPT="test -c" VIM_VERSION=nvim
-    - env: ENV=vimlint SCRIPT=lint VIM_VERSION=vim-8.0
+    - env: ENV=vimlint SCRIPT=lint VIM_VERSION=vim-8.2
       language: python
       python: 3.6
 install:

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY . /vim-go/
 WORKDIR /vim-go
 
 RUN scripts/install-vim vim-8.0
+RUN scripts/install-vim vim-8.2
 RUN scripts/install-vim nvim
 
 ENTRYPOINT ["make"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VIMS ?= vim-8.0 nvim
+VIMS ?= vim-8.0 vim-8.2 nvim
 
 all: install lint test
 
@@ -16,7 +16,7 @@ test:
 
 lint:
 	@echo "==> Running linting tools"
-	@./scripts/lint vim-8.0
+	@./scripts/lint vim-8.2
 
 docker:
 	@echo "==> Building/starting Docker container"

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ issues](https://github.com/fatih/vim-go/issues), please open an issue with
 clear reproduction steps. `:GoReportGitHubIssue` can be used pre-populate a lot
 of the information needed when creating a new issue.
 
+## Contributing
+
+All PRs are welcome. If you are planning to contribute a large patch or to
+integrate a new tool, please create an issue first to get any upfront questions
+or design decisions out of the way first.
+
+You can run the tests locally by running `make`. It will lint the VimL for you,
+lint the documentation, and run the tests against the minimum required version
+of Vim, other versions of Vim that may be critical to support, and Neovim.
+
 ## License
 
 The BSD 3-Clause License - see [`LICENSE`](LICENSE) for more details

--- a/scripts/docker-test
+++ b/scripts/docker-test
@@ -10,6 +10,6 @@ cd "$vimgodir"
 docker build --tag vim-go-test .
 # seccomp=confined is required for dlv to run in a container, hence it's
 # required for vim-go's debug tests.
-docker run --rm --security-opt="seccomp=unconfined" vim-go-test
+docker run -e VIMS --rm --security-opt="seccomp=unconfined" vim-go-test
 
 # vim:ts=2:sts=2:sw=2:et

--- a/scripts/install-vim
+++ b/scripts/install-vim
@@ -23,6 +23,15 @@ case "$vim" in
     giturl="https://github.com/vim/vim"
     ;;
 
+  "vim-8.2")
+    # This is the version that's installed by homebrew currently. It doesn't
+    # have to stay up to date with homebrew, and is only chosen here because
+    # that's what homebrew was using at the the time and we need a version to
+    # vimlint with.
+    tag="v8.2.0200"
+    giturl="https://github.com/vim/vim"
+    ;;
+
   "nvim")
     # Use latest stable version.
     tag="v0.3.2"
@@ -31,7 +40,7 @@ case "$vim" in
 
   *)
     echo "unknown version: '${1:-}'"
-    echo "First argument must be 'vim-8.0' or 'nvim'."
+    echo "First argument must be 'vim-8.0', vim-8.2, or 'nvim'."
     exit 1
     ;;
 esac

--- a/scripts/run-vim
+++ b/scripts/run-vim
@@ -17,7 +17,7 @@ shift $((OPTIND - 1))
 
 if [ -z "${1:-}" ]; then
   echo "unknown version: '${1:-}'"
-  echo "First argument must be 'vim-8.0' or 'nvim'."
+  echo "First argument must be 'vim-8.0', 'vim-8.2', or 'nvim'."
   exit 1
 fi
 


### PR DESCRIPTION
##### build and test againt Vim 8.2

* Build and test against Vim 8.2
* Run the linters against Vim 8.2
* Update scripts/docker-test to pass to set $VIMS in the container so
  that running `make docker` with $VIMS set will respect $VIMS when
  running the tests in docker.


##### update README.md with a section on contributing


