### PR TITLE
lint: execute errcheck using ExecInDir

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -223,18 +223,19 @@ endfunction
 function! go#lint#Errcheck(bang, ...) abort
   if a:0 == 0
     let l:import_path = go#package#ImportPath()
-    if import_path == -1
+    if l:import_path == -1
       call go#util#EchoError('package is not inside GOPATH src')
       return
     endif
+    let l:args = [l:import_path]
   else
-    let l:import_path = join(a:000, ' ')
+    let l:args = a:000
   endif
 
   call go#util#EchoProgress('[errcheck] analysing ...')
   redraw
 
-  let [l:out, l:err] = go#util#Exec([go#config#ErrcheckBin(), '-abspath', l:import_path])
+  let [l:out, l:err] = go#util#ExecInDir([go#config#ErrcheckBin(), '-abspath'] + l:args)
 
   let l:listtype = go#list#Type("GoErrCheck")
   if l:err != 0

--- a/autoload/go/test-fixtures/lint/src/errcheck/errcheck.go
+++ b/autoload/go/test-fixtures/lint/src/errcheck/errcheck.go
@@ -1,0 +1,10 @@
+package errcheck
+
+import (
+	"io"
+	"os"
+)
+
+func foo() {
+	io.Copy(os.Stdout, os.Stdin)
+}

--- a/autoload/go/test-fixtures/lint/src/errcheck/errcheck_test.go
+++ b/autoload/go/test-fixtures/lint/src/errcheck/errcheck_test.go
@@ -1,0 +1,11 @@
+package errcheck
+
+import (
+	"io"
+	"os"
+	"testing"
+)
+
+func TestFoo(t *testing.T) {
+	io.Copy(os.Stdout, os.Stdin)
+}


### PR DESCRIPTION
Execute errcheck using ExecInDir so that it will use the package of the
current buffer. It looks like it was inadvertently changed from
ExecInDir to Exec a long while ago when the exec functions were
refactored.

Fixes #2725