### PR TITLE
Add option for GoFmt on close

### DIFF
--- a/autoload/go/auto.vim
+++ b/autoload/go/auto.vim
@@ -132,6 +132,15 @@ function! s:handler(timer_id)
   let s:timer_id = 0
 endfunction
 
+function! go#auto#fmt_autoclose()
+  if !(go#config#FmtAutoclose() && isdirectory(expand('%:p:h')) && expand('<afile>:p') == expand('%:p'))
+    return
+  endif
+
+  " Go code formatting on save
+  call go#fmt#Format(-1)
+endfunction
+
 function! go#auto#fmt_autosave()
   if !(go#config#FmtAutosave() && isdirectory(expand('%:p:h')) && expand('<afile>:p') == expand('%:p'))
     return

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -303,6 +303,10 @@ function! go#config#ListHeight() abort
   return get(g:, "go_list_height", 0)
 endfunction
 
+function! go#config#FmtAutoclose() abort
+	return get(g:, "go_fmt_autoclose", 0)
+endfunction
+
 function! go#config#FmtAutosave() abort
 	return get(g:, "go_fmt_autosave", 1)
 endfunction

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -96,7 +96,10 @@ augroup vim-go-buffer
     autocmd CompleteDone <buffer> call go#auto#complete_done()
   endif
 
+  " Only format when leaving.  Avoids dumb fold closing
+  " but still ensures formatting is done
   autocmd BufWritePre <buffer> call go#auto#fmt_autosave()
+  autocmd BufWinLeave <buffer> call go#auto#fmt_autoclose()
   autocmd BufWritePost <buffer> call go#auto#metalinter_autosave()
 
   "TODO(bc): how to clear sameids and diagnostics when a non-go buffer is


### PR DESCRIPTION
Ref Issue #2771 .

setting the following will disable auto formatting on save but enable it on closing the buffer.

```
let g:go_fmt_autosave = 0 
let g:go_fmt_autoclose = 1
```