### PR TITLE
update for Go 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.13
+  - 1.14
 notifications:
   email: false
 matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13
+FROM golang:1.14.0-buster
 
 RUN apt-get update -y && \
   apt-get install -y build-essential curl git libncurses5-dev python3-pip && \

--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -219,6 +219,14 @@ function! s:errorformat() abort
   let format .= ",%G" . indent . "%#%\\t%\\{2}%m"
   " }}}1
 
+  " Go 1.14 test verbose output {{{1
+  " Match test output lines similarly to Go 1.11 test output lines, but they
+  " have the test name followed by a colon before the filename when run with
+  " the -v flag.
+  let format .= ",%A" . indent . "%\\+%[%^:]%\\+: %f:%l: %m"
+  let format .= ",%A" . indent . "%\\+%[%^:]%\\+: %f:%l: "
+  " }}}1
+
   " Go 1.11 test output {{{1
   " Match test output lines similarly to Go 1.10 test output lines, but they
   " use an indent level where the Go 1.10 test output uses tabs, so they'll


### PR DESCRIPTION
Use Go 1.14 for testing.

Update go test error handling to account for changes to go test -v
output.