### PR TITLE
doc: Fix typo

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1469,7 +1469,7 @@ Use this option to define the command to be used for |:GoReferrers|. By
 default `gopls` is used, because it is the fastest and works with Go modules.
 One might also use `guru` for its ability to show references from other
 packages.  This option will be removed after `gopls` can show references from
-other packages. Valid options are `gopls` and `guru`. By default it's `guru`.
+other packages. Valid options are `gopls` and `guru`. By default it's `gopls`.
 >
   let g:go_referrers_mode = 'gopls'
 <


### PR DESCRIPTION
This PR fixes a typo in the docs. The default of `g:go_referrers_mode` is `gopls`.

https://github.com/fatih/vim-go/blob/80943242fa8a13313bbbfe4e78b40d3309f8b7ee/autoload/go/config.vim#L515