### PR TITLE
lint: add staticcheck support

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -264,15 +264,25 @@ function! go#config#SetTemplateAutocreate(value) abort
 endfunction
 
 function! go#config#MetalinterCommand() abort
-  return get(g:, "go_metalinter_command", "golangci-lint")
+  return get(g:, 'go_metalinter_command', 'golangci-lint')
 endfunction
 
 function! go#config#MetalinterAutosaveEnabled() abort
-  return get(g:, "go_metalinter_autosave_enabled", ["govet", "golint"])
+  let l:default = []
+  if get(g:, 'go_metalinter_command', 'golangci-lint') == 'golangci-lint'
+    let l:default = ['govet', 'golint']
+  endif
+
+  return get(g:, 'go_metalinter_autosave_enabled', l:default)
 endfunction
 
 function! go#config#MetalinterEnabled() abort
-  return get(g:, "go_metalinter_enabled", ["vet", "golint", "errcheck"])
+  let l:default = []
+  if get(g:, 'go_metalinter_command', 'golangci-lint') == 'golangci-lint'
+    let l:default = ['vet', 'golint', 'errcheck']
+  endif
+
+  return get(g:, 'go_metalinter_enabled', l:default)
 endfunction
 
 function! go#config#GolintBin() abort

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -21,7 +21,7 @@ func! s:gometa(metalinter) abort
           \ ]
     endif
 
-    " clear the quickfix lists
+    " clear the quickfix list
     call setqflist([], 'r')
 
     let g:go_metalinter_enabled = ['golint']
@@ -57,7 +57,7 @@ func! s:gometa_shadow(metalinter) abort
           \ {'lnum': 4, 'bufnr': bufnr('%'), 'col': 7, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'e', 'module': '', 'text': 'Running error: golint: analysis skipped: errors in package'}
         \ ]
 
-    " clear the quickfix lists
+    " clear the quickfix list
     call setqflist([], 'r')
 
     let g:go_metalinter_enabled = ['golint']
@@ -109,7 +109,7 @@ func! s:gometaautosave(metalinter, withList) abort
       let l:expected = extend(copy(l:list), l:expected)
     endif
 
-    " set the location lists
+    " set the location list
     call setloclist(0, l:list, 'r')
 
     let g:go_metalinter_autosave_enabled = ['golint']
@@ -144,7 +144,7 @@ func! s:gometa_importabs(metalinter) abort
           \ {'lnum': 3, 'bufnr': bufnr('%'), 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] Can''t run linter golint: golint: analysis skipped: errors in package'},
           \ {'lnum': 3, 'bufnr': bufnr('%'), 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'e', 'module': '', 'text': 'Running error: golint: analysis skipped: errors in package'},
         \ ]
-    " clear the quickfix lists
+    " clear the quickfix list
     call setqflist([], 'r')
 
     let g:go_metalinter_enabled = ['golint']
@@ -180,7 +180,7 @@ func! s:gometaautosave_importabs(metalinter) abort
           \ {'lnum': 3, 'bufnr': bufnr('%')+1, 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'e', 'module': '', 'text': 'Running error: golint: analysis skipped: errors in package'}
         \ ]
 
-    " clear the location lists
+    " clear the location list
     call setloclist(0, [], 'r')
 
     let g:go_metalinter_autosave_enabled = ['golint']
@@ -215,7 +215,8 @@ func! s:gometa_multiple(metalinter) abort
           \ {'lnum': 8, 'bufnr': bufnr('%'), 'col': 7, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] Can''t run linter golint: golint: analysis skipped: errors in package'},
           \ {'lnum': 8, 'bufnr': bufnr('%'), 'col': 7, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'e', 'module': '', 'text': 'Running error: golint: analysis skipped: errors in package'},
         \ ]
-    " clear the quickfix lists
+
+    " clear the quickfix list
     call setqflist([], 'r')
 
     let g:go_metalinter_enabled = ['golint']
@@ -251,7 +252,7 @@ func! s:gometaautosave_multiple(metalinter) abort
           \ {'lnum': 8, 'bufnr': bufnr('%'), 'col': 7, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'e', 'module': '', 'text': 'Running error: golint: analysis skipped: errors in package'},
         \ ]
 
-    " clear the location lists
+    " clear the location list
     call setloclist(0, [], 'r')
 
     let g:go_metalinter_autosave_enabled = ['golint']
@@ -283,7 +284,7 @@ func! Test_Vet() abort
 
     let winnr = winnr()
 
-    " clear the location lists
+    " clear the quickfix list
     call setqflist([], 'r')
 
     call go#lint#Vet(1)
@@ -317,7 +318,7 @@ func! Test_Vet_subdir() abort
 
     let winnr = winnr()
 
-    " clear the location lists
+    " clear the quickfix list
     call setqflist([], 'r')
 
     call go#lint#Vet(1)
@@ -345,7 +346,7 @@ func! Test_Vet_compilererror() abort
 
     let winnr = winnr()
 
-    " clear the location lists
+    " clear the quickfix list
     call setqflist([], 'r')
 
     call go#lint#Vet(1)
