### PR TITLE
small improvements to testing experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 VIMS ?= vim-8.0 vim-8.2 nvim
+TEST_FLAGS ?=
 
 all: install lint test
 
@@ -12,7 +13,7 @@ install:
 test:
 	@echo "==> Running tests for $(VIMS)"
 	@for vim in $(VIMS); do \
-		./scripts/test $$vim; \
+		./scripts/test $(TEST_FLAGS) $$vim; \
 	done
 
 lint:

--- a/scripts/runtest.vim
+++ b/scripts/runtest.vim
@@ -32,7 +32,7 @@ endfunction
 function! s:clearOptions() abort
   " clear all the vim-go options
   for l:k in keys(g:)
-    if l:k =~ '^go_'
+    if l:k =~ '^go_' && l:k !~ '^go_loaded_'
       call execute(printf('unlet g:%s', l:k))
     endif
   endfor


### PR DESCRIPTION
Allow flags to be passed to scripts/test easily in the Makefile.

Do not clear variables named g:go_loaded_ at the end of each test,
because these variables indicate whether filetype plugins have been
loaded.