### PR TITLE
use get to get version from data dictionary

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -273,7 +273,7 @@ function! s:newlsp() abort
           " version.
           let l:lsp = s:lspfactory.get()
           let l:version = get(l:lsp.fileVersions, l:fname, 0)
-          let l:data_version = get(l.data, 'version', 0)
+          let l:data_version = get(l:data, 'version', 0)
           if l:version != 0 && l:data_version == l:version
             call s:highlightMatches(l:errorMatches, l:warningMatches)
           endif

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -273,7 +273,8 @@ function! s:newlsp() abort
           " version.
           let l:lsp = s:lspfactory.get()
           let l:version = get(l:lsp.fileVersions, l:fname, 0)
-          if l:version != 0 && l:data.version == l:version
+          let l:data_version = get(l.data, 'version', 0)
+          if l:version != 0 && l:data_version == l:version
             call s:highlightMatches(l:errorMatches, l:warningMatches)
           endif
         endif


### PR DESCRIPTION
Since I recently updated the vim-go plugin, I kept getting `E716` error messages about a missing `version` key in a dictionary. Some debugging pointed me to the `lsp.vim` autoload file, where `l:version` is being compared to `l:data.version`. It turns out the latter might be missing.

Instead, I've opted to add `l:data_version = get(l:data, 'version', 0)`. The default `0` pretty much ensuring there won't be a match with `l:version` (as the condition starts with `l:version != 0`). I've not kept up with the development of the lsp development, so I'm not sure if this is the definitive solution here, but it definitely got rid of the annoying red banner at the bottom of my screen :)

Some details as to my setup:

go version go1.13.6 linux/amd64 (Fedora31)

```
GO111MODULE=""
GOARCH="amd64"
GOBIN=""
GOCACHE="/home/elias/.cache/go-build"
GOENV="/home/elias/.config/go/env"
GOEXE=""
GOFLAGS=""
GOHOSTARCH="amd64"
GOHOSTOS="linux"
GONOPROXY=""
GONOSUMDB=""
GOOS="linux"
GOPATH="/home/elias/go"
GOPRIVATE=""
GOPROXY="direct"
GOROOT="/usr/lib/golang"
GOSUMDB="off"
GOTMPDIR=""
GOTOOLDIR="/usr/lib/golang/pkg/tool/linux_amd64"
GCCGO="gccgo"
AR="ar"
CC="gcc"
CXX="g++"
CGO_ENABLED="1"
GOMOD=""
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-g -O2"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-g -O2"
PKG_CONFIG="pkg-config"
GOGCCFLAGS="-fPIC -m64 -pthread -fmessage-length=0 -fdebug-prefix-map=/tmp/go-build065783368=/tmp/go-build -gno-record-gcc-switches"
```

Vim:

