### PR TITLE
lint: handle paths in go vet errors correctly

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -204,8 +204,8 @@ function! go#lint#Golint(bang, ...) abort
   call go#statusline#Update(expand('%:p:h'), l:status)
 endfunction
 
-" Vet calls 'go vet' on the current directory. Any warnings are populated in
-" the location list
+" Vet calls 'go vet' on the current buffer's directory. Any warnings are
+" populated in the location list
 function! go#lint#Vet(bang, ...) abort
   call go#cmd#autowrite()
 
@@ -250,7 +250,13 @@ function! go#lint#Vet(bang, ...) abort
 
     let l:winid = win_getid(winnr())
     let l:errorformat = "%-Gexit status %\\d%\\+," . &errorformat
-    call go#list#ParseFormat(l:listtype, l:errorformat, out, "GoVet", 0)
+    let l:dir = getcwd()
+    call go#util#Chdir(expand('%:p:h'))
+    try
+      call go#list#ParseFormat(l:listtype, l:errorformat, out, "GoVet", 0)
+    finally
+      call go#util#Chdir(l:dir)
+    endtry
     let l:errors = go#list#Get(l:listtype)
 
     if empty(l:errors)

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -277,7 +277,7 @@ func! Test_Vet() abort
 
   try
     let expected = [
-          \ {'lnum': 7, 'bufnr': bufnr('%')+2, 'col': 2, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '',
+          \ {'lnum': 7, 'bufnr': bufnr('%'), 'col': 2, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '',
           \ 'text': 'Printf format %d has arg str of wrong type string'}
         \ ]
 
@@ -340,7 +340,7 @@ func! Test_Vet_compilererror() abort
 
   try
     let expected = [
-          \ {'lnum': 6, 'bufnr': bufnr('%')+2, 'col': 22, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': "missing ',' before newline in argument list (and 1 more errors)"}
+          \ {'lnum': 6, 'bufnr': bufnr('%'), 'col': 22, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': "missing ',' before newline in argument list (and 1 more errors)"}
         \ ]
 
     let winnr = winnr()

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -301,6 +301,40 @@ func! Test_Vet() abort
   endtry
 endfunc
 
+func! Test_Vet_subdir() abort
+  let l:tmp = gotest#load_fixture('lint/src/vet/vet.go')
+
+  " go up one directory to easily test that go vet's file paths are handled
+  " correctly when the working directory is not the directory that contains
+  " the file being vetted.
+  call go#util#Chdir('..')
+
+  try
+    let expected = [
+          \ {'lnum': 7, 'bufnr': bufnr('%'), 'col': 2, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '',
+          \ 'text': 'Printf format %d has arg str of wrong type string'}
+        \ ]
+
+    let winnr = winnr()
+
+    " clear the location lists
+    call setqflist([], 'r')
+
+    call go#lint#Vet(1)
+
+    let actual = getqflist()
+    let start = reltime()
+    while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+      sleep 100m
+      let actual = getqflist()
+    endwhile
+
+    call gotest#assert_quickfix(actual, expected)
+  finally
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
 func! Test_Vet_compilererror() abort
   let l:tmp = gotest#load_fixture('lint/src/vet/compilererror/compilererror.go')
 

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -678,6 +678,15 @@ function! s:matchaddpos(group, pos) abort
   endfor
 endfunction
 
+function! go#util#Chdir(dir) abort
+  if !exists('*chdir')
+    let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
+    execute cd . a:dir
+    return
+  endif
+  call chdir(a:dir)
+endfunction
+
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -18,7 +18,7 @@ fun! gotest#write_file(path, contents) abort
 
   call mkdir(fnamemodify(l:full_path, ':h'), 'p')
   call writefile(a:contents, l:full_path)
-  exe 'cd ' . l:dir . '/src'
+  call go#util#Chdir(l:dir . '/src')
 
   silent exe 'e! ' . a:path
 
@@ -57,7 +57,7 @@ fun! gotest#load_fixture(path) abort
   let l:full_path = l:dir . '/src/' . a:path
 
   call mkdir(fnamemodify(l:full_path, ':h'), 'p')
-  exe 'cd ' . l:dir . '/src'
+  call go#util#Chdir(l:dir . '/src')
   silent exe 'noautocmd e ' . a:path
   silent exe printf('read %s/test-fixtures/%s', g:vim_go_root, a:path)
   silent noautocmd w!


### PR DESCRIPTION
##### util: add go#util#Chdir

Add go#util#Chdir to act as a shim for chdir(), which is not available
in Neovim.

##### lint: add test for go#lint#Vet

Add a test to verify that paths returned in go vet's output are
interpreted relative to the current buffer.

##### lint: correct go#lint#Vet tests

Correct go#lint#Vet tests to expect that the error is for the current
buffer.

##### lint: interpret go vet's errors relative to the correct directory

Fixes #2881 