### PR TITLE
ignore invalid channel ids when stopping gopls

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 .dlv/
 .git/
 .viminfo
+issues/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
-.DS_Store
-/doc/tags
-/.coverage.covimerage
-/coverage.xml
 *.pyc
+.DS_Store
+/.bash_history
+/.cache
+/.config
+/.coverage.covimerage
+/.local
+/coverage.xml
+/doc/tags
+/issues

--- a/scripts/runtest.vim
+++ b/scripts/runtest.vim
@@ -81,8 +81,12 @@ for s:test in sort(s:tests)
   " Restore the working directory after each test.
   execute s:cd . s:dir
 
-  " exit gopls after each test
-  call go#lsp#Exit()
+  try
+    " exit gopls after each test
+    call go#lsp#Exit()
+  catch /^Vim(call):E900: Invalid channel id/
+    " do nothing - gopls has stopped
+  endtry
 
   let s:done += 1
 


### PR DESCRIPTION
Ignore invalid channel ids when stopping gopls in scripts/runtest. After
the release of gopls v0.4.0, Neovim tests started failing due to an
invalid channel id when trying to stop gopls.