### PR TITLE
debug: reset running state

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -237,6 +237,7 @@ function! s:show_variables() abort
 endfunction
 
 function! s:clearState() abort
+  let s:state['running'] = 0
   let s:state['currentThread'] = {}
   let s:state['localVars'] = {}
   let s:state['functionArgs'] = {}


### PR DESCRIPTION
Reset debug's running state when clearing state so that a subsequent
:GoDebugStart followed by :GoDebugContinue will hook up the rest of the
debugging commands.