### PR TITLE
lint: report golangci-lint problems

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -331,7 +331,10 @@ function! s:metalinterautosavecomplete(filepath, job, exit_code, messages)
 
   let l:idx = len(a:messages) - 1
   while l:idx >= 0
-    if a:messages[l:idx] !~# '^' . a:filepath . ':'
+    " leave in any messages that report errors about a:filepath or that report
+    " more general problems that prevent golangci-lint from linting
+    " a:filepath.
+    if a:messages[l:idx] !~# '^' . a:filepath . ':' && a:messages[l:idx] !~# '^level='
       call remove(a:messages, l:idx)
     endif
     let l:idx -= 1
@@ -343,7 +346,7 @@ function! s:errorformat(metalinter) abort
     " Golangci-lint can output the following:
     "   <file>:<line>:<column>: <message> (<linter>)
     " This can be defined by the following errorformat:
-    return '%f:%l:%c:\ %m'
+    return 'level=%tarning\ msg="%m:\ [%f:%l:%c:\ %.%#]",level=%trror\ msg="%m:\ [%f:%l:%c:\ %.%#]",%f:%l:%c:\ %m'
   elseif a:metalinter == 'gopls'
     return '%f:%l:%c:%t:\ %m,%f:%l:%c::\ %m'
   endif

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -68,7 +68,7 @@ function! go#lint#Gometa(bang, autosave, ...) abort
     let l:err = len(l:messages)
   else
     if go#util#has_job()
-      call s:lint_job({'cmd': cmd, 'statustype': l:metalinter, 'errformat': errformat}, a:bang, a:autosave)
+      call s:lint_job(l:metalinter, {'cmd': cmd, 'statustype': l:metalinter, 'errformat': errformat}, a:bang, a:autosave)
       return
     endif
 
@@ -89,8 +89,8 @@ function! go#lint#Gometa(bang, autosave, ...) abort
     let l:winid = win_getid(winnr())
     " Parse and populate our location list
 
-    if a:autosave && l:metalinter != 'gopls'
-      call s:metalinterautosavecomplete(fnamemodify(expand('%:p'), ":."), 0, 1, l:messages)
+    if a:autosave
+      call s:metalinterautosavecomplete(l:metalinter, fnamemodify(expand('%:p'), ":."), 0, 1, l:messages)
     endif
     call go#list#ParseFormat(l:listtype, errformat, l:messages, 'GoMetaLinter')
 
@@ -278,7 +278,7 @@ function! go#lint#ToggleMetaLinterAutoSave() abort
   call go#util#EchoProgress("auto metalinter enabled")
 endfunction
 
-function! s:lint_job(args, bang, autosave)
+function! s:lint_job(metalinter, args, bang, autosave)
   let l:opts = {
         \ 'statustype': a:args.statustype,
         \ 'errorformat': a:args.errformat,
@@ -289,7 +289,7 @@ function! s:lint_job(args, bang, autosave)
   if a:autosave
     let l:opts.for = "GoMetaLinterAutoSave"
     " s:metalinterautosavecomplete is really only needed for golangci-lint
-    let l:opts.complete = funcref('s:metalinterautosavecomplete', [expand('%:p:t')])
+    let l:opts.complete = funcref('s:metalinterautosavecomplete', [a:metalinter, expand('%:p:t')])
   endif
 
   " autowrite is not enabled for jobs
@@ -324,7 +324,11 @@ function! s:golangcilintcmd(bin_path)
   return cmd
 endfunction
 
-function! s:metalinterautosavecomplete(filepath, job, exit_code, messages)
+function! s:metalinterautosavecomplete(metalinter, filepath, job, exit_code, messages)
+  if a:metalinter != 'golangci-lint'
+    return
+  endif
+
   if len(a:messages) == 0
     return
   endif

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -17,7 +17,7 @@ func! s:gometa(metalinter) abort
         \ ]
     if a:metalinter == 'golangci-lint'
       let expected = [
-            \ {'lnum': 5, 'bufnr': bufnr('%')+2, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function `MissingFooDoc` should have comment or be unexported (golint)'}
+            \ {'lnum': 5, 'bufnr': bufnr('%')+4, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function `MissingFooDoc` should have comment or be unexported (golint)'}
           \ ]
     endif
 
@@ -27,6 +27,42 @@ func! s:gometa(metalinter) abort
     let g:go_metalinter_enabled = ['golint']
 
     call go#lint#Gometa(0, 0, $GOPATH . '/src/foo')
+
+    let actual = getqflist()
+    let start = reltime()
+    while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+      sleep 100m
+      let actual = getqflist()
+    endwhile
+
+    call gotest#assert_quickfix(actual, expected)
+  finally
+      call call(RestoreGOPATH, [])
+      unlet g:go_metalinter_enabled
+  endtry
+endfunc
+
+func! Test_GometaGolangciLint_problems() abort
+  call s:gometa_problems('golangci-lint')
+endfunc
+
+func! s:gometa_problems(metalinter) abort
+  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnamemodify(getcwd(), ':p') . 'test-fixtures/lint')
+  silent exe 'e ' . $GOPATH . '/src/lint/golangci-lint/problems/problems.go'
+
+  try
+    let g:go_metalinter_command = a:metalinter
+    let expected = [
+          \ {'lnum': 3, 'bufnr': bufnr('%'), 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] Can''t run linter golint: golint: analysis skipped: errors in package'},
+          \ {'lnum': 3, 'bufnr': bufnr('%'), 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'e', 'module': '', 'text': 'Running error: golint: analysis skipped: errors in package'}
+        \ ]
+
+    " clear the quickfix lists
+    call setqflist([], 'r')
+
+    let g:go_metalinter_enabled = ['golint']
+
+    call go#lint#Gometa(0, 0)
 
     let actual = getqflist()
     let start = reltime()
@@ -60,6 +96,42 @@ func! s:gometaautosave(metalinter) abort
             \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function `MissingDoc` should have comment or be unexported (golint)'}
           \ ]
     endif
