### PR TITLE
lsp: drop out of date diagnostics

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -120,6 +120,8 @@ function! go#fmt#update_file(source, target)
   " reload buffer to reflect latest changes
   silent edit!
 
+  call go#lsp#DidChange(expand(a:target, ':p'))
+
   let &fileformat = old_fileformat
   let &syntax = &syntax
 

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -224,11 +224,20 @@ function! s:newlsp() abort
   function! l:lsp.updateDiagnostics() dict abort
     for l:data in self.diagnosticsQueue
       call remove(self.diagnosticsQueue, 0)
+
+      let l:fname = go#path#FromURI(l:data.uri)
+      " don't process the messages if the file has already changed.
+      let l:lsp = s:lspfactory.get()
+      let l:version = get(l:lsp.fileVersions, l:fname, 0)
+      if l:version != 0 && l:data.version == l:version
+        continue
+      endif
+
       try
         let l:diagnostics = []
         let l:errorMatches = []
         let l:warningMatches = []
-        let l:fname = go#path#FromURI(l:data.uri)
+
         " get the buffer name relative to the current directory, because
         " Vim says that a buffer name can't be an absolute path.
         let l:bufname = fnamemodify(l:fname, ':.')

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -622,7 +622,6 @@ function! go#util#HighlightPositions(group, pos) abort
       " use a single line prop by default
       let l:prop = {'type': a:group, 'length': l:pos[2]}
 
-      " specify end line and column if needed.
       let l:line = getline(l:pos[0])
 
       " l:max is the 1-based index within the buffer of the first character after l:pos.
@@ -632,6 +631,7 @@ function! go#util#HighlightPositions(group, pos) abort
         " https://github.com/vim/vim/issues/5334) is available.
         let l:end_lnum = byte2line(l:max)
 
+        " specify end line and column if needed.
         if l:pos[0] != l:end_lnum
           let l:end_col = l:max - line2byte(l:end_lnum)
           let l:prop = {'type': a:group, 'end_lnum': l:end_lnum, 'end_col': l:end_col}


### PR DESCRIPTION
Drop out of date diagnostics so that highlighting will not be applied
incorrectly. Running `:GoImports` was causing errors sometimes and
causing highlighting to be applied on the wrong lines since it changed
the source.

Send changes to gopls after formatting with gofmt or goimports so that
gopls will have the current version.