### PR TITLE
lsp: highlight diagnostics when version is missing

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -273,7 +273,7 @@ function! s:newlsp() abort
           " version.
           let l:lsp = s:lspfactory.get()
           let l:version = get(l:lsp.fileVersions, l:fname, 0)
-          if l:version != 0 && l:data.version == l:version
+          if l:version != 0 && (!has_key(l:data, 'version') || l:data.version == l:version)
             call s:highlightMatches(l:errorMatches, l:warningMatches)
           endif
         endif


### PR DESCRIPTION
publishDiagnostics seems to sometimes be missing a version. When that's
the case, skip trying to compare the versions.

Fixes #2757 