### PR TITLE
fmt: format with gopls

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -64,8 +64,8 @@ function! go#fmt#Format(withGoimport) abort
   if l:err == 0
     call go#fmt#update_file(l:tmpname, expand('%'))
   elseif !go#config#FmtFailSilently()
-    let errors = s:parse_errors(expand('%'), out)
-    call s:show_errors(errors)
+    let l:errors = s:replace_filename(expand('%'), out)
+    call s:show_errors(l:errors)
   endif
 
   " We didn't use the temp file, so clean up
@@ -162,38 +162,27 @@ function! s:fmt_cmd(bin_name, source, target)
   return cmd
 endfunction
 
-" parse_errors parses the given errors and returns a list of parsed errors
-function! s:parse_errors(filename, content) abort
-  let splitted = split(a:content, '\n')
+" replace_filename replaces the filename on each line of content with
+" a:filename.
+function! s:replace_filename(filename, content) abort
+  let l:errors = split(a:content, '\n')
 
-  " list of errors to be put into location list
-  let errors = []
-  for line in splitted
-    let tokens = matchlist(line, '^\(.\{-}\):\(\d\+\):\(\d\+\)\s*\(.*\)')
-    if !empty(tokens)
-      call add(errors,{
-            \"filename": a:filename,
-            \"lnum":     tokens[2],
-            \"col":      tokens[3],
-            \"text":     tokens[4],
-            \ })
-    endif
-  endfor
-
-  return errors
+  let l:errors = map(l:errors, printf('substitute(v:val, ''^.\{-}:'', ''%s:'', '''')', a:filename))
+  return join(l:errors, "\n")
 endfunction
 
-" show_errors opens a location list and shows the given errors. If the given
-" errors is empty, it closes the the location list
+" show_errors opens a location list and shows the given errors. If errors is
+" empty, it closes the the location list.
 function! s:show_errors(errors) abort
+  let l:errorformat = '%f:%l:%c:\ %m'
   let l:listtype = go#list#Type("GoFmt")
-  if !empty(a:errors)
-    call go#list#Populate(l:listtype, a:errors, 'Format')
-  endif
+
+  call go#list#ParseFormat(l:listtype, l:errorformat, a:errors, 'Format')
+  let l:errors = go#list#Get(l:listtype)
 
   " this closes the window if there are no errors or it opens
-  " it if there is any
-  call go#list#Window(l:listtype, len(a:errors))
+  " it if there are any.
+  call go#list#Window(l:listtype, len(l:errors))
 endfunction
 
 function! go#fmt#ToggleFmtAutoSave() abort

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -18,6 +18,11 @@ set cpo&vim
 "  this and have VimL experience, please look at the function for
 "  improvements, patches are welcome :)
 function! go#fmt#Format(withGoimport) abort
+  let l:bin_name = go#config#FmtCommand()
+  if a:withGoimport == 1
+    let l:bin_name = "goimports"
+  endif
+
   if go#config#FmtExperimental()
     " Using winsaveview to save/restore cursor state has the problem of
     " closing folds on save:
@@ -52,13 +57,8 @@ function! go#fmt#Format(withGoimport) abort
     let l:tmpname = tr(l:tmpname, '\', '/')
   endif
 
-  let bin_name = go#config#FmtCommand()
-  if a:withGoimport == 1
-    let bin_name = "goimports"
-  endif
-
   let current_col = col('.')
-  let [l:out, l:err] = go#fmt#run(bin_name, l:tmpname, expand('%'))
+  let [l:out, l:err] = go#fmt#run(l:bin_name, l:tmpname, expand('%'))
   let diff_offset = len(readfile(l:tmpname)) - line('$')
 
   if l:err == 0

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -23,6 +23,11 @@ function! go#fmt#Format(withGoimport) abort
     let l:bin_name = "goimports"
   endif
 
+  if l:bin_name == 'gopls'
+    call go#lsp#Format()
+    return
+  endif
+
   if go#config#FmtExperimental()
     " Using winsaveview to save/restore cursor state has the problem of
     " closing folds on save:
@@ -65,7 +70,7 @@ function! go#fmt#Format(withGoimport) abort
     call go#fmt#update_file(l:tmpname, expand('%'))
   elseif !go#config#FmtFailSilently()
     let l:errors = s:replace_filename(expand('%'), out)
-    call s:show_errors(l:errors)
+    call go#fmt#ShowErrors(l:errors)
   endif
 
   " We didn't use the temp file, so clean up
@@ -173,7 +178,7 @@ endfunction
 
 " show_errors opens a location list and shows the given errors. If errors is
 " empty, it closes the the location list.
-function! s:show_errors(errors) abort
+function! go#fmt#ShowErrors(errors) abort
   let l:errorformat = '%f:%l:%c:\ %m'
   let l:listtype = go#list#Type("GoFmt")
 

--- a/autoload/go/fmt_test.vim
+++ b/autoload/go/fmt_test.vim
@@ -50,6 +50,71 @@ func! Test_goimports() abort
   call assert_equal(expected, actual)
 endfunc
 
+func! Test_run_fmt_gopls() abort
+  try
+    let g:go_fmt_command = 'gopls'
+
+    let actual_file = tempname()
+    call writefile(readfile("test-fixtures/fmt/hello.go"), actual_file)
+
+    let expected = join(readfile("test-fixtures/fmt/hello_golden.go"), "\n")
+
+    " run our code
+    call go#fmt#run("gofmt", actual_file, "test-fixtures/fmt/hello.go")
+
+    " this should now contain the formatted code
+    let actual = join(readfile(actual_file), "\n")
+
+    call assert_equal(expected, actual)
+  finally
+    unlet g:go_fmt_command
+  endtry
+endfunc
+
+func! Test_update_file_gopls() abort
+  try
+    let g:go_fmt_command = 'gopls'
+
+    let expected = join(readfile("test-fixtures/fmt/hello_golden.go"), "\n")
+    let source_file = tempname()
+    call writefile(readfile("test-fixtures/fmt/hello_golden.go"), source_file)
+
+    let target_file = tempname()
+    call writefile([""], target_file)
+
+    " update_file now
+    call go#fmt#update_file(source_file, target_file)
+
+    " this should now contain the formatted code
+    let actual = join(readfile(target_file), "\n")
+
+    call assert_equal(expected, actual)
+  finally
+    unlet g:go_fmt_command
+  endtry
+endfunc
+
+func! Test_goimports_gopls() abort
+  try
+    let g:go_fmt_command = 'gopls'
+
+    let $GOPATH = 'test-fixtures/fmt/'
+    let actual_file = tempname()
+    call writefile(readfile("test-fixtures/fmt/src/imports/goimports.go"), actual_file)
+
+    let expected = join(readfile("test-fixtures/fmt/src/imports/goimports_golden.go"), "\n")
+
+    " run our code
+    call go#fmt#run("goimports", actual_file, "test-fixtures/fmt/src/imports/goimports.go")
+
+    " this should now contain the formatted code
+    let actual = join(readfile(actual_file), "\n")
+
+    call assert_equal(expected, actual)
+  finally
+    unlet g:go_fmt_command
+  endtry
+endfunc
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -48,6 +48,21 @@ function! go#lsp#message#Shutdown() abort
        \ }
 endfunction
 
+function! go#lsp#message#Format(file) abort
+  return {
+          \ 'notification': 0,
+          \ 'method': 'textDocument/formatting',
+          \ 'params': {
+          \   'textDocument': {
+          \       'uri': go#path#ToURI(a:file)
+          \   },
+          \   'options': {
+          \     'insertSpaces': v:false,
+          \   },
+          \ }
+       \ }
+endfunction
+
 function! go#lsp#message#Exit() abort
   return {
           \ 'notification': 1,

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1342,8 +1342,8 @@ Use this option to auto |:GoFmt| on save. By default it's enabled >
 <
                                                           *'g:go_fmt_command'*
 
-Use this option to define which tool is used to gofmt. By default `gofmt` is
-used.
+Use this option to define which tool is used to gofmt. Valid options are
+`gofmt`, `goimports`, and `gopls`. By default `gofmt` is used.
 >
 
   let g:go_fmt_command = "gofmt"
@@ -1393,7 +1393,9 @@ fails. By default the location list is shown. >
 Use this option to enable fmt's experimental mode. This experimental mode is
 superior to the current mode as it fully saves the undo history, so undo/redo
 doesn't break. However, it's slow (creates/deletes a file for every save) and
-it's causing problems on some Vim versions. By default it's disabled. >
+it's causing problems on some Vim versions. This has no effect if
+`g:go_fmt_command` is set to `gopls`. By default it's disabled.
+>
 
   let g:go_fmt_experimental = 0
 


### PR DESCRIPTION
##### fmt: use errorformat to parse errors


##### fmt: scope bin_name uses and assign it at the top of go#fmt#Format


##### fmt: add an option to format with gopls

Add an option to format with gopls.