+
+    " clear the location lists
+    call setloclist(0, [], 'r')
+
+    let g:go_metalinter_autosave_enabled = ['golint']
+
+    call go#lint#Gometa(0, 1)
+
+    let actual = getloclist(0)
+    let start = reltime()
+    while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+      sleep 100m
+      let actual = getloclist(0)
+    endwhile
+
+    call gotest#assert_quickfix(actual, expected)
+  finally
+    call call(RestoreGOPATH, [])
+    unlet g:go_metalinter_autosave_enabled
+  endtry
+endfunc
+
+func! Test_GometaAutoSaveGolangciLint_problems() abort
+  call s:gometaautosave_problems('golangci-lint')
+endfunc
+
+func! s:gometaautosave_problems(metalinter) abort
+  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
+  silent exe 'e ' . $GOPATH . '/src/lint/golangci-lint/problems/ok.go'
+
+  try
+    let g:go_metalinter_command = a:metalinter
+    let expected = [
+          \ {'lnum': 3, 'bufnr': bufnr('%')+1, 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] Can''t run linter golint: golint: analysis skipped: errors in package'},
+          \ {'lnum': 3, 'bufnr': bufnr('%')+1, 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'e', 'module': '', 'text': 'Running error: golint: analysis skipped: errors in package'}
+        \ ]
 
     " clear the location lists
     call setloclist(0, [], 'r')
@@ -149,7 +221,7 @@ func! Test_Lint_GOPATH() abort
 
   let expected = [
           \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported'},
-          \ {'lnum': 5, 'bufnr': bufnr('%')+4, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
+          \ {'lnum': 5, 'bufnr': bufnr('%')+6, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
       \ ]
 
   let winnr = winnr()
@@ -177,7 +249,7 @@ func! Test_Lint_NullModule() abort
 
   let expected = [
           \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported'},
-          \ {'lnum': 5, 'bufnr': bufnr('%')+4, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
+          \ {'lnum': 5, 'bufnr': bufnr('%')+6, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
       \ ]
 
   let winnr = winnr()

--- a/autoload/go/test-fixtures/lint/src/lint/baz.go
+++ b/autoload/go/test-fixtures/lint/src/lint/baz.go
@@ -1,0 +1,3 @@
+package lint
+
+func baz() {}

--- a/autoload/go/test-fixtures/lint/src/lint/golangci-lint/problems/ok.go
+++ b/autoload/go/test-fixtures/lint/src/lint/golangci-lint/problems/ok.go
@@ -1,0 +1,3 @@
+package problems
+
+func bar() {}

--- a/autoload/go/test-fixtures/lint/src/lint/golangci-lint/problems/problems.go
+++ b/autoload/go/test-fixtures/lint/src/lint/golangci-lint/problems/problems.go
@@ -1,0 +1,5 @@
+package problems
+
+import "/quux"
+
+func baz() {}


### PR DESCRIPTION
##### lint: update golangci-lint handling to report compiler problems


##### lint: add tests for golangci-lint problems


##### lint: specify which linter's messages are to be filtered

Specify which linter's messages are to be filtered in
s:metalinterautosavecomplete.

Fixes #2700