@@ -376,7 +377,7 @@ func! Test_Lint_GOPATH() abort
 
   let winnr = winnr()
 
-  " clear the location lists
+  " clear the quickfix list
   call setqflist([], 'r')
 
   call go#lint#Golint(1)
@@ -404,7 +405,7 @@ func! Test_Lint_NullModule() abort
 
   let winnr = winnr()
 
-  " clear the location lists
+  " clear the quickfix list
   call setqflist([], 'r')
 
   call go#lint#Golint(1)
@@ -430,7 +431,7 @@ func! Test_Errcheck() abort
           \ {'lnum': 10, 'bufnr': bufnr('')+1, 'col': 9, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': ":\tio.Copy(os.Stdout, os.Stdin)"},
         \ ]
 
-    " clear the location lists
+    " clear the quickfix list
     call setqflist([], 'r')
 
     call go#lint#Errcheck(1)
@@ -452,7 +453,7 @@ func! Test_Errcheck_options() abort
           \ {'lnum': 9, 'bufnr': bufnr(''), 'col': 9, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': ":\tio.Copy(os.Stdout, os.Stdin)"},
         \ ]
 
-    " clear the location lists
+    " clear the quickfix list
     call setqflist([], 'r')
 
     call go#lint#Errcheck(1, '-ignoretests')
@@ -471,7 +472,7 @@ func! Test_Errcheck_compilererror() abort
     let l:bufnr = bufnr('')
     let expected = []
 
-    " clear the location lists
+    " clear the quickfix list
     call setqflist([], 'r')
 
     call go#lint#Errcheck(1)

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -6,6 +6,10 @@ func! Test_GometaGolangciLint() abort
   call s:gometa('golangci-lint')
 endfunc
 
+func! Test_GometaStaticcheck() abort
+  call s:gometa('staticcheck')
+endfunc
+
 func! s:gometa(metalinter) abort
   let RestoreGOPATH = go#util#SetEnv('GOPATH', fnamemodify(getcwd(), ':p') . 'test-fixtures/lint')
   silent exe 'e! ' . $GOPATH . '/src/lint/lint.go'
