### PR TITLE
fmt: show errors when g:go_fmt_command is gopls

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -189,7 +189,7 @@ function! go#fmt#ShowErrors(errors) abort
   let l:errorformat = '%f:%l:%c:\ %m'
   let l:listtype = go#list#Type("GoFmt")
 
-  call go#list#ParseFormat(l:listtype, l:errorformat, a:errors, 'Format')
+  call go#list#ParseFormat(l:listtype, l:errorformat, a:errors, 'Format', 0)
   let l:errors = go#list#Get(l:listtype)
 
   " this closes the window if there are no errors or it opens


### PR DESCRIPTION
Show errors when g:go_fmt_command is gopls by passing the final argument
to go#list#ParseFormat. That parameter was added and merged via a branch
that was created after the branch for adding support for gopls go
g:go_fmt_command was created but was merged first.