### PR TITLE
chore: godoc popup border style

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -69,7 +69,7 @@ function! s:GodocView(newposition, position, content) abort
       endif
       call popup_atcursor(split(a:content, '\n'), {
             \ 'padding': [1, 1, 1, 1],
-            \ 'borderchars': get(g:, 'go_doc_popup_border', borderchars),
+            \ 'borderchars': borderchars,
             \ 'border': [1, 1, 1, 1],
             \ })
     elseif has('nvim') && exists('*nvim_open_win')

--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -6,6 +6,8 @@
 let s:cpo_save = &cpo
 set cpo&vim
 
+scriptencoding utf-8
+
 let s:buf_nr = -1
 
 function! go#doc#OpenBrowser(...) abort
@@ -61,10 +63,14 @@ function! s:GodocView(newposition, position, content) abort
     if exists('*popup_atcursor') && exists('*popup_clear')
       call popup_clear()
 
+      let borderchars = ['-', '|', '-', '|', '+', '+', '+', '+']
+      if &encoding == "utf-8"
+        let borderchars = ['─', '│', '─', '│', '┌', '┐', '┘', '└']
+      endif
       call popup_atcursor(split(a:content, '\n'), {
             \ 'padding': [1, 1, 1, 1],
-            \ 'borderchars': ['-','|','-','|','+','+','+','+'],
-            \ "border": [1, 1, 1, 1],
+            \ 'borderchars': get(g:, 'go_doc_popup_border', borderchars),
+            \ 'border': [1, 1, 1, 1],
             \ })
     elseif has('nvim') && exists('*nvim_open_win')
       let lines = split(a:content, '\n')

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1465,14 +1465,6 @@ Use this option to use the popup-window for |K| and |:GoDoc|, rather than the
   let g:go_doc_popup_window = 0
 <
 
-                                                     *'g:go_doc_popup_border'*
-
-Use this option to custome border chars of the popup-window for |K|
-and |:GoDoc|, Default is empty. Example usage, set the border as rounded:
->
-  let g:go_doc_popup_border = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']
-<
-
                                                              *'g:go_def_mode'*
 
 Use this option to define the command to be used for |:GoDef|. By default

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1465,6 +1465,14 @@ Use this option to use the popup-window for |K| and |:GoDoc|, rather than the
   let g:go_doc_popup_window = 0
 <
 
+                                                     *'g:go_doc_popup_border'*
+
+Use this option to custome border chars of the popup-window for |K|
+and |:GoDoc|, Default is empty. Example usage, set the border as rounded:
+>
+  let g:go_doc_popup_border = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']
+<
+
                                                              *'g:go_def_mode'*
 
 Use this option to define the command to be used for |:GoDef|. By default
@@ -1486,7 +1494,7 @@ other packages. Valid options are `gopls` and `guru`. By default it's `gopls`.
 <
                                                       *'g:go_implements_mode'*
 
-Use this option to define the command to be used for |:GoImplements|. 
+Use this option to define the command to be used for |:GoImplements|.
 The Implements feature in gopls is still new and being worked upon.
 Valid options are `gopls` and `guru`. By default it's `guru`.
 >


### PR DESCRIPTION
godoc popup cames from `g:go_doc_popup_window`

what I changed:

1. beautify popup border style if utf-8 supported
2. add variable `g:go_doc_popup_border` to support custome border style

default style (original):

![default style](https://user-images.githubusercontent.com/247015/83093800-bc3e5780-a0d2-11ea-88a2-7d8033329d46.png)

default style if utf-8 supported:

![utf-8 style](https://user-images.githubusercontent.com/247015/83093803-bcd6ee00-a0d2-11ea-9c1e-bf90df9ae630.png)

bounded style with `let g:go_doc_popup_border = ['─', '│', '─', '│', '╭', '╮', '╯', '╰']` :

![rounded style](https://user-images.githubusercontent.com/247015/83093794-b9436700-a0d2-11ea-9b79-1203b950b2e3.png)
