### PR TITLE
util: resolve module root

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -144,7 +144,7 @@ function! go#util#ModuleRoot() abort
     return expand('%:p:h')
   endif
 
-  return fnamemodify(l:module, ':p:h')
+  return resolve(fnamemodify(l:module, ':p:h'))
 endfunction
 
 " Run a shell command.


### PR DESCRIPTION
Resolve the module root to the true path. All other path expansions in
Vim are the resolved path, so the module root path should also be the
resolved path.

Fixes #2913