### PR TITLE
clear messages after each test

### DIFF
--- a/scripts/runtest.vim
+++ b/scripts/runtest.vim
@@ -121,6 +121,8 @@ for s:test in sort(s:tests)
     if g:test_verbose is 1
       call s:logmessages()
       call add(s:logs, printf("--- PASS %s (%ss)", s:test[:-3], s:elapsed_time))
+    else
+      silent messages clear
     endif
   endif
 endfor


### PR DESCRIPTION
Clear messages after each test so that the messages from a passing test don't pollute the next test that fails.