### PR TITLE
debug: handle process exits cleanly

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -1128,6 +1128,15 @@ function! s:list_breakpoints()
     if l:line =~# '^Signs for '
       let l:file = l:line[10:-2]
       continue
+    else
+      " sign place's output may end with Signs instead of starting with Signs.
+      " See
+      " https://github.com/fatih/vim-go/issues/2920#issuecomment-644885774.
+      let l:idx = match(l:line, '\.go .* Signs:$')
+      if l:idx >= 0
+        let l:file = l:line[0:l:idx+2]
+        continue
+      endif
     endif
 
     if l:line !~# 'name=godebugbreakpoint'

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -668,7 +668,7 @@ function! go#debug#Start(is_test, ...) abort
 
     let s:state['job'] = go#job#Start(l:cmd, l:opts)
   catch
-    call go#util#EchoError(v:exception)
+    call go#util#EchoError(printf('could not start debugger: %s', v:exception))
   endtry
 
   return s:state['job']
@@ -771,7 +771,7 @@ function! s:eval(arg) abort
       \ })
     return s:eval_tree(l:res.result.Variable, 0)
   catch
-    call go#util#EchoError(v:exception)
+    call go#util#EchoError(printf('evaluation failed: %s', v:exception))
     return ''
   endtry
 endfunction
@@ -785,7 +785,7 @@ function! go#debug#Print(arg) abort
   try
     echo substitute(s:eval(a:arg), "\n$", "", 0)
   catch
-    call go#util#EchoError(v:exception)
+    call go#util#EchoError(printf('could not print: %s', v:exception))
   endtry
 endfunction
 
@@ -804,7 +804,7 @@ function! s:update_goroutines() abort
     let l:res = s:call_jsonrpc('RPCServer.ListGoroutines')
     call s:show_goroutines(l:currentGoroutineID, l:res)
   catch
-    call go#util#EchoError(v:exception)
+    call go#util#EchoError(printf('could not show goroutines: %s', v:exception))
   endtry
  endfunction
 
@@ -894,7 +894,7 @@ function! s:update_variables() abort
       let s:state['localVars'] = l:res.result['Variables']
     endif
   catch
-    call go#util#EchoError(v:exception)
+    call go#util#EchoError(printf('could not list variables: %s', v:exception))
   endtry
 
   try
@@ -904,7 +904,7 @@ function! s:update_variables() abort
       let s:state['functionArgs'] = res.result['Args']
     endif
   catch
-    call go#util#EchoError(v:exception)
+    call go#util#EchoError(printf('could not list function arguments: %s', v:exception))
   endtry
 
   call s:show_variables()
@@ -919,7 +919,7 @@ function! go#debug#Set(symbol, value) abort
           \ 'scope':  {'GoroutineID': l:res.result.State.currentThread.goroutineID}
     \ })
   catch
-    call go#util#EchoError(v:exception)
+    call go#util#EchoError(printf('could not set symbol value: %s', v:exception))
   endtry
 
   call s:update_variables()
@@ -930,7 +930,7 @@ function! s:update_stacktrace() abort
     let l:res = s:call_jsonrpc('RPCServer.Stacktrace', {'id': s:goroutineID(), 'depth': 5})
     call s:show_stacktrace(l:res)
   catch
-    call go#util#EchoError(v:exception)
+    call go#util#EchoError(printf('could not update stack: %s', v:exception))
   endtry
 endfunction
 
@@ -997,8 +997,9 @@ function! go#debug#Stack(name) abort
       endif
       call s:stack_cb(l:res)
     catch
-      call go#util#EchoError(v:exception)
+      call go#util#EchoError(printf('rpc failure: %s', v:exception))
       call s:clearState()
+      call go#util#EchoInfo('restarting debugger')
       call go#debug#Restart()
     endtry
   catch
@@ -1023,7 +1024,7 @@ function! go#debug#Restart() abort
 
     call call('go#debug#Start', s:start_args)
   catch
-    call go#util#EchoError(v:exception)
+    call go#util#EchoError(printf('restart failed: %s', v:exception))
   endtry
 endfunction
 
@@ -1045,7 +1046,7 @@ function! go#debug#Goroutine() abort
     call s:stack_cb(l:res)
     call go#util#EchoInfo("Switched goroutine to: " . l:goroutineID)
   catch
-    call go#util#EchoError(v:exception)
+    call go#util#EchoError(printf('could not switch goroutine: %s', v:exception))
   endtry
 endfunction
 
@@ -1094,7 +1095,7 @@ function! go#debug#Breakpoint(...) abort
       endif
     endif
   catch
-    call go#util#EchoError(v:exception)
+    call go#util#EchoError(printf('could not toggle breakpoint: %s', v:exception))
     return 1
   endtry
 

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -959,7 +959,11 @@ function! go#debug#Stack(name) abort
   endif
 
   try
-    " TODO: document why this is needed.
+    " s:stack_name is reset in s:stack_cb(). While its value is 'next', the
+    " current operation being performed by delve is a next operation and it
+    " must be cancelled before another next operation can start. See
+    " https://github.com/go-delve/delve/blob/ab5713d3ec5d12754f4b2edf85e4b36a08b67c48/Documentation/api/ClientHowto.md#special-continue-commands-and-asynchronous-breakpoints
+    " for more information.
     if l:name is# 'next' && get(s:, 'stack_name', '') is# 'next'
       call s:call_jsonrpc('RPCServer.CancelNext')
     endif

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -127,6 +127,15 @@ function! s:call_jsonrpc(method, ...) abort
   endtry
 endfunction
 
+function! s:exited(res) abort
+  if type(a:res) ==# type(v:null)
+    return 0
+  endif
+
+  let state = a:res.result.State
+  return state.exited == v:true
+endfunction
+
 " Update the location of the current breakpoint or line we're halted on based on
 " response from dlv.
 function! s:update_breakpoint(res) abort
@@ -932,6 +941,10 @@ function! s:stack_cb(res) abort
     return
   endif
 
+  if s:exited(a:res)
+    call go#debug#Stop()
+    return
+  endif
   call s:update_breakpoint(a:res)
   call s:update_goroutines()
   call s:update_stacktrace()


### PR DESCRIPTION
Improve the debugging experience when the process being debugged exits. Previously the debugger would stay active, some unexpected messages would be shown to the user, and a `:GoDebugContinue` would restart the application.

##### explain why CancelNext needs to be called

##### debug: handle process exit cleanly

Quit the debugger when the process being debugged stops.


##### debug: make error messages more useful

Add context to error messages so that it's easier to understand fron
where they originate.


##### debug: refactor NextInProgress handling

Extract the NextInProgress handling to its own function for readability.

Fixes #2920 