```
VIM - Vi IMproved 8.2 (2019 Dec 12, compiled Feb 10 2020 00:00:00)
Included patches: 1-236
Modified by <bugzilla@redhat.com>
Compiled by <bugzilla@redhat.com>
Huge version with GTK3 GUI.  Features included (+) or not (-):
+acl               -farsi             -mouse_sysmouse    -tag_old_static
+arabic            +file_in_path      +mouse_urxvt       -tag_any_white
+autocmd           +find_in_path      +mouse_xterm       -tcl
+autochdir         +float             +multi_byte        +termguicolors
-autoservername    +folding           +multi_lang        +terminal
+balloon_eval      -footer            -mzscheme          +terminfo
+balloon_eval_term +fork()            +netbeans_intg     +termresponse
+browse            +gettext           +num64             +textobjects
++builtin_terms    -hangul_input      +packages          +textprop
+byte_offset       +iconv             +path_extra        +timers
+channel           +insert_expand     +perl/dyn          +title
+cindent           +job               +persistent_undo   +toolbar
+clientserver      +jumplist          +popupwin          +user_commands
+clipboard         +keymap            +postscript        +vartabs
+cmdline_compl     +lambda            +printer           +vertsplit
+cmdline_hist      +langmap           +profile           +virtualedit
+cmdline_info      +libcall           -python            +visual
+comments          +linebreak         +python3/dyn       +visualextra
+conceal           +lispindent        +quickfix          +viminfo
+cryptv            +listcmds          +reltime           +vreplace
+cscope            +localmap          +rightleft         +wildignore
+cursorbind        +lua/dyn           +ruby/dyn          +wildmenu
+cursorshape       +menu              +scrollbind        +windows
+dialog_con_gui    +mksession         +signs             +writebackup
+diff              +modify_fname      +smartindent       +X11
+digraphs          +mouse             -sound             -xfontset
+dnd               +mouseshape        +spell             +xim
-ebcdic            +mouse_dec         +startuptime       +xpm
+emacs_tags        +mouse_gpm         +statusline        +xsmp_interact
+eval              -mouse_jsbterm     -sun_workshop      +xterm_clipboard
+ex_extra          +mouse_netterm     +syntax            -xterm_save
+extra_search      +mouse_sgr         +tag_binary        
   system vimrc file: "/etc/vimrc"
     user vimrc file: "$HOME/.vimrc"
 2nd user vimrc file: "~/.vim/vimrc"
      user exrc file: "$HOME/.exrc"
  system gvimrc file: "/etc/gvimrc"
    user gvimrc file: "$HOME/.gvimrc"
2nd user gvimrc file: "~/.vim/gvimrc"
       defaults file: "$VIMRUNTIME/defaults.vim"
    system menu file: "$VIMRUNTIME/menu.vim"
  fall-back for $VIM: "/etc"
 f-b for $VIMRUNTIME: "/usr/share/vim/vim82"
Compilation: gcc -c -I. -Iproto -DHAVE_CONFIG_H -DFEAT_GUI_GTK  -I/usr/include/gtk-3.0 -I/usr/include/pango-1.0 -I/usr/include/glib-2.0 -I/usr/lib64/glib-2.0/include -I/usr/include/harfbuzz -I/usr/include/fribidi -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/cairo -I/usr/include/pixman-1 -I/usr/include/gdk-pixbuf-2.0 -I/usr/include/libmount -I/usr/include/blkid -I/usr/include/gio-unix-2.0 -I/usr/include/libdrm -I/usr/include/atk-1.0 -I/usr/include/at-spi2-atk/2.0 -I/usr/include/at-spi-2.0 -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include -pthread    -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=1       
Linking: gcc   -L. -Wl,-z,relro  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -fstack-protector-strong -rdynamic -Wl,-export-dynamic -Wl,--enable-new-dtags -Wl,-z,relro -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld  -Wl,-z,relro  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -lpython3.7m -lcrypt -lpthread -ldl  -lutil -lm  -L/usr/local/lib -Wl,--as-needed -o vim   -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -lharfbuzz -latk-1.0 -lcairo-gobject -lcairo -lgdk_pixbuf-2.0 -lgio-2.0 -lgobject-2.0 -lglib-2.0  -lSM -lICE -lXpm -lXt -lX11 -lSM -lICE  -lm  -lselinux  -lncurses -lacl -lattr -lgpm -ldl   -Wl,--enable-new-dtags -Wl,-z,relro -Wl,--as-needed -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -Wl,-z,relro -Wl,--as-needed -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -fstack-protector-strong -L/usr/local/lib  -L/usr/lib64/perl5/CORE -lperl -lpthread -lresolv -ldl -lm -lcrypt -lutil -lc        

```

The actual error from `vim -V9debug.log foo.go` that pointed me to this file:

```
Searching for "/home/user/.vim/plugged/vim-go/autoload/go/lsp/lsp.vim"
chdir(/home/user/.vim/plugged/vim-go/autoload/go/lsp)
fchdir() to previous dir
line 14: sourcing "/home/user/.vim/plugged/vim-go/autoload/go/lsp/lsp.vim"
finished sourcing /home/user/.vim/plugged/vim-go/autoload/go/lsp/lsp.vim
continuing in go#guru#SameIds
[...]
vim-go: function 125[10]..128[3]..129[2]..130, line 52: Vim(if):E716: Key not present in Dictionary: version == l:version
```