### PR TITLE
config: add new options for gopls

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -530,6 +530,10 @@ function! go#config#GoplsUsePlaceholders() abort
   return get(g:, 'go_gopls_use_placeholders', v:null)
 endfunction
 
+function! go#config#GoplsTempModfile() abort
+  return get(g:, 'go_gopls_temp_modfile', v:null)
+endfunction
+
 function! go#config#GoplsEnabled() abort
   return get(g:, 'go_gopls_enabled', 1)
 endfunction
@@ -539,7 +543,7 @@ function! go#config#DiagnosticsEnabled() abort
 endfunction
 
 function! go#config#GoplsOptions() abort
-  return get(g: 'g:go_gopls_options', [])
+  return get(g:, 'go_gopls_options', [])
 endfunction
 
 " Set the default value. A value of "1" is a shortcut for this, for

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -538,6 +538,10 @@ function! go#config#DiagnosticsEnabled() abort
   return get(g:, 'go_diagnostics_enabled', 0)
 endfunction
 
+function! go#config#GoplsOptions() abort
+  return get(g: 'g:go_gopls_options', [])
+endfunction
+
 " Set the default value. A value of "1" is a shortcut for this, for
 " compatibility reasons.
 if exists("g:go_gorename_prefill") && g:go_gorename_prefill == 1

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -466,11 +466,26 @@ function! s:newlsp() abort
   endif
 
   let l:cmd = [l:bin_path]
+  let l:cmdopts = go#config#GoplsOptions()
+
   if go#util#HasDebug('lsp')
-    let l:cmd = extend(l:cmd, ['-debug', 'localhost:0'])
+    " debugging can be enabled either with g:go_debug or with
+    " g:go_gopls_options; use g:go_gopls_options if it's given in case users
+    " are running the gopls debug server on a known port.
+    let l:needsDebug = 1
+
+    for l:item in l:cmdopts
+      let l:idx = stridx(l:item, '-debug')
+      if l:idx == 0 || l:idx == 1
+        let l:needsDebug = 0
+      endif
+    endfor
+    if l:needsDebug
+      let l:cmd = extend(l:cmd, ['-debug', 'localhost:0'])
+    endif
   endif
 
-  let l:lsp.job = go#job#Start(l:cmd, l:opts)
+  let l:lsp.job = go#job#Start(l:cmd+l:cmdopts, l:opts)
 
   return l:lsp
 endfunction

--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -212,6 +212,7 @@ function! go#lsp#message#ConfigurationResult(items) abort
     let l:config = {
           \ 'buildFlags': [],
           \ 'hoverKind': 'NoDocumentation',
+          \ 'tempModFile': v:true,
           \ }
     let l:buildtags = go#config#BuildTags()
     if buildtags isnot ''
@@ -223,6 +224,7 @@ function! go#lsp#message#ConfigurationResult(items) abort
     let l:completeUnimported = go#config#GoplsCompleteUnimported()
     let l:staticcheck = go#config#GoplsStaticCheck()
     let l:usePlaceholder = go#config#GoplsUsePlaceholders()
+    let l:tempModfile = go#config#GoplsTempModfile()
 
     if l:deepCompletion isnot v:null
       if l:deepCompletion
@@ -257,6 +259,14 @@ function! go#lsp#message#ConfigurationResult(items) abort
         let l:config.usePlaceholders = v:true
       else
         let l:config.usePlaceholders = v:false
+      endif
+    endif
+
+    if l:tempModfile isnot v:null
+      if l:tempModfile
+        let l:config.tempModfile = v:true
+      else
+        let l:config.tempModfile = v:false
       endif
     endif
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1743,6 +1743,13 @@ options may also need to be adjusted.
   let g:go_gopls_enabled = 1
 <
 
+                                                        *'g:go_gopls_options'*
+
+The commandline arguments to pass to gopls. By default, it's an empty array.
+>
+  let g:go_gopls_options = []
+<
+
                                             *'g:go_gopls_complete_unimported'*
 
 Specifies whether `gopls` should include suggestions from unimported packages.

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1753,7 +1753,7 @@ The commandline arguments to pass to gopls. By default, it's an empty array.
                                             *'g:go_gopls_complete_unimported'*
 
 Specifies whether `gopls` should include suggestions from unimported packages.
-When it is `v:null`, `gopls`' defaults will be used. By default it is
+When it is `v:null`, `gopls`' default will be used. By default it is
 `v:null`.
 >
   let g:go_gopls_complete_unimported = v:null
@@ -1762,7 +1762,7 @@ When it is `v:null`, `gopls`' defaults will be used. By default it is
                                                 *'g:go_gopls_deep_completion'*
 
 Specifies whether `gopls` should use deep completion. When it is `v:null`,
-`gopls`' defaults will be used. By default it is `v:null`.
+`gopls`' default will be used. By default it is `v:null`.
 
 >
   let g:go_gopls_deep_completion = v:null
@@ -1771,7 +1771,7 @@ Specifies whether `gopls` should use deep completion. When it is `v:null`,
                                                        *'g:go_gopls_matcher'*
 
 Specifies how `gopls` should match for completions. Valid values are `v:null`,
-`fuzzy`, and `caseSensitive`.  When it is `v:null`, `gopls`' defaults will be
+`fuzzy`, and `caseSensitive`.  When it is `v:null`, `gopls`' default will be
 used. By default it is `v:null`.
 >
   let g:go_gopls_matcher = v:null
@@ -1780,7 +1780,7 @@ used. By default it is `v:null`.
                                                    *'g:go_gopls_staticcheck'*
 
 Specifies whether `gopls` should run staticcheck checks. When it is `v:null`,
-`gopls`' defaults will be used. By default it is `v:null`.
+`gopls`' default will be used. By default it is `v:null`.
 >
   let g:go_gopls_staticcheck = v:null
 <
@@ -1790,10 +1790,19 @@ Specifies whether `gopls` should run staticcheck checks. When it is `v:null`,
 Specifies whether `gopls` can provide placeholders for function parameters and
 struct fields. When set, completion items will be treated as anonymous
 snippets if UltiSnips is installed and configured to be used as
-|'g:go_snippet_engine'|. When it is `v:null`, `gopls`' defaults will be used.
+|'g:go_snippet_engine'|. When it is `v:null`, `gopls`' default will be used.
 By default it is `v:null`.
 >
   let g:go_gopls_use_placeholders = v:null
+<
+
+                                                   *'g:go_gopls_temp_modfile'*
+
+Specifies whether `gopls` should use a temp modfile and suggest edits rather
+than modifying the ambient go.mod file.  When it is `v:null`, `gopls`' default
+will be used.  By default it is `v:null`.
+>
+  let g:go_gopls_temp_modfile = v:null
 <
 
                                                  *'g:go_diagnostics_enabled'*


### PR DESCRIPTION
##### config: add g:go_gopls_options

Add an option, g:go_gopls_options, for gopls commandline options.


##### config: add g:go_gopls_temp_modfile

Add a new option, g:go_gopls_temp_modfile to configure gopls'
tempModfile configuration option.


