### PR TITLE
highlight: make the GoDebug highlight group definitions defaults

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -422,8 +422,8 @@ function! s:hi()
 
   " :GoDebug commands
   if go#config#HighlightDebug()
-    hi GoDebugBreakpoint term=standout ctermbg=117 ctermfg=0 guibg=#BAD4F5  guifg=Black
-    hi GoDebugCurrent term=reverse  ctermbg=12  ctermfg=7 guibg=DarkBlue guifg=White
+    hi def GoDebugBreakpoint term=standout ctermbg=117 ctermfg=0 guibg=#BAD4F5  guifg=Black
+    hi def GoDebugCurrent term=reverse  ctermbg=12  ctermfg=7 guibg=DarkBlue guifg=White
   endif
 endfunction
 


### PR DESCRIPTION
Make the GoDebug highlight groups defaults so a user's definition for
them will not be overridden.