### PR TITLE
Documentation: installation with vim-plug to get the latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ for popular package managers:
 * [Pathogen](https://github.com/tpope/vim-pathogen)
   * `git clone https://github.com/fatih/vim-go.git ~/.vim/bundle/vim-go`
 * [vim-plug](https://github.com/junegunn/vim-plug)
-  * `Plug 'fatih/vim-go', { 'do': ':GoUpdateBinaries' }`
+  * `Plug 'fatih/vim-go', { 'tag': '*', 'do': ':GoUpdateBinaries' }`
 * [Vundle](https://github.com/VundleVim/Vundle.vim)
   * `Plugin 'fatih/vim-go'`
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -105,7 +105,7 @@ manager's install command.
 <
 *  https://github.com/junegunn/vim-plug >
 
-    Plug 'fatih/vim-go', { 'do': ':GoUpdateBinaries' }
+    Plug 'fatih/vim-go', { 'tag': '*', 'do': ':GoUpdateBinaries' }
 <
 *  https://github.com/Shougo/neobundle.vim >
 


### PR DESCRIPTION
After installing the plugin with vim-plug i realized that it got the master branch and not the latest release.
I changed the documentation so that the recommended way to install vim-go with vim-plug install the latest release.
I don't really know what could be the solution for Pathogen, Vim 8, I guess we could use :
```
git clone -b v1.23 https://github.com/fatih/vim-go
```
but this will requires to be change for each release.
I have no idea how to do the same with Vundle
