### PR TITLE
Improve formatting experience

### DIFF
--- a/autoload/go/fmt_test.vim
+++ b/autoload/go/fmt_test.vim
@@ -3,49 +3,21 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 func! Test_run_fmt() abort
-  let actual_file = tempname()
-  call writefile(readfile("test-fixtures/fmt/hello.go"), actual_file)
+  let input_file = "test-fixtures/fmt/hello.go"
+  let actual = join(go#fmt#run(-1, readfile(input_file), input_file), "\n")
 
   let expected = join(readfile("test-fixtures/fmt/hello_golden.go"), "\n")
-
-  " run our code
-  call go#fmt#run("gofmt", actual_file, "test-fixtures/fmt/hello.go")
-
-  " this should now contain the formatted code
-  let actual = join(readfile(actual_file), "\n")
-
-  call assert_equal(expected, actual)
-endfunc
-
-func! Test_update_file() abort
-  let expected = join(readfile("test-fixtures/fmt/hello_golden.go"), "\n")
-  let source_file = tempname()
-  call writefile(readfile("test-fixtures/fmt/hello_golden.go"), source_file)
-
-  let target_file = tempname()
-  call writefile([""], target_file)
-
-  " update_file now
-  call go#fmt#update_file(source_file, target_file)
-
-  " this should now contain the formatted code
-  let actual = join(readfile(target_file), "\n")
 
   call assert_equal(expected, actual)
 endfunc
 
 func! Test_goimports() abort
   let $GOPATH = 'test-fixtures/fmt/'
-  let actual_file = tempname()
-  call writefile(readfile("test-fixtures/fmt/src/imports/goimports.go"), actual_file)
+
+  let input_file = "test-fixtures/fmt/src/imports/goimports.go"
+  let actual = join(go#fmt#run(1, readfile(input_file), input_file), "\n")
 
   let expected = join(readfile("test-fixtures/fmt/src/imports/goimports_golden.go"), "\n")
-
-  " run our code
-  call go#fmt#run("goimports", actual_file, "test-fixtures/fmt/src/imports/goimports.go")
-
-  " this should now contain the formatted code
-  let actual = join(readfile(actual_file), "\n")
 
   call assert_equal(expected, actual)
 endfunc

--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -99,8 +99,8 @@ fun! gotest#assert_buffer(skipHeader, want) abort
   try
     call writefile(l:buffer, l:tmp . '/have')
     call writefile(l:want, l:tmp . '/want')
-    call go#fmt#run('gofmt', l:tmp . '/have', l:tmp . '/have')
-    call go#fmt#run('gofmt', l:tmp . '/want', l:tmp . '/want')
+    call system('gofmt -w ' . l:tmp . '/have')
+    call system('gofmt -w ' . l:tmp . '/want')
     let [l:out, l:err] = go#util#Exec(["diff", "-u", l:tmp . '/have', l:tmp . '/want'])
   finally
     call delete(l:tmp . '/have')

--- a/scripts/install-vim
+++ b/scripts/install-vim
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Install and setup a Vim or Neovim for running tests.
 # This should work on both Travis and people's desktop computers, and be 100%
@@ -65,10 +65,15 @@ cd "$srcdir"
 # 0.2.0 doesn't have a binary build for Linux, so we use 0.2.1-dev for now.
 if [ "$1" = "nvim" ]; then
 
-  # TODO: Use macOS binaries on macOS
-  curl -Ls https://github.com/neovim/neovim/releases/download/$tag/nvim-linux64.tar.gz |
-    tar xzf - -C /tmp/vim-go-test/
-  mv /tmp/vim-go-test/nvim-linux64 /tmp/vim-go-test/nvim-install
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    curl -Ls https://github.com/neovim/neovim/releases/download/$tag/nvim-macos.tar.gz |
+      tar xzf - -C /tmp/vim-go-test/
+    mv /tmp/vim-go-test/nvim-osx64 /tmp/vim-go-test/nvim-install
+  else
+    curl -Ls https://github.com/neovim/neovim/releases/download/$tag/nvim-linux64.tar.gz |
+      tar xzf - -C /tmp/vim-go-test/
+    mv /tmp/vim-go-test/nvim-linux64 /tmp/vim-go-test/nvim-install
+  fi
   mkdir -p "$installdir/share/nvim/runtime/pack/vim-go/start"
   ln -s "$vimgodir" "$installdir/share/nvim/runtime/pack/vim-go/start/vim-go"
 


### PR DESCRIPTION
This PR fixes annoying bug in golang formatting with goimport: after saving the errors are in wrong lines and each package added by go fmt. You can reproduce this by configuring vim-go to use go-import and formatting following file:

```golang
package main

import (
	"github.com/gocql/gocql"
)

func main() {
	ip := "ok"

	fmt.Println(gocql.NewCluster(ip))
}
```

After saving this the `fmt` is added to imports, but you'll get an error on line `ip := "ok"` with following message: `undeclared name: fmt`. The error happens because file is formatted with goimport after saving, not before.

To to fix this this PR formats current buffer directly, instead of using temporary files. This results in much faster formatting, no errors with "undeclared names" like above. Also the undo history is preserved by default (no need for experimental mode).

