### PR TITLE
issue: improve automated issue template execution

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -23,6 +23,7 @@ Use a *minimal* vimrc with other plugins disabled; do not link to a 2,000 line v
 
 If this is not provided or is obviously incomplete, the issue may be unceremoniously closed.
 -->
+<!-- vimrc -->
 <details><summary>vimrc</summary><br><pre>
 
 </pre></details>

--- a/autoload/go/issue.vim
+++ b/autoload/go/issue.vim
@@ -19,15 +19,13 @@ function! s:issuebody() abort
     let body = add(body, l)
 
     if l =~ '^<!-- :version'
-      redir => out
-        silent version
-      redir END
+      let out = execute('version')
       let body = extend(body, split(out, "\n")[0:2])
     elseif l =~ '^<!-- go version -->'
       let [out, err] = go#util#Exec(['go', 'version'])
       let body = add(body, substitute(l:out, rtrimpat, '', ''))
     elseif l =~ '^<!-- go env -->'
-      let [out, err] = go#util#Exec(['go', 'env'])
+      let [out, err] = go#util#ExecInDir(['go', 'env'])
       let body = add(body, substitute(l:out, rtrimpat, '', ''))
     elseif l=~ '^<!-- gopls version -->'
       let [out, err] = go#util#Exec(['gopls', 'version'])
@@ -35,7 +33,7 @@ function! s:issuebody() abort
     endif
   endfor
 
-  let body = add(body, "#### vim-go configuration:\n<details><summary>vim-go configuration</summary><br><pre>")
+  let body = add(body, "\n#### vim-go configuration:\n<details><summary>vim-go configuration</summary><br><pre>")
 
   for k in keys(g:)
     if k =~ '^go_'
@@ -43,6 +41,9 @@ function! s:issuebody() abort
     endif
   endfor
 
+  let body = add(body, '</pre></details>')
+
+  let body = add(body, printf("\n#### filetype detection configuration:\n<details><summary>filetype detection</summary><br><pre>%s", execute('filetype')))
   let body = add(body, '</pre></details>')
 
   return join(body, "\n")


### PR DESCRIPTION
* include filetype detection settings
* run `go env` in the directory containing the current buffer to get the
  relevant GOMOD value
* Use execute() instead of redir