### PR TITLE
debug: refactor sign management

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@
 .git/
 .viminfo
 issues/
+autoload/go/**/pkg/


### PR DESCRIPTION
Use functions instead of ex commands for managing signs when possible.

Put signs in the vim-go-debug group to avoid using the global group.