### PR TITLE
plugin: ensure binaries are not cross compiled

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -125,8 +125,11 @@ function! go#util#gomodcache() abort
   return substitute(s:exec(['go', 'env', 'GOMODCACHE'])[0], '\n', '', 'g')
 endfunction
 
-function! go#util#osarch() abort
-  return go#util#env("goos") . '_' . go#util#env("goarch")
+" hostosarch returns the OS and ARCH values that the go binary is intended for.
+function! go#util#hostosarch() abort
+  let [l:hostos, l:err] = s:exec(['go', 'env', 'GOHOSTOS'])
+  let [l:hostarch, l:err] = s:exec(['go', 'env', 'GOHOSTARCH'])
+  return [trim(l:hostos), trim(l:hostarch)]
 endfunction
 
 " go#util#ModuleRoot returns the root directory of the module of the current

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -86,6 +86,10 @@ function! s:GoInstallBinaries(updateBinaries, ...)
 
   let go_bin_path = go#path#BinPath()
 
+  let [l:goos, l:goarch] = go#util#hostosarch()
+  let Restore_goos = go#util#SetEnv('GOOS', l:goos)
+  let Restore_goarch = go#util#SetEnv('GOARCH', l:goarch)
+
   " change $GOBIN so go get can automatically install to it
   let Restore_gobin = go#util#SetEnv('GOBIN', go_bin_path)
 
@@ -218,6 +222,8 @@ function! s:GoInstallBinaries(updateBinaries, ...)
   " restore back!
   call call(Restore_path, [])
   call call(Restore_gobin, [])
+  call call(Restore_goarch, [])
+  call call(Restore_goos, [])
 
   if resetshellslash
     set shellslash


### PR DESCRIPTION
Make sure the binary tools that vim-go relies on are not cross-compiled
when installing them.

Fixes #2980