### PR TITLE
Update mappings.vim to support vim8 for go-run-{split,vertical}

### DIFF
--- a/ftplugin/go/mappings.vim
+++ b/ftplugin/go/mappings.vim
@@ -11,7 +11,7 @@ endif
 " Some handy plug mappings
 nnoremap <silent> <Plug>(go-run) :<C-u>call go#cmd#Run(!g:go_jump_to_error)<CR>
 
-if has("nvim")
+if has("nvim") || has("terminal")
   nnoremap <silent> <Plug>(go-run-vertical) :<C-u>call go#cmd#RunTerm(!g:go_jump_to_error, 'vsplit', [])<CR>
   nnoremap <silent> <Plug>(go-run-split) :<C-u>call go#cmd#RunTerm(!g:go_jump_to_error, 'split', [])<CR>
   nnoremap <silent> <Plug>(go-run-tab) :<C-u>call go#cmd#RunTerm(!g:go_jump_to_error, 'tabe', [])<CR>


### PR DESCRIPTION
Add has("terminal") so that vim8 users with terminal support can use  go-run-split and go-run-vertical