### PR TITLE
shane: probably meaningless to do snip compl if v:completed_item.kind is empty

### DIFF
--- a/autoload/go/auto.vim
+++ b/autoload/go/auto.vim
@@ -17,10 +17,9 @@ function! go#auto#complete_done()
 endfunction
 
 function! s:ExpandSnippet() abort
-  if !exists('v:completed_item') || empty(v:completed_item) || !go#config#GoplsUsePlaceholders()
+  if !exists('v:completed_item') || empty(v:completed_item) || empty(v:completed_item.kind) || !go#config#GoplsUsePlaceholders()
     return
   endif
-
 
   let l:engine = go#config#SnippetEngine()
 


### PR DESCRIPTION
looks it is meaningless if kind is empty, 
besides/otherwise some cases it perhaps difficult to escape from pumvisible status, if/because snip compl is going/doing ..