### PR TITLE
lsp: implement fillstruct

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -570,6 +570,10 @@ function! go#config#GoplsOptions() abort
   return get(g:, 'go_gopls_options', ['-remote=auto'])
 endfunction
 
+function! go#config#FillStructMode() abort
+  return get(g:, 'go_fillstruct_mode', 'fillstruct')
+endfunction
+
 " Set the default value. A value of "1" is a shortcut for this, for
 " compatibility reasons.
 if exists("g:go_gorename_prefill") && g:go_gorename_prefill == 1

--- a/autoload/go/fillstruct.vim
+++ b/autoload/go/fillstruct.vim
@@ -3,6 +3,12 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 function! go#fillstruct#FillStruct() abort
+  let l:mode = go#config#FillStructMode()
+  if l:mode is 'gopls'
+    call go#lsp#FillStruct()
+    return
+  endif
+
   let l:cmd = ['fillstruct',
       \ '-file', bufname(''),
       \ '-offset', go#util#OffsetCursor(),

--- a/autoload/go/fillstruct_test.vim
+++ b/autoload/go/fillstruct_test.vim
@@ -4,6 +4,7 @@ set cpo&vim
 
 func! Test_fillstruct() abort
   try
+    let g:go_fillstruct_mode = 'fillstruct'
     let l:tmp = gotest#write_file('a/a.go', [
           \ 'package a',
           \ 'import "net/mail"',
@@ -16,12 +17,14 @@ func! Test_fillstruct() abort
           \ '\tAddress: "",',
           \ '}'])
   finally
+    unlet g:go_fillstruct_mode
     call delete(l:tmp, 'rf')
   endtry
 endfunc
 
 func! Test_fillstruct_line() abort
   try
+    let g:go_fillstruct_mode = 'fillstruct'
     let l:tmp = gotest#write_file('a/a.go', [
           \ 'package a',
           \ 'import "net/mail"',
@@ -34,12 +37,14 @@ func! Test_fillstruct_line() abort
           \ '\tAddress: "",',
           \ '}'])
   finally
+    unlet g:go_fillstruct_mode
     call delete(l:tmp, 'rf')
   endtry
 endfunc
 
 func! Test_fillstruct_two_line() abort
   try
+    let g:go_fillstruct_mode = 'fillstruct'
     let l:tmp = gotest#write_file('a/a.go', [
           \ 'package a',
           \ 'import (',
@@ -62,12 +67,14 @@ func! Test_fillstruct_two_line() abort
           \ '\tAddress: "",',
           \ '}) }'])
   finally
+    unlet g:go_fillstruct_mode
     call delete(l:tmp, 'rf')
   endtry
 endfunc
 
 func! Test_fillstruct_two_cursor() abort
   try
+    let g:go_fillstruct_mode = 'fillstruct'
     let l:tmp = gotest#write_file('a/a.go', [
           \ 'package a',
           \ 'import (',
@@ -87,10 +94,128 @@ func! Test_fillstruct_two_cursor() abort
           \ '\tAddress: "",',
           \ '}) }'])
   finally
+    unlet g:go_fillstruct_mode
     call delete(l:tmp, 'rf')
   endtry
 endfunc
 
