### PR TITLE
syntax: highlight package name if requested

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -406,6 +406,10 @@ function! go#config#SearchBinPathFirst() abort
   return get(g:, 'go_search_bin_path_first', 1)
 endfunction
 
+function! go#config#HighlightPackageName() abort
+  return get(g:, 'go_highlight_package_name', 0)
+endfunction
+
 function! go#config#HighlightArrayWhitespaceError() abort
   return get(g:, 'go_highlight_array_whitespace_error', 0)
 endfunction

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2038,6 +2038,12 @@ Disable everything (same as not setting 'foldmethod' to `syntax`):
 >
   let g:go_fold_enable = []
 <
+                                     *'g:go_highlight_package_name'*
+
+Highlight package name.
+
+  let g:go_highlight_package_name = 0
+
                                      *'g:go_highlight_array_whitespace_error'*
 
 Highlight white space after `[]`. >

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -11,7 +11,13 @@ endif
 
 syn case match
 
-syn keyword     goPackage           package
+if go#config#HighlightPackageName()
+  syn keyword goPackage     package nextgroup=goPackageName skipwhite
+  syn match   goPackageName /\w\+/  contained skipwhite
+else
+  syn keyword goPackage package
+endif
+
 syn keyword     goImport            import    contained
 syn keyword     goVar               var       contained
 syn keyword     goConst             const     contained


### PR DESCRIPTION
Hello,

I am building custom color scheme for vim and was trying to highlight package name like:
```
package *main* // <-- I want main to be highlighted
```
Because package is keyword and has highest priority I wan't able to customise it from my local vim config, so I prepared this PR. If there is a way to do it differently please let me know.

Anyway I think it is nice addition for those who need the same functionality.

Thank you!