### PR TITLE
lsp: drop out of date diagnostics

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -117,8 +117,15 @@ function! go#fmt#update_file(source, target)
     call setfperm(a:target , original_fperm)
   endif
 
+  " reset diagnostic matches before reloading so that any locations that have
+  " been invalidated by formatting won't cause errors when the buffer is
+  " reloaded from disk.
+  let b:go_diagnostic_matches = {'errors': [], 'warnings': []}
+
   " reload buffer to reflect latest changes
   silent edit!
+
+  call go#lsp#DidChange(expand(a:target, ':p'))
 
   let &fileformat = old_fileformat
   let &syntax = &syntax

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -224,11 +224,13 @@ function! s:newlsp() abort
   function! l:lsp.updateDiagnostics() dict abort
     for l:data in self.diagnosticsQueue
       call remove(self.diagnosticsQueue, 0)
+
       try
         let l:diagnostics = []
         let l:errorMatches = []
         let l:warningMatches = []
         let l:fname = go#path#FromURI(l:data.uri)
+
         " get the buffer name relative to the current directory, because
         " Vim says that a buffer name can't be an absolute path.
         let l:bufname = fnamemodify(l:fname, ':.')
@@ -267,7 +269,13 @@ function! s:newlsp() abort
         endif
 
         if bufnr(l:bufname) == bufnr('')
-          call s:highlightMatches(l:errorMatches, l:warningMatches)
+          " only apply highlighting when the diagnostics are for the current
+          " version.
+          let l:lsp = s:lspfactory.get()
+          let l:version = get(l:lsp.fileVersions, l:fname, 0)
+          if l:version != 0 && l:data.version == l:version
+            call s:highlightMatches(l:errorMatches, l:warningMatches)
+          endif
         endif
 
         let self.diagnostics[l:fname] = l:diagnostics

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -622,7 +622,6 @@ function! go#util#HighlightPositions(group, pos) abort
       " use a single line prop by default
       let l:prop = {'type': a:group, 'length': l:pos[2]}
 
-      " specify end line and column if needed.
       let l:line = getline(l:pos[0])
 
       " l:max is the 1-based index within the buffer of the first character after l:pos.
@@ -632,6 +631,7 @@ function! go#util#HighlightPositions(group, pos) abort
         " https://github.com/vim/vim/issues/5334) is available.
         let l:end_lnum = byte2line(l:max)
 
+        " specify end line and column if needed.
         if l:pos[0] != l:end_lnum
           let l:end_col = l:max - line2byte(l:end_lnum)
           let l:prop = {'type': a:group, 'end_lnum': l:end_lnum, 'end_col': l:end_col}
@@ -657,7 +657,6 @@ function! go#util#HighlightPositions(group, pos) abort
     return s:matchaddpos(a:group, a:pos)
   endif
 endfunction
-
 
 " s:matchaddpos works around matchaddpos()'s limit of only 8 positions per
 " call by calling matchaddpos() with no more than 8 positions per call.


### PR DESCRIPTION
Drop out of date diagnostics so that highlighting will not be applied
incorrectly.

Running :GoImports was causing errors sometimes and
causing highlighting to be applied on the wrong lines since it changed
the source. Since formatting with gofmt or goimports will change the
files, clear the diagnostic errors and warnings before reloading the
buffer so that the BufWinEnter autocmd doesn't try to set the matches to
the wrong locations.

Send changes to gopls after formatting with gofmt or goimports so that
gopls will have the current version.