### PR TITLE
fmt: fix :GoImports

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -23,12 +23,14 @@ function! go#fmt#Format(withGoimport) abort
     let l:mode = go#config#ImportsMode()
     if l:mode == 'gopls'
       if !go#config#GoplsEnabled()
-        call go#util#EchoError("go_def_mode is 'gopls', but gopls is disabled")
+        call go#util#EchoError("go_imports_mode is 'gopls', but gopls is disabled")
         return
       endif
       call go#lsp#Imports()
       return
     endif
+
+    let l:bin_name = 'goimports'
   endif
 
   if l:bin_name == 'gopls'


### PR DESCRIPTION
Fix :GoImports so that it works as expected when g:go_imports_mode is
not gopls.

Fix the an error message so that it refers to g:go_imports_mode instead
of g:go_def_mode.