### PR TITLE
config: use remote gopls by default

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -551,7 +551,7 @@ function! go#config#DiagnosticsEnabled() abort
 endfunction
 
 function! go#config#GoplsOptions() abort
-  return get(g:, 'go_gopls_options', [])
+  return get(g:, 'go_gopls_options', ['-remote=auto'])
 endfunction
 
 " Set the default value. A value of "1" is a shortcut for this, for

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1782,7 +1782,7 @@ options may also need to be adjusted.
 
                                                         *'g:go_gopls_options'*
 
-The commandline arguments to pass to gopls. By default, it's an empty array.
+The commandline arguments to pass to gopls. By default, it's `-remote=auto`.
 >
   let g:go_gopls_options = []
 <


### PR DESCRIPTION
Change g:go_gopls_options to enable remote by default so that multiple
instance of vim can share the same gopls instance.