+func! Test_gopls_fillstruct() abort
+  try
+    let g:go_fillstruct_mode = 'gopls'
+    let l:tmp = gotest#write_file('a/a.go', [
+          \ 'package a',
+          \ 'import "net/mail"',
+          \ "var addr = mail.\x1fAddress{}"])
+
+    call go#fillstruct#FillStruct()
+
+    let start = reltime()
+    while &modified == 0 && reltimefloat(reltime(start)) < 10
+      sleep 100m
+    endwhile
+
+    call gotest#assert_buffer(1, [
+          \ 'var addr = mail.Address{',
+          \ '\tName:    "",',
+          \ '\tAddress: "",',
+          \ '}'])
+  finally
+    unlet g:go_fillstruct_mode
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
+func! Test_gopls_fillstruct_line() abort
+  try
+    let g:go_fillstruct_mode = 'gopls'
+    let l:tmp = gotest#write_file('a/a.go', [
+          \ 'package a',
+          \ 'import "net/mail"',
+          \ "\x1f" . 'var addr = mail.Address{}'])
+
+    call go#fillstruct#FillStruct()
+
+    let start = reltime()
+    while &modified == 0 && reltimefloat(reltime(start)) < 10
+      sleep 100m
+    endwhile
+
+    call gotest#assert_buffer(1, [
+          \ 'var addr = mail.Address{',
+          \ '\tName:    "",',
+          \ '\tAddress: "",',
+          \ '}'])
+  finally
+    unlet g:go_fillstruct_mode
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
+func! Test_gopls_fillstruct_two_line() abort
+  try
+    let g:go_fillstruct_mode = 'gopls'
+    let l:tmp = gotest#write_file('a/a.go', [
+          \ 'package a',
+          \ 'import (',
+          \ '"fmt"',
+          \ '"net/mail"',
+          \ ')',
+          \ "\x1f" . 'func x() { fmt.Println(mail.Address{}, mail.Address{}) }'])
+
+    call go#fillstruct#FillStruct()
+
+    let start = reltime()
+    while &modified == 0 && reltimefloat(reltime(start)) < 10
+      sleep 100m
+    endwhile
+
+    " the fillstruct behavior of gopls is different than fillstruct; the
+    " latter will not expand the struct when the cursor is not on a struct
+    " when there is more than one struct literal on the line.
+    call gotest#assert_buffer(1, [
+          \ 'import (',
+          \ '"fmt"',
+          \ '"net/mail"',
+          \ ')',
+          \ 'func x() { fmt.Println(mail.Address{}, mail.Address{}) }'])
+  finally
+    unlet g:go_fillstruct_mode
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
+func! Test_gopls_fillstruct_two_cursor() abort
+  try
+    let g:go_fillstruct_mode = 'gopls'
+    let l:tmp = gotest#write_file('a/a.go', [
+          \ 'package a',
+          \ 'import (',
+          \ '"fmt"',
+          \ '"net/mail"',
+          \ ')',
+          \ "func x() { fmt.Println(mail.Address{}, mail.Ad\x1fdress{}) }"])
+
+    call go#fillstruct#FillStruct()
+
+    let start = reltime()
+    while &modified == 0 && reltimefloat(reltime(start)) < 10
+      sleep 100m
+    endwhile
+
+    call gotest#assert_buffer(1, [
+          \ 'import (',
+          \ '"fmt"',
+          \ '"net/mail"',
+          \ ')',
+          \ 'func x() { fmt.Println(mail.Address{}, mail.Address{',
+          \ '\tName:    "",',
+          \ '\tAddress: "",',
+          \ '}) }'])
+  finally
+    unlet g:go_fillstruct_mode
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -1479,17 +1479,22 @@ function! s:handleCodeAction(msg) abort dict
       if !has_key(l:item.edit, 'documentChanges')
         continue
       endif
-      for l:change in l:item.edit.documentChanges
-        if !has_key(l:change, 'edits')
-          continue
-        endif
-        " TODO(bc): change to the buffer for l:change.textDocument.uri
-        call s:applyTextEdits(l:change.edits)
-      endfor
+      call s:applyDocumentChanges(l:item.edit.documentChanges)
     endif
   endfor
 endfunction
 
+function s:applyDocumentChanges(changes)
+  for l:change in a:changes
+    if !has_key(l:change, 'edits')
+      continue
+    endif
+    " TODO(bc): change to the buffer for l:change.textDocument.uri
+    call s:applyTextEdits(l:change.edits)
+  endfor
+endfunction
+
+" s:applyTextEdit applies the list of WorkspaceEdit values in msg.
 function s:applyTextEdits(msg) abort
   if a:msg is v:null
     return

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1474,6 +1474,14 @@ and `guru`.
 >
   let g:go_def_mode = 'gopls'
 <
+                                                      *'g:go_fillstruct_mode'*
+
+Use this option to define the command to be used for |:GoFillStruct|. By
+default `fillstruct` is used. Valid values are `fillstruct` and `gopls`. By
+default it is `fillstruct`.
+>
+  let g:go_fillstruct_mode = 'fillstruct'
+<
                                                        *'g:go_referrers_mode'*
 
 Use this option to define the command to be used for |:GoReferrers|. By


### PR DESCRIPTION
##### lsp: refactor applying document changes

Create and call a new function that applies the documentChanges property
of a WorkspaceEdit message.


##### fillstruct: add an option to satisfy fill struct with gopls

Add a new option, g:go_fill_struct_mode, to allow gopls to be used to
satisfy :GoFillStruct

Fix a small bug with debugging gopls; make sure the timer starts when
the queue's first item is added instead of starting only when a second
message is added to the queue.

Closes #2940


##### fillstruct: add tests for gopls mode


