### PR TITLE
config: spell g:go_imports_mode correctly

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -351,8 +351,8 @@ function! go#config#FmtCommand() abort
   return get(g:, "go_fmt_command", "gofmt")
 endfunction
 
-function! go#config#ImportsCommand() abort
-  return get(g:, "go_imports_command", "goimports")
+function! go#config#ImportsMode() abort
+  return get(g:, "go_imports_mode", "goimports")
 endfunction
 
 function! go#config#FmtOptions() abort

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -20,8 +20,8 @@ set cpo&vim
 function! go#fmt#Format(withGoimport) abort
   let l:bin_name = go#config#FmtCommand()
   if a:withGoimport == 1
-    let l:bin_name = go#config#ImportsCommand()
-    if l:bin_name == 'gopls'
+    let l:mode = go#config#ImportsMode()
+    if l:mode == 'gopls'
       if !go#config#GoplsEnabled()
         call go#util#EchoError("go_def_mode is 'gopls', but gopls is disabled")
         return

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1401,13 +1401,13 @@ it's causing problems on some Vim versions. This has no effect if
 
 <
 
-                                                      *'g:go_imports_command'*
+                                                        *'g:go_imports_mode'*
 
 Use this option to define which tool is used to adjust imports. Valid options
 are `goimports` and `gopls`. By default `goimports` is used.
 >
 
-  let g:go_imports_command = "goimports"
+  let g:go_imports_mode = "goimports"
 <
                                                      *'g:go_mod_fmt_autosave'*
 


### PR DESCRIPTION
Change the spelling of an option from g:go_imports_command to
g:go_imports_mode