### PR TITLE
lsp: keep diagnostics highlighting on format

### DIFF
--- a/autoload/go/config_test.vim
+++ b/autoload/go/config_test.vim
@@ -97,6 +97,7 @@ func! Test_GoplsEnabled_Clear() abort
 
   finally
     unlet g:go_gopls_enabled
+    call delete(l:tmp, 'rf')
   endtry
 endfunc
 " restore Vi compatibility settings

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -484,7 +484,11 @@ function! s:same_ids_highlight(exit_val, output, mode) abort
     " is redisplayed: e.g. :edit, :GoRename, etc.
     augroup vim-go-sameids
       autocmd! * <buffer>
-      autocmd BufWinEnter <buffer> nested call go#guru#SameIds(0)
+      if has('textprop')
+        autocmd BufReadPost <buffer> nested call go#guru#SameIds(0)
+      else
+        autocmd BufWinEnter <buffer> nested call go#guru#SameIds(0)
+      endif
     augroup end
   endif
 endfunction

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -559,7 +559,7 @@ function! go#util#SetEnv(name, value) abort
 endfunction
 
 function! go#util#ClearHighlights(group) abort
-  if exists('*prop_remove')
+  if has('textprop')
     " the property type may not exist when syntax highlighting is not enabled.
     if empty(prop_type_get(a:group))
       return
@@ -617,7 +617,7 @@ endfunction
 " pos should be a list of 3 element lists. The lists should be [line, col,
 " length] as used by matchaddpos().
 function! go#util#HighlightPositions(group, pos) abort
-  if exists('*prop_add')
+  if has('textprop')
     for l:pos in a:pos
       " use a single line prop by default
       let l:prop = {'type': a:group, 'length': l:pos[2]}

--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -12,9 +12,6 @@ set cpo&vim
 " The full path to the created directory is returned, it is the caller's
 " responsibility to clean that up!
 fun! gotest#write_file(path, contents) abort
-  if go#util#has_job()
-    call go#lsp#CleanWorkspaces()
-  endif
   let l:dir = go#util#tempdir("vim-go-test/testrun/")
   let $GOPATH .= ':' . l:dir
   let l:full_path = l:dir . '/src/' . a:path
@@ -22,10 +19,6 @@ fun! gotest#write_file(path, contents) abort
   call mkdir(fnamemodify(l:full_path, ':h'), 'p')
   call writefile(a:contents, l:full_path)
   exe 'cd ' . l:dir . '/src'
-
-  if go#util#has_job()
-    call go#lsp#AddWorkspaceDirectory(fnamemodify(l:full_path, ':p:h'))
-  endif
 
   silent exe 'e! ' . a:path
 

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -99,25 +99,29 @@ augroup vim-go-buffer
   autocmd BufWritePre <buffer> call go#auto#fmt_autosave()
   autocmd BufWritePost <buffer> call go#auto#metalinter_autosave()
 
-  "TODO(bc): how to clear sameids and diagnostics when a non-go buffer is
-  " loaded into a window and the previously loaded buffer is still loaded in
-  " another window?
+  if !has('textprop')
+    "TODO(bc): how to clear sameids and diagnostics when a non-go buffer is
+    " loaded into a window and the previously loaded buffer is still loaded in
+    " another window?
 
-  " clear SameIds when the buffer is unloaded from its last window so that
-  " loading another buffer (especially of a different filetype) in the same
-  " window doesn't highlight the most recently matched identifier's positions.
-  autocmd BufWinLeave <buffer> call go#guru#ClearSameIds()
-  " clear SameIds when a new buffer is loaded in the window so that the
-  " previous buffer's highlighting isn't used.
-  autocmd BufWinEnter <buffer> call go#guru#ClearSameIds()
+    " TODO(bc): only clear when the new buffer isn't the old buffer
 
-  " clear diagnostics when the buffer is unloaded from its last window so that
-  " loading another buffer (especially of a different filetype) in the same
-  " window doesn't highlight th previously loaded buffer's diagnostics.
-  autocmd BufWinLeave <buffer> call go#lsp#ClearDiagnosticHighlights()
-  " clear diagnostics when a new buffer is loaded in the window so that the
-  " previous buffer's diagnostics aren't used.
-  autocmd BufWinEnter <buffer> call go#lsp#ClearDiagnosticHighlights()
+    " clear SameIds when the buffer is unloaded from its last window so that
+    " loading another buffer (especially of a different filetype) in the same
+    " window doesn't highlight the most recently matched identifier's positions.
+    autocmd BufWinLeave <buffer> call go#guru#ClearSameIds()
+    " clear SameIds when a new buffer is loaded in the window so that the
+    " previous buffer's highlighting isn't used.
+    autocmd BufWinEnter <buffer> call go#guru#ClearSameIds()
+
+    " clear diagnostics when the buffer is unloaded from its last window so that
+    " loading another buffer (especially of a different filetype) in the same
+    " window doesn't highlight the previously loaded buffer's diagnostics.
+    autocmd BufWinLeave <buffer> call go#lsp#ClearDiagnosticHighlights()
+    " clear diagnostics when a new buffer is loaded in the window so that the
+    " previous buffer's diagnostics aren't used.
+    "autocmd BufWinEnter <buffer> call go#lsp#ClearDiagnosticHighlights()
+  endif
 
   autocmd BufEnter <buffer>
         \  if go#config#AutodetectGopath() && !exists('b:old_gopath')

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -38,8 +38,7 @@ call s:checkVersion()
 " these packages are used by vim-go and can be automatically installed if
 " needed by the user with GoInstallBinaries.
 
-" NOTE(bc): varying the binary name and the tail of the import path (e.g.
-" gocode-gomod) does not yet work in module aware mode.
+" NOTE(bc): varying the binary name and the tail of the import path does not yet work in module aware mode.
 let s:packages = {
       \ 'asmfmt':        ['github.com/klauspost/asmfmt/cmd/asmfmt@master'],
       \ 'dlv':           ['github.com/go-delve/delve/cmd/dlv@master'],

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -399,7 +399,7 @@ function! s:hi()
   " filetype plugin on, the highlight groups won't be defined when
   " ftplugin/go.vim is executed when the first go file is opened.
   " See https://github.com/fatih/vim-go/issues/2658.
-  if exists('*prop_type_add')
+  if has('textprop')
     if empty(prop_type_get('goSameId'))
       call prop_type_add('goSameId', {'highlight': 'goSameId'})
     endif


### PR DESCRIPTION
##### fmt: add tests for highlighting gopls diagnostics

Add tests for highlighting gopls diagnostics:
* verify diagnostic highlights when a file is changed by gofmt on save.
* verify diagnostic highlights when a file is saved and not changed by
  gofmt.
* verify diagnostic highlights when a file is reloaded.

Cleanup a file added by gotest#write_file that was previously left
around.

Add a # Please enter the commit message for your changes. Lines starting


##### fmt: preserve gopls diagnostic highlighting

Preserve highlight of gopls sourced diagnostics when formatting.

Use `has('textprop')` instead of exists('*prop_remove') to determine
whether to use text properties.

Try to preserve column after formatting by shifting the cursor over when
the line has indentation added.

Fixes #2753 