### PR TITLE
doc: fix GoAddTags for fixed value

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -800,7 +800,7 @@ CTRL-t
     You can define a constant value instead of the default field based value.
     For example the following command will add ``valid:"1"`` to all fields.
 >
-      :GoAddTags valid=1
+      :GoAddTags valid:1
 <
                                                                *:GoRemoveTags*
 :[range]GoRemoveTags [key],[option] [key1],[option1] ...


### PR DESCRIPTION
The help section of GoAddTags seems wrong.  When executing :GoAddTags key=value, vim-go actually inserts key=value:"_tagname_"

However, executing :GoAddTags key:value seems to be correct... not sure if the doc should be fixed or the code should be fixed though, but I went with the easier, but safer route by fixing the documentation for now :-).