@@ -13,7 +17,7 @@ func! s:gometa(metalinter) abort
   try
     let g:go_metalinter_command = a:metalinter
     let expected = [
-          \ {'lnum': 5, 'bufnr': bufnr('%')+1, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingFooDoc should have comment or be unexported (golint)'}
+          \ {'lnum': 1, 'bufnr': bufnr('%')+5, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'at least one file in a package should have a package comment (ST1000)'}
         \ ]
     if a:metalinter == 'golangci-lint'
       let expected = [
@@ -24,7 +28,10 @@ func! s:gometa(metalinter) abort
     " clear the quickfix list
     call setqflist([], 'r')
 
-    let g:go_metalinter_enabled = ['golint']
+    let g:go_metalinter_enabled = ['ST1000']
+    if a:metalinter == 'golangci-lint'
+      let g:go_metalinter_enabled = ['golint']
+    endif
 
     call go#lint#Gometa(0, 0, $GOPATH . '/src/foo')
 
@@ -39,6 +46,7 @@ func! s:gometa(metalinter) abort
   finally
       call call(RestoreGOPATH, [])
       unlet g:go_metalinter_enabled
+      unlet g:go_metalinter_command
   endtry
 endfunc
 
@@ -75,6 +83,7 @@ func! s:gometa_shadow(metalinter) abort
   finally
       call call(RestoreGOPATH, [])
       unlet g:go_metalinter_enabled
+      unlet g:go_metalinter_command
   endtry
 endfunc
 
@@ -82,8 +91,16 @@ func! Test_GometaAutoSaveGolangciLint() abort
   call s:gometaautosave('golangci-lint', 0)
 endfunc
 
+func! Test_GometaAutoSaveStaticcheck() abort
+  call s:gometaautosave('staticcheck', 0)
+endfunc
+
 func! Test_GometaAutoSaveGolangciLintKeepsErrors() abort
   call s:gometaautosave('golangci-lint', 1)
+endfunc
+
+func! Test_GometaAutoSaveStaticcheckKeepsErrors() abort
+  call s:gometaautosave('staticcheck', 1)
 endfunc
 
 func! s:gometaautosave(metalinter, withList) abort
@@ -93,7 +110,7 @@ func! s:gometaautosave(metalinter, withList) abort
   try
     let g:go_metalinter_command = a:metalinter
     let l:expected = [
-          \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported (golint)'}
+          \ {'lnum': 1, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'at least one file in a package should have a package comment (ST1000)'}
         \ ]
     if a:metalinter == 'golangci-lint'
       let l:expected = [
@@ -112,7 +129,10 @@ func! s:gometaautosave(metalinter, withList) abort
     " set the location list
     call setloclist(0, l:list, 'r')
 
-    let g:go_metalinter_autosave_enabled = ['golint']
+    let g:go_metalinter_autosave_enabled = ['ST1000']
+    if a:metalinter == 'golangci-lint'
+      let g:go_metalinter_autosave_enabled = ['golint']
+    endif
 
     call go#lint#Gometa(0, 1)
 
@@ -127,6 +147,7 @@ func! s:gometaautosave(metalinter, withList) abort
   finally
     call call(RestoreGOPATH, [])
     unlet g:go_metalinter_autosave_enabled
+    unlet g:go_metalinter_command
   endtry
 endfunc
 
@@ -162,6 +183,7 @@ func! s:gometa_importabs(metalinter) abort
   finally
       call call(RestoreGOPATH, [])
       unlet g:go_metalinter_enabled
+      unlet g:go_metalinter_command
   endtry
 endfunc
 
@@ -198,6 +220,7 @@ func! s:gometaautosave_importabs(metalinter) abort
   finally
     call call(RestoreGOPATH, [])
     unlet g:go_metalinter_autosave_enabled
+    unlet g:go_metalinter_command
   endtry
 endfunc
 
@@ -234,6 +257,7 @@ func! s:gometa_multiple(metalinter) abort
   finally
       call call(RestoreGOPATH, [])
       unlet g:go_metalinter_enabled
+      unlet g:go_metalinter_command
   endtry
 endfunc
 
@@ -270,6 +294,7 @@ func! s:gometaautosave_multiple(metalinter) abort
   finally
     call call(RestoreGOPATH, [])
     unlet g:go_metalinter_autosave_enabled
+    unlet g:go_metalinter_command
   endtry
 endfunc
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1623,27 +1623,45 @@ window. The list to use can be set using |'g:go_list_type_commands'|.
 <
                                           *'g:go_metalinter_autosave_enabled'*
 
-Specifies the enabled linters for auto |:GoMetaLinter| on save. By
-default it's using `vet` and `golint`. If any are enabled, `--disable-all`
-will be sent to the metalinter.
+Specifies the enabled linters for auto |:GoMetaLinter| on save. When the
+metalinter is `golangci-lint`, if any are enabled, `--disable-all` will be
+sent to the metalinter.
+
+When `g:go_metalinter_command` is set to `staticcheck`, the default value is
+an empty list; `staticcheck`'s `-checks` flag will not be used.
+>
+  let g:go_metalinter_autosave_enabled = ['all']
+<
+
+When `g:go_metalinter_command is set to `golangci-lint'`, the default value is
 >
   let g:go_metalinter_autosave_enabled = ['vet', 'golint']
 <
                                                    *'g:go_metalinter_enabled'*
 
-Specifies the linters to enable for the |:GoMetaLinter| command. By default
-it's using `vet`, `golint` and `errcheck`. If any are enabled, `--disable-all`
-will be sent to the metalinter.
+Specifies the linters to enable for the |:GoMetaLinter| command. For
+`golangci-lint`, if any are enabled, `--disable-all` will be passed to the
+metalinter.
+
+When `g:go_metalinter_command` is set to `staticcheck`, the default value is
+an empty list; `staticcheck`'s `-checks` flag will not be used.
+>
+  let g:go_metalinter_autosave_enabled = ['all']
+<
+
+When `g:go_metalinter_command is set to `golangci-lint'`, the default value is
 >
   let g:go_metalinter_enabled = ['vet', 'golint', 'errcheck']
 <
                                                    *'g:go_metalinter_command'*
 
 Overrides the command to be executed when |:GoMetaLinter| is called. By
-default it's `golangci-lint`. Valid options are `golangci-lint` and `gopls`.
+default it's `golangci-lint`. Valid options are `golangci-lint, `gopls`, and
+`staticcheck`..
+
 When the value is `gopls`, users may want to consider setting
-`g:go_gopls_staticcheck`.  It can also be used as an advanced setting for
-users who want to have more control over the metalinter.
+`g:go_gopls_staticcheck`. It can also be used as an advanced setting for users
+who want to have more control over the metalinter.
 >
   let g:go_metalinter_command = "golangci-lint"
 <
@@ -1651,6 +1669,8 @@ users who want to have more control over the metalinter.
 
 Overrides the maximum time the linters have to complete. By default it's 5
 seconds.
+
+Only applies when the metalinter is `golangci-lint`.
 >
   let g:go_metalinter_deadline = "5s"
 <

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -49,6 +49,7 @@ let s:packages = {
       \ 'golint':        ['golang.org/x/lint/golint@master'],
       \ 'gopls':         ['golang.org/x/tools/gopls@latest', {}, {'after': function('go#lsp#Restart', [])}],
       \ 'golangci-lint': ['github.com/golangci/golangci-lint/cmd/golangci-lint@master'],
+      \ 'staticcheck':   ['honnef.co/go/tools/cmd/staticcheck@latest'],
       \ 'gomodifytags':  ['github.com/fatih/gomodifytags@master'],
       \ 'gorename':      ['golang.org/x/tools/cmd/gorename@master'],
       \ 'gotags':        ['github.com/jstemmer/gotags@master'],


### PR DESCRIPTION
##### lint: add local variable scope prefix


##### lint: add support for using staticcheck as a metalinter

Add support for using staticcheck as a metalinter so that users that
don't want to use gopls' staticcheck integration have an option other
than golangci-lint.


