### PR TITLE
add an option to reuse terminal windows

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -53,6 +53,10 @@ function! go#config#TermCloseOnExit() abort
   return get(g:, 'go_term_close_on_exit', 1)
 endfunction
 
+function! go#config#TermReuse() abort
+  return get(g:, 'go_term_reuse', 0)
+endfunction
+
 function! go#config#SetTermCloseOnExit(value) abort
   let g:go_term_close_on_exit = a:value
 endfunction

--- a/autoload/go/term_test.vim
+++ b/autoload/go/term_test.vim
@@ -53,6 +53,40 @@ func! Test_GoTermNewMode_SplitRight()
   endtry
 endfunc
 
+func! Test_GoTermReuse()
+  if !(has('nvim') || has('terminal'))
+    return
+  endif
+
+  try
+    let l:filename = 'term/term.go'
+    let l:tmp = gotest#load_fixture(l:filename)
+    exe 'cd ' . l:tmp . '/src/term'
+
+    let expected = expand('%:p')
+
+    let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
+
+    set nosplitright
+
+    let g:go_term_reuse = 1
+    call go#term#new(0, cmd, &errorformat)
+    let actual = expand('%:p')
+    call assert_equal(actual, l:expected)
+    call assert_equal(3, len(getwininfo()))
+
+    call go#term#new(0, cmd, &errorformat)
+    let actual = expand('%:p')
+    call assert_equal(actual, l:expected)
+
+    call assert_equal(3, len(getwininfo()))
+  finally
+    sleep 50m
+    unlet g:go_term_reuse
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1717,6 +1717,13 @@ Applicable to Neovim and Vim with `terminal` feature only.
 >
   let g:go_term_mode = "vsplit"
 <
+                                                          *'g:go_term_reuse'*
+
+Reuse the terminal window when |'g:go_term_enabled'| is set. By default it's
+disabled.
+>
+  let g:go_term_reuse = 0
+<
                                                           *'g:go_term_height'*
                                                            *'g:go_term_width'*
 


### PR DESCRIPTION
##### term: use go#util#Chdir

Use go#util#Chdir instead of the older method of changing directories.


##### term: add an option to reuse terminal windows

Closes #2510


