### PR TITLE
adjust imports on save

### DIFF
--- a/autoload/go/auto.vim
+++ b/autoload/go/auto.vim
@@ -133,11 +133,28 @@ function! s:handler(timer_id)
 endfunction
 
 function! go#auto#fmt_autosave()
-  if !(go#config#FmtAutosave() && isdirectory(expand('%:p:h')) && expand('<afile>:p') == expand('%:p'))
+  if !(isdirectory(expand('%:p:h')) && expand('<afile>:p') == expand('%:p'))
     return
   endif
 
-  " Go code formatting on save
+  if !(go#config#FmtAutosave() || go#config#ImportsAutosave())
+    return
+  endif
+
+  if go#config#ImportsAutosave() && !(go#config#FmtAutosave() && go#config#FmtCommand() == 'goimports')
+    call go#fmt#Format(1)
+
+    " return early when the imports mode is goimports, because there's no need
+    " to format again when goimports was run
+    if go#config#ImportsMode() == 'goimports'
+      return
+    endif
+  endif
+
+  if !go#config#FmtAutosave()
+    return
+  endif
+
   call go#fmt#Format(-1)
 endfunction
 

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -307,6 +307,10 @@ function! go#config#FmtAutosave() abort
 	return get(g:, "go_fmt_autosave", 1)
 endfunction
 
+function! go#config#ImportsAutosave() abort
+  return get(g:, 'go_imports_autosave', 1)
+endfunction
+
 function! go#config#SetFmtAutosave(value) abort
   let g:go_fmt_autosave = a:value
 endfunction

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1401,7 +1401,13 @@ it's causing problems on some Vim versions. This has no effect if
 
 <
 
-                                                        *'g:go_imports_mode'*
+                                                     *'g:go_imports_autosave'*
+
+Use this option to auto |:GoImports| on save. By default it's enabled.
+>
+  let g:go_imports_autosave = 1
+<
+                                                         *'g:go_imports_mode'*
 
 Use this option to define which tool is used to adjust imports. Valid options
 are `goimports` and `gopls`. By default `goimports` is used.


### PR DESCRIPTION
Introduce a new option, g:go_imports_autosave, to allow imports to be
adjusted even when g:go_fmt_command is not set to goimports.

Closes #2795