### PR TITLE
run: fix command output

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -174,7 +174,7 @@ function! go#cmd#Run(bang, ...) abort
   if go#util#IsWin()
     try
       if go#util#HasDebug('shell-commands')
-        call go#util#EchoInfo('shell command: ' . l:cmd)
+        call go#util#EchoInfo(printf('shell command: %s', string(l:cmd)))
       endif
 
       execute l:cd . fnameescape(expand("%:p:h"))


### PR DESCRIPTION
Output the command properly when g:go_debug has 'shell-commands' so that
an error isn't raised.