### PR TITLE
doc: update g:go_jump_to_error documentation

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1326,11 +1326,12 @@ value from 'updatetime'. By default it's set to 800ms.
                                                         *'g:go_jump_to_error'*
 
 Use this option to enable/disable passing the bang attribute to the mappings
-|(go-build)|, |(go-run)|, etc..  When enabled it will jump to the first error
-automatically (means it will NOT pass the bang attribute to the appropriate
-command, i.e: (go-run) -> :GoRun ). Note, that calling this doesn't have any
-affect on calling the commands manually. This setting is only useful for
-changing the behaviour of our custom static mappings. By default it's enabled.
+(e.g. |(go-build)|, |(go-run)|, etc.) and the metalinter on save.  When
+enabled it will jump to the first error automatically (means it will NOT pass
+the bang attribute to the appropriate command, i.e: (go-run) -> :GoRun ).
+Note, that calling this doesn't have any affect on calling the commands
+manually. This setting is only useful for changing the behaviour of our custom
+static mappings. By default it's enabled.
 >
   let g:go_jump_to_error = 1
 <


### PR DESCRIPTION
Document that g:go_jump_to_error is also used to control whether
metalinter errors are jumped to on save.