### PR TITLE
lint: do not duplicate errors in quickfix on save

### DIFF
--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -194,7 +194,7 @@ function! go#fmt#CleanErrors() abort
     let l:list_title = getloclist(0, {'title': 1})
   endif
 
-  if has_key(l:list_title, "title") && l:list_title['title'] == "Format"
+  if has_key(l:list_title, 'title') && (l:list_title['title'] == 'Format' || l:list_title['title'] == 'GoMetaLinterAutoSave')
     call go#list#Clean(l:listtype)
   endif
 endfunction

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -378,7 +378,7 @@ function! s:lint_job(metalinter, args, bang, autosave)
     let l:opts.for = "GoMetaLinterAutoSave"
     " s:metalinterautosavecomplete is really only needed for golangci-lint
     let l:opts.complete = funcref('s:metalinterautosavecomplete', [a:metalinter, expand('%:p:t')])
-    let l:opts.preserveerrors = function('s:preserveerrors')
+    let l:opts.preserveerrors = funcref('s:preserveerrors'), [a:autosave])
   endif
 
   " autowrite is not enabled for jobs

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -83,9 +83,11 @@ function! go#lint#Gometa(bang, autosave, ...) abort
   endif
 
   if a:autosave
-    let l:listtype = go#list#Type("GoMetaLinterAutoSave")
+    let l:listtype = go#list#Type('GoMetaLinterAutoSave')
+    let l:for = 'GoMetaLinterAutoSave'
   else
-    let l:listtype = go#list#Type("GoMetaLinter")
+    let l:listtype = go#list#Type('GoMetaLinter')
+    let l:for = 'GoMetaLinterAuto'
   endif
 
   if l:err == 0
@@ -100,7 +102,7 @@ function! go#lint#Gometa(bang, autosave, ...) abort
     if a:autosave
       call s:metalinterautosavecomplete(l:metalinter, fnamemodify(expand('%:p'), ":."), 0, 1, l:messages)
     endif
-    call go#list#ParseFormat(l:listtype, errformat, l:messages, 'GoMetaLinter', s:preserveerrors(a:autosave, l:listtype))
+    call go#list#ParseFormat(l:listtype, errformat, l:messages, l:for, s:preserveerrors(a:autosave, l:listtype))
 
     let errors = go#list#Get(l:listtype)
     call go#list#Window(l:listtype, len(errors))
@@ -370,15 +372,15 @@ function! s:lint_job(metalinter, args, bang, autosave)
   let l:opts = {
         \ 'statustype': a:args.statustype,
         \ 'errorformat': a:args.errformat,
-        \ 'for': "GoMetaLinter",
+        \ 'for': 'GoMetaLinter',
         \ 'bang': a:bang,
       \ }
 
   if a:autosave
-    let l:opts.for = "GoMetaLinterAutoSave"
+    let l:opts.for = 'GoMetaLinterAutoSave'
     " s:metalinterautosavecomplete is really only needed for golangci-lint
     let l:opts.complete = funcref('s:metalinterautosavecomplete', [a:metalinter, expand('%:p:t')])
-    let l:opts.preserveerrors = funcref('s:preserveerrors'), [a:autosave])
+    let l:opts.preserveerrors = funcref('s:preserveerrors', [a:autosave])
   endif
 
   " autowrite is not enabled for jobs
@@ -449,8 +451,8 @@ function! s:errorformat(metalinter) abort
 
 endfunction
 
-function! s:preserveerrors(listtype) abort
-  return a:listtype == go#list#Type("GoFmt") && go#config#FmtAutosave() && isdirectory(expand('%:p:h'))
+function! s:preserveerrors(autosave, listtype) abort
+  return a:autosave && a:listtype == go#list#Type("GoFmt") && go#config#FmtAutosave() && isdirectory(expand('%:p:h'))
 endfunction
 
 " restore Vi compatibility settings


### PR DESCRIPTION
##### lint: fix function reference

Fix references to s:preserveerrors to avoid an error when using the
function reference.


##### lint: allow errors to be cleared on save

* Allow errors to be cleared on save.
* Take a:autosave into account in s:preserveerrors so that errors won't
  be preserved unexpectedly.
* Normalize some strings relevant to this change to use single quoted
  strings instead of double quoted strings.

Fixes #2809


