### PR TITLE
lsp: clear list when formatting

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -128,18 +128,7 @@ function! go#fmt#update_file(source, target)
   let &fileformat = old_fileformat
   let &syntax = &syntax
 
-  let l:listtype = go#list#Type("GoFmt")
-
-  " clean up previous list
-  if l:listtype == "quickfix"
-    let l:list_title = getqflist({'title': 1})
-  else
-    let l:list_title = getloclist(0, {'title': 1})
-  endif
-
-  if has_key(l:list_title, "title") && l:list_title['title'] == "Format"
-    call go#list#Clean(l:listtype)
-  endif
+  call go#fmt#CleanErrors()
 endfunction
 
 " run runs the gofmt/goimport command for the given source file and returns
@@ -179,6 +168,21 @@ function! s:replace_filename(filename, content) abort
 
   let l:errors = map(l:errors, printf('substitute(v:val, ''^.\{-}:'', ''%s:'', '''')', a:filename))
   return join(l:errors, "\n")
+endfunction
+
+function! go#fmt#CleanErrors() abort
+  let l:listtype = go#list#Type("GoFmt")
+
+  " clean up previous list
+  if l:listtype == "quickfix"
+    let l:list_title = getqflist({'title': 1})
+  else
+    let l:list_title = getloclist(0, {'title': 1})
+  endif
+
+  if has_key(l:list_title, "title") && l:list_title['title'] == "Format"
+    call go#list#Clean(l:listtype)
+  endif
 endfunction
 
 " show_errors opens a location list and shows the given errors. If errors is

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -1301,6 +1301,8 @@ function! go#lsp#Format() abort
   let l:msg = go#lsp#message#Format(l:fname)
   call l:lsp.sendMessage(l:msg, l:state)
 
+  call go#fmt#CleanErrors()
+
   " await the result to avoid any race conditions among autocmds (e.g.
   " BufWritePre and BufWritePost)
   call formatHandler.await()
@@ -1362,12 +1364,14 @@ function! s:formatHandler(msg) abort dict
 endfunction
 
 function! s:handleFormatError(filename, msg) abort dict
-  if !go#config#FmtFailSilently()
-    let l:errors = split(a:msg, '\n')
-    let l:errors = map(l:errors, printf('substitute(v:val, ''^'', ''%s:'', '''')', a:filename))
-    let l:errors = join(l:errors, "\n")
-    call go#fmt#ShowErrors(l:errors)
+  if go#config#FmtFailSilently()
+    return
   endif
+
+  let l:errors = split(a:msg, '\n')
+  let l:errors = map(l:errors, printf('substitute(v:val, ''^'', ''%s:'', '''')', a:filename))
+  let l:errors = join(l:errors, "\n")
+  call go#fmt#ShowErrors(l:errors)
 endfunction
 
 function! s:textEditLess(left, right) abort


### PR DESCRIPTION
Clear the location list when formatting with gopls before processing
results for consistency with behavior when using goimports or gofmt.