### PR TITLE
Add omnifunc icase override setting

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -494,6 +494,10 @@ function! go#config#CodeCompletionEnabled() abort
   return get(g:, "go_code_completion_enabled", 1)
 endfunction
 
+function! go#config#CodeCompletionIcase() abort
+  return get(g:, "go_code_completion_icase", 0)
+endfunction
+
 function! go#config#Updatetime() abort
   let go_updatetime = get(g:, 'go_updatetime', 800)
   return go_updatetime == 0 ? &updatetime : go_updatetime

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -709,7 +709,7 @@ function! s:completionHandler(next, msg) abort dict
   for l:item in a:msg.items
     let l:start = l:item.textEdit.range.start.character
 
-    let l:match = {'abbr': l:item.label, 'word': l:item.textEdit.newText, 'info': '', 'kind': go#lsp#completionitemkind#Vim(l:item.kind), 'user_data': ''}
+    let l:match = {'abbr': l:item.label, 'word': l:item.textEdit.newText, 'info': '', 'kind': go#lsp#completionitemkind#Vim(l:item.kind), 'user_data': '', 'icase': go#config#CodeCompletionIcase()}
     if has_key(l:item, 'detail')
         let l:match.menu = l:item.detail
         if go#lsp#completionitemkind#IsFunction(l:item.kind) || go#lsp#completionitemkind#IsMethod(l:item.kind)

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1258,7 +1258,7 @@ Enable code completion with 'omnifunc'. By default it is enabled.
 
                                                 *'g:go_code_completion_icase'*
 
-Override the 'icase' value in 'omnifunc' results. By default it is set to 0.
+Override the icase field in 'omnifunc' results. By default it is set to 0.
 See 'complete-items' for details.
 >
   let g:go_code_completion_icase = 0

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1256,6 +1256,14 @@ Enable code completion with 'omnifunc'. By default it is enabled.
   let g:go_code_completion_enabled = 1
 <
 
+                                                *'g:go_code_completion_icase'*
+
+Override the 'icase' value in 'omnifunc' results. By default it is set to 0.
+See 'complete-items' for details.
+>
+  let g:go_code_completion_icase = 0
+<
+
                                                       *'g:go_test_show_name'*
 
 Show the name of each failed test before the errors and logs output by the


### PR DESCRIPTION
This change allows a plugin user to set the `icase` key in `omnifunc` results. By setting this to 1, the user is able to filter omnifunc results in a non-case sensitive manner.

For example:

1. Enter insert mode.
2. Type `fmt.`
3. Trigger omnifunc completion using `<C-X><C-O>`
4. Deselect the first item in the list (`Formatter`) by pressing `<C-P>`.
5. If `g:go_code_completion_icase` is set to 0 (default), then anything you type next will filter the completion list but in a case sensitive manner. This is also the behaviour when `icase` is not present at all. But if `g:go_code_completion_icase` set to 1, then the filtering is case-insensitive.

---

My own personal workaround to get this behaviour has been to define my own `omnifunc` for Go files that calls `go#complete#Complete` and then modifies the result on the way back through.

```
function MyOmniFunc(findstart, base)
    let results = go#complete#Complete(a:findstart, a:base)
    if !a:findstart
        for result in results
            let result.icase = 1
        endfor
    endif
    return results
endfunction
autocmd FileType go set omnifunc=MyOmniFunc
```

(so if you don't want to accept this PR, there aren't any dramas on my part since I have an functional workaround).