### PR TITLE
Set shell to cmd.exe with flag /C on Windows

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -162,6 +162,14 @@ function! s:system(cmd, ...) abort
       set shell=/bin/sh shellredir=>%s\ 2>&1 shellcmdflag=-c
   endif
 
+  if go#util#IsWin()
+    let l:cmdexe=go#util#Join($SYSTEMROOT, 'System32', 'cmd.exe')
+    if executable(l:cmdexe)
+      let &shell = l:cmdexe
+      set shellcmdflag=/C
+    endif
+  endif
+
   try
     return call('system', [a:cmd] + a:000)
   finally


### PR DESCRIPTION
If shell was set to pwsh, then vim-go would fail when creating a new file from a template.

This PR sets the shell to `cmd.exe` with the `/C` flag, which is how stock vim on Windows is configured.

Fixes #2712.