### PR TITLE
Import/ignore commented

### DIFF
--- a/autoload/go/import.vim
+++ b/autoload/go/import.vim
@@ -82,7 +82,7 @@ function! go#import#SwitchImport(enabled, localname, path, bang) abort
       while line <= line("$")
         let line = line + 1
         let linestr = getline(line)
-        let m = matchlist(getline(line), '^\()\|\(\s\+\)\(\S*\s*\)"\(.\+\)"\)')
+        let m = matchlist(getline(line), '^\()\|\(\s\+\)\(\w\+\s\+\)\="\(.\+\)"\)')
         if empty(m)
           if siteprefix == "" && a:enabled
             " must be in the first group

--- a/autoload/go/import_test.vim
+++ b/autoload/go/import_test.vim
@@ -1,0 +1,35 @@
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+func! Test_SwitchImportAddIgnoresCommented()
+  try
+    let l:tmp = gotest#write_file('import/import.go', [
+          \ 'package import',
+          \ '',
+          \ 'import (',
+          \ "\t" . '// "fmt"',
+          \ "\t" . '"io"',
+          \ "\t" . '"ioutil"',
+          \ "\t" . '"os"',
+          \ ')',
+          \ '',
+          \ 'func main() {',
+          \ ' io.Copy(ioutil.Discard, os.Stdin)',
+          \ ' fmt.Println("import the package")',
+          \ '}',
+        \ ])
+    call go#import#SwitchImport(1, '', 'fmt', 0)
+
+    let l:actual = getline(4)
+    call assert_equal("\t" . '"fmt"', l:actual)
+  finally
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et


### PR DESCRIPTION
##### import: disregard commented imports

Adjust the regular expression that matches existing imports so that
commented out package imports will will not be matched.

Fixes #1717


##### import: add test

Add a test to verify that imports that are commented out are ignored by
go#import#SwitchImport


