### PR TITLE
Add additional deoplete instructions to vim-go.txt

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -140,6 +140,10 @@ The following plugins are supported for use with vim-go:
 
 * Real-time completion (Neovim and Vim 8):
   https://github.com/Shougo/deoplete.nvim
+  
+  Make sure "noselect" is set in the 'completeopt' option.
+  
+    set completeopt+=noselect
 
   Add the following line to your vimrc. This instructs deoplete to use omni
   completion for Go files.


### PR DESCRIPTION
I was having issues with autocompletion in Neovim after updating Go to 1.14.1 and updating all my Neovim dependencies. I was poking around and noticed the following commit:

https://github.com/Shougo/deoplete.nvim/commit/479e1fd81a612f9987a0179a8b35c8da35943fd8

In `doc/deoplete.txt`:
> Note: You need to set "noselect" in 'completeopt' option to work.

I added `set completeopt+=noselect` _before_ making the "omni_patterns" call and all seemed to work like normal.

Feel free to discard, however, if these instructions are not broadly applicable. Thanks!