### PR TITLE
Run gogetdoc in the dir containing the file

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -192,10 +192,10 @@ function! s:gogetdoc(json) abort
 
   if &modified
     let l:cmd += ['-modified']
-    return go#util#Exec(l:cmd, go#util#archive())
+    return go#util#ExecInDir(l:cmd, go#util#archive())
   endif
 
-  return go#util#Exec(l:cmd)
+  return go#util#ExecInDir(l:cmd)
 endfunction
 
 " returns the package and exported name. exported name might be empty.


### PR DESCRIPTION
My company keeps its `go` source in a subdir of the main git repo.  I typically start vim in the root of the repo.  When using `K` to view the documentation of a keyword in a go file, I get an error (output of `gogetdoc`) such as:

```
vim-go: cannot load package containing /my/repo/go/my-daemon/handler/handler.go: go [list -e -json -compiled -test=false -export=false -deps=true -- /my/repo/go/my-daemon/handler]: exit status 1: go: directory go/my-daemon/handler is outside main module
```

If I `pushd go` and run `vim`, the documentation displays as expected, but running vim in this way this complicates some of my non-`go` editing and plugin setup.

This pr fixes the issue by starting `gogetdoc` in the dir containing the open file, I presume by making `go list` able to find the main module.

Thanks!