### PR TITLE
fixes errormessage when detecting a neovim version < 0.4.0

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -19,7 +19,7 @@ function! s:checkVersion() abort
 
     if l:unsupported == 1
       echohl Error
-      echom "vim-go requires at least Vim 8.0.1453 or Neovim 0.3.2, but you're using an older version."
+      echom "vim-go requires at least Vim 8.0.1453 or Neovim 0.4.0, but you're using an older version."
       echom "Please update your Vim for the best vim-go experience."
       echom "If you really want to continue you can set this to make the error go away:"
       echom "    let g:go_version_warning = 0"


### PR DESCRIPTION
currently, vim-go states that neovim version has to be >= 0.3.2 while it actually checks for a version >= 0.4.0

This commit changes the errormessage