### PR TITLE
fmt: fix goimports test

### DIFF
--- a/autoload/go/fmt_test.vim
+++ b/autoload/go/fmt_test.vim
@@ -35,7 +35,7 @@ func! Test_update_file() abort
 endfunc
 
 func! Test_goimports() abort
-  let $GOPATH = 'test-fixtures/fmt/'
+  let $GOPATH = printf('%s/%s', fnamemodify(getcwd(), ':p'), 'test-fixtures/fmt')
   let actual_file = tempname()
   call writefile(readfile("test-fixtures/fmt/src/imports/goimports.go"), actual_file)
 


### PR DESCRIPTION
GOPATH must be an absolute path. Appparently goimports just recently
started enforcing that, so this long standing deficiency in the
goimports path caused tests to start failing.