### PR TITLE
use the docker cache more frequently

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
       uses: actions/checkout@v2.1.0
     - name: install vim
       run: $GITHUB_WORKSPACE/scripts/install-vim vim-8.2
+    - name: install tools
+      run: $GITHUB_WORKSPACE/scripts/install-tools vim-8.2
     - name: lint
       run: $GITHUB_WORKSPACE/scripts/lint vim-8.2
   test:
@@ -44,6 +46,8 @@ jobs:
       uses: actions/checkout@v2.1.0
     - name: install vim
       run: $GITHUB_WORKSPACE/scripts/install-vim ${{ matrix.vim }}
+    - name: install tools
+      run: $GITHUB_WORKSPACE/scripts/install-tools ${{ matrix.vim }}
     - name: test
       run: $GITHUB_WORKSPACE/scripts/test -c ${{ matrix.vim }}
     - uses: codecov/codecov-action@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,18 @@ RUN pip3 install vim-vint
 RUN useradd -ms /bin/bash -d /vim-go vim-go
 USER vim-go
 
-COPY . /vim-go/
+COPY scripts/install-vim /vim-go/scripts/install-vim
 WORKDIR /vim-go
 
 RUN scripts/install-vim vim-8.0
 RUN scripts/install-vim vim-8.2
 RUN scripts/install-vim nvim
+
+COPY . /vim-go/
+WORKDIR /vim-go
+
+RUN scripts/install-tools vim-8.0
+RUN scripts/install-tools vim-8.2
+RUN scripts/install-tools nvim
 
 ENTRYPOINT ["make"]

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ install:
 	@echo "==> Installing Vims: $(VIMS)"
 	@for vim in $(VIMS); do \
 		./scripts/install-vim $$vim; \
+		./scripts/install-tools $$vim; \
 	done
 
 test:

--- a/scripts/install-tools
+++ b/scripts/install-tools
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Install and setup a Vim or Neovim for running tests.
+# This should work on both GitHub Actions and people's desktop computers, and
+# be 100% independent from any system installed Vim.
+#
+
+set -euC
+
+vimgodir=$(cd -P "$(dirname "$0")/.." > /dev/null && pwd)
+cd "$vimgodir"
+
+vim=${1:-}
+
+installdir="/tmp/vim-go-test/$1-install"
+
+# Make sure all Go tools and other dependencies are installed.
+echo "Installing Go binaries"
+export GOPATH=$installdir
+export GO111MODULE=off
+export PATH=${GOPATH}/bin:$PATH
+"$vimgodir/scripts/run-vim" $vim +':silent :GoUpdateBinaries' +':qa'
+
+echo "Installing lint tools"
+(
+  mkdir -p "$installdir/share/vim/vimgo/pack/vim-go/start/"
+  cd "$installdir/share/vim/vimgo/pack/vim-go/start/"
+  [ -d "vim-vimhelplint" ] || git clone --depth 1 --quiet https://github.com/machakann/vim-vimhelplint
+  [ -d "vim-vimlparser" ]  || git clone --depth 1 --quiet https://github.com/ynkdir/vim-vimlparser
+  [ -d "vim-vimlint" ]     || git clone --depth 1 --quiet https://github.com/syngan/vim-vimlint
+)
+
+echo "vim-go tools installed to: $installdir/share/vim/vimgo/pack/vim-go/start"
+
+# vim:ts=2:sts=2:sw=2:et

--- a/scripts/install-vim
+++ b/scripts/install-vim
@@ -1,8 +1,8 @@
 #!/bin/sh
 #
 # Install and setup a Vim or Neovim for running tests.
-# This should work on both Travis and people's desktop computers, and be 100%
-# independent from any system installed Vim.
+# This should work on both GitHub Actions and people's desktop computers, and
+# be 100% independent from any system installed Vim.
 #
 # It will echo the full path to a Vim binary, e.g.:
 #   /some/path/src/vim
@@ -91,22 +91,6 @@ else
   mkdir -p "$installdir/share/vim/vimgo/pack/vim-go/start"
   ln -s "$vimgodir" "$installdir/share/vim/vimgo/pack/vim-go/start/vim-go"
 fi
-
-# Make sure all Go tools and other dependencies are installed.
-echo "Installing Go binaries"
-export GOPATH=$installdir
-export GO111MODULE=off
-export PATH=${GOPATH}/bin:$PATH
-"$vimgodir/scripts/run-vim" $vim +':silent :GoUpdateBinaries' +':qa'
-
-echo "Installing lint tools"
-(
-  mkdir -p "$installdir/share/vim/vimgo/pack/vim-go/start/"
-  cd "$installdir/share/vim/vimgo/pack/vim-go/start/"
-  [ -d "vim-vimhelplint" ] || git clone --depth 1 --quiet https://github.com/machakann/vim-vimhelplint
-  [ -d "vim-vimlparser" ]  || git clone --depth 1 --quiet https://github.com/ynkdir/vim-vimlparser
-  [ -d "vim-vimlint" ]     || git clone --depth 1 --quiet https://github.com/syngan/vim-vimlint
-)
 
 # Don't really need source after successful install.
 rm -rf "$srcdir"


### PR DESCRIPTION
Separate the installing of Vim in the docker image from the installation
of the tools that vim-go needs so that Vim doesn't have to be compiled
from scratch each time `make docker ` is run.