### PR TITLE
lint: homogenize code quality tool calls

### DIFF
--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -158,9 +158,8 @@ func! Test_Vet() abort
   let l:tmp = gotest#load_fixture('lint/src/vet/vet.go')
 
   try
-
     let expected = [
-          \ {'lnum': 7, 'bufnr': bufnr('%'), 'col': 2, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '',
+          \ {'lnum': 7, 'bufnr': bufnr('%')+2, 'col': 2, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '',
           \ 'text': 'Printf format %d has arg str of wrong type string'}
         \ ]
 
@@ -188,9 +187,8 @@ func! Test_Vet_compilererror() abort
   let l:tmp = gotest#load_fixture('lint/src/vet/compilererror/compilererror.go')
 
   try
-
     let expected = [
-          \ {'lnum': 6, 'bufnr': bufnr('%'), 'col': 22, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': "missing ',' before newline in argument list (and 1 more errors)"}
+          \ {'lnum': 6, 'bufnr': bufnr('%')+2, 'col': 22, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': "missing ',' before newline in argument list (and 1 more errors)"}
         \ ]
 
     let winnr = winnr()

--- a/scripts/test
+++ b/scripts/test
@@ -69,6 +69,7 @@ find "$vimgodir" -name '*_test.vim' | while read test_file; do
   "$vimgodir/scripts/run-vim" $coverage $vim -e \
     +"silent e $test_file" \
     +"let g:test_verbose=$verbose" \
+    +"let g:go_echo_command_info=0" \
     -S ./scripts/runtest.vim < /dev/null || (
       # If Vim exits with non-0 it's almost certainly a bug in the test runner;
       # should very rarely happen in normal usage.


### PR DESCRIPTION
##### lint: homogenize vet and errcheck handling

* Use go#util#ExecInDir() when running go vet.
* Make the progress message when starting go vet consistent with
  errcheck's similiar progress message.
* Call go#cmd#autowrite() when starting go#lint#Errcheck to either write
  the buffers that have modifications when 'autowrite' or 'autowriteall'
  are set or display a message if neither of those options are set,
  because errcheck only analyzes files on disk.
* chagne the error message that's displayed when the package name cannot
  be determined to avoid implying that the package must be in GOPATH
  when the user is operating in module aware mode.
* Do not echo the start of errcheck progress if g:go_echo_command_info
  is cleared.
* disable g:go_echo_command_info when running tests to avoid screen
  clutter when tests fail.

##### lint: set progress and statusline for consistently


