### PR TITLE
lint: fix title for GoMetaLinter

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -87,7 +87,7 @@ function! go#lint#Gometa(bang, autosave, ...) abort
     let l:for = 'GoMetaLinterAutoSave'
   else
     let l:listtype = go#list#Type('GoMetaLinter')
-    let l:for = 'GoMetaLinterAuto'
+    let l:for = 'GoMetaLinter'
   endif
 
   if l:err == 0


### PR DESCRIPTION
Remove the Auto suffix from the GoMetaLinter title; it was a copy/paste
mistake.