### PR TITLE
preserve previous quickfix errors from formatting

### DIFF
--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -548,7 +548,7 @@ function! s:parse_guru_output(exit_val, output, title) abort
 
   let errformat = "%f:%l.%c-%[%^:]%#:\ %m,%f:%l:%c:\ %m"
   let l:listtype = go#list#Type("_guru")
-  call go#list#ParseFormat(l:listtype, errformat, a:output, a:title)
+  call go#list#ParseFormat(l:listtype, errformat, a:output, a:title, 0)
 
   let errors = go#list#Get(l:listtype)
   call go#list#Window(l:listtype, len(errors))

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -79,39 +79,51 @@ func! s:gometa_problems(metalinter) abort
 endfunc
 
 func! Test_GometaAutoSaveGolangciLint() abort
-  call s:gometaautosave('golangci-lint')
+  call s:gometaautosave('golangci-lint', 0)
 endfunc
 
-func! s:gometaautosave(metalinter) abort
+func! Test_GometaAutoSaveKeepsErrors() abort
+  call s:gometaautosave('golangci-lint', 1)
+endfunc
+
+func! s:gometaautosave(metalinter, withList) abort
   let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
   silent exe 'e ' . $GOPATH . '/src/lint/lint.go'
 
   try
     let g:go_metalinter_command = a:metalinter
-    let expected = [
+    let l:expected = [
           \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported (golint)'}
         \ ]
     if a:metalinter == 'golangci-lint'
-      let expected = [
+      let l:expected = [
             \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function `MissingDoc` should have comment or be unexported (golint)'}
           \ ]
     endif
 
-    " clear the location lists
-    call setloclist(0, [], 'r')
+    let l:list = []
+    if a:withList
+      let l:list = [
+            \ {'lnum': 1, 'bufnr': 1, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'before metalinter'}
+          \ ]
+      let l:expected = extend(l:list, l:expected)
+    endif
+
+    " set the location lists
+    call setloclist(0, l:list, 'r')
 
     let g:go_metalinter_autosave_enabled = ['golint']
 
     call go#lint#Gometa(0, 1)
 
-    let actual = getloclist(0)
-    let start = reltime()
-    while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+    let l:actual = getloclist(0)
+    let l:start = reltime()
+    while len(l:actual) != len(l:expected) && reltimefloat(reltime(l:start)) < 10
       sleep 100m
-      let actual = getloclist(0)
+      let l:actual = getloclist(0)
     endwhile
 
-    call gotest#assert_quickfix(actual, expected)
+    call gotest#assert_quickfix(l:actual, l:expected)
   finally
     call call(RestoreGOPATH, [])
     unlet g:go_metalinter_autosave_enabled

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -58,14 +58,14 @@ endfunction
 
 " Parse parses the given items based on the specified errorformat and
 " populates the list.
-function! go#list#ParseFormat(listtype, errformat, items, title) abort
+function! go#list#ParseFormat(listtype, errformat, items, title, add) abort
   " backup users errorformat, will be restored once we are finished
   let old_errorformat = &errorformat
 
   " parse and populate the location list
   let &errorformat = a:errformat
   try
-    call go#list#Parse(a:listtype, a:items, a:title)
+    call go#list#Parse(a:listtype, a:items, a:title, a:add)
   finally
     "restore back
     let &errorformat = old_errorformat
@@ -74,12 +74,25 @@ endfunction
 
 " Parse parses the given items based on the global errorformat and
 " populates the list.
-function! go#list#Parse(listtype, items, title) abort
+function! go#list#Parse(listtype, items, title, add) abort
+  let l:list = []
+  if a:add
+    let l:list = go#list#Get(a:listtype)
+  endif
+
   if a:listtype == "locationlist"
-    lgetexpr a:items
+    if a:add
+      laddexpr a:items
+    else
+      lgetexpr a:items
+    endif
     call setloclist(0, [], 'a', {'title': a:title})
   else
-    cgetexpr a:items
+    if a:add
+      caddexpr a:items
+    else
+      cgetexpr a:items
+    endif
     call setqflist([], 'a', {'title': a:title})
   endif
 endfunction

--- a/autoload/go/referrers.vim
+++ b/autoload/go/referrers.vim
@@ -31,7 +31,7 @@ function! s:parse_output(exit_val, output, title) abort
 
   let errformat = ",%f:%l:%c:\ %m"
   let l:listtype = go#list#Type("GoReferrers")
-  call go#list#ParseFormat(l:listtype, errformat, a:output, a:title)
+  call go#list#ParseFormat(l:listtype, errformat, a:output, a:title, 0)
 
   let errors = go#list#Get(l:listtype)
   call go#list#Window(l:listtype, len(errors))

--- a/autoload/go/tags.vim
+++ b/autoload/go/tags.vim
@@ -98,7 +98,7 @@ func s:write_out(out) abort
   if has_key(result, 'errors')
     let l:winnr = winnr()
     let l:listtype = go#list#Type("GoModifyTags")
-    call go#list#ParseFormat(l:listtype, "%f:%l:%c:%m", result['errors'], "gomodifytags")
+    call go#list#ParseFormat(l:listtype, "%f:%l:%c:%m", result['errors'], "gomodifytags", 0)
     call go#list#Window(l:listtype, len(result['errors']))
 
     "prevent jumping to quickfix list

--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -174,7 +174,7 @@ func s:handle_exit(job_id, exit_status, state) abort
     let l:i += 1
   endwhile
 
-  call go#list#ParseFormat(l:listtype, a:state.errorformat, a:state.stdout, l:title)
+  call go#list#ParseFormat(l:listtype, a:state.errorformat, a:state.stdout, l:title, 0)
   let l:errors = go#list#Get(l:listtype)
   call go#list#Window(l:listtype, len(l:errors))
 

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -80,7 +80,7 @@ function! go#test#Test(bang, compile, ...) abort
 
   if l:err != 0
     let l:winid = win_getid(winnr())
-    call go#list#ParseFormat(l:listtype, s:errorformat(), split(out, '\n'), l:cmd)
+    call go#list#ParseFormat(l:listtype, s:errorformat(), split(out, '\n'), l:cmd, 0)
     let errors = go#list#Get(l:listtype)
     call go#list#Window(l:listtype, len(errors))
     if empty(errors)


### PR DESCRIPTION
Don't overwrite quickfix lists from formatting the current buffer when
metalinting is run.

Fixes #2722.