### PR TITLE
Use COMSPEC to find cmd.exe.

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -163,9 +163,8 @@ function! s:system(cmd, ...) abort
   endif
 
   if go#util#IsWin()
-    let l:cmdexe=go#util#Join($SYSTEMROOT, 'System32', 'cmd.exe')
-    if executable(l:cmdexe)
-      let &shell = l:cmdexe
+    if executable($COMSPEC)
+      let &shell = $COMSPEC
       set shellcmdflag=/C
     endif
   endif


### PR DESCRIPTION
PR #2712 constructed a path to cmd.exe, but there is a standard environment variable that points to cmd.exe, which is COMSPEC. This fix uses COMSPEC.