### PR TITLE
make qf open with rightbelow as default

### DIFF
--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -31,7 +31,7 @@ function! go#list#Window(listtype, ...) abort
   if a:listtype == "locationlist"
     exe 'lopen ' . height
   else
-    exe 'copen ' . height
+    exe 'rightbelow copen ' . height
   endif
 endfunction
 


### PR DESCRIPTION
made qf open with righbelow looks would be more convenience. 
or maybe it can be added a option for it .. 
but for now, i think default as 'rightbelow' perhaps better, since many user may like set a side bar/split at the right side (e.g project tree or tagbar or sth) ...