### PR TITLE
adjust imports on save

### DIFF
--- a/autoload/go/auto.vim
+++ b/autoload/go/auto.vim
@@ -133,11 +133,28 @@ function! s:handler(timer_id)
 endfunction
 
 function! go#auto#fmt_autosave()
-  if !(go#config#FmtAutosave() && isdirectory(expand('%:p:h')) && expand('<afile>:p') == expand('%:p'))
+  if !(isdirectory(expand('%:p:h')) && expand('<afile>:p') == expand('%:p'))
     return
   endif
 
-  " Go code formatting on save
+  if !(go#config#FmtAutosave() || go#config#ImportsAutosave())
+    return
+  endif
+
+  if go#config#ImportsAutosave() && !(go#config#FmtAutosave() && go#config#FmtCommand() == 'goimports')
+    call go#fmt#Format(1)
+
+    " return early when the imports mode is goimports, because there's no need
+    " to format again when goimports was run
+    if go#config#ImportsMode() == 'goimports'
+      return
+    endif
+  endif
+
+  if !go#config#FmtAutosave()
+    return
+  endif
+
   call go#fmt#Format(-1)
 endfunction
 

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -307,6 +307,10 @@ function! go#config#FmtAutosave() abort
 	return get(g:, "go_fmt_autosave", 1)
 endfunction
 
+function! go#config#ImportsAutosave() abort
+  return get(g:, 'go_imports_autosave', 1)
+endfunction
+
 function! go#config#SetFmtAutosave(value) abort
   let g:go_fmt_autosave = a:value
 endfunction

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -1354,7 +1354,7 @@ function! go#lsp#Imports() abort
   let l:handler = go#promise#New(function('s:handleCodeAction', [], l:state), 10000, '')
   let l:state.handleResult = l:handler.wrapper
   let l:state.error = l:handler.wrapper
-  " let l:state.handleError = function('s:handleCodeActionError', [l:fname], l:state)
+  let l:state.handleError = function('s:handleCodeActionError', [l:fname], l:state)
   let l:msg = go#lsp#message#CodeActionImports(l:fname)
   call l:lsp.sendMessage(l:msg, l:state)
 
@@ -1374,6 +1374,11 @@ function! s:handleFormat(msg) abort dict
 endfunction
 
 function! s:handleCodeAction(msg) abort dict
+  if type(a:msg) is type('')
+    call self.handleError(a:msg)
+    return
+  endif
+
   if a:msg is v:null
     return
   endif

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1401,7 +1401,13 @@ it's causing problems on some Vim versions. This has no effect if
 
 <
 
-                                                        *'g:go_imports_mode'*
+                                                     *'g:go_imports_autosave'*
+
+Use this option to auto |:GoImports| on save. By default it's enabled.
+>
+  let g:go_imports_autosave = 1
+<
+                                                         *'g:go_imports_mode'*
 
 Use this option to define which tool is used to adjust imports. Valid options
 are `goimports` and `gopls`. By default `goimports` is used.


### PR DESCRIPTION
Introduce a new option, g:go_imports_autosave, to allow imports to be
adjusted even when g:go_fmt_command is not set to goimports.

Closes #2795