### PR TITLE
debug: restore all buffers' mappings

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -500,7 +500,7 @@ function! s:start_cb() abort
     autocmd! *
     call s:configureMappings('(go-debug-breakpoint)', '(go-debug-continue)')
   augroup END
-  doautocmd vim-go-debug FileType go
+  doautocmd vim-go-debug BufWinEnter *.go
 endfunction
 
 function! s:continue()
@@ -534,7 +534,7 @@ function! s:continue()
     autocmd! *
     call s:configureMappings('(go-debug-breakpoint)', '(go-debug-continue)', '(go-debug-halt)', '(go-debug-next)', '(go-debug-print)', '(go-debug-step)')
   augroup END
-  doautocmd vim-go-debug FileType go
+  doautocmd vim-go-debug BufWinEnter *.go
 endfunction
 
 function! s:err_cb(ch, msg) abort
@@ -1503,9 +1503,10 @@ function! s:configureMappings(...) abort
 
     let l:lhs = l:config.key
     try
-      call execute(printf('autocmd FileType go call s:save_maparg_for(expand(''%%''), ''%s'')', l:lhs))
+      call execute(printf('autocmd BufWinEnter *.go call s:save_maparg_for(expand(''%%''), ''%s'')', l:lhs))
+      call execute('autocmd BufWinLeave  *.go call s:restoreMappings()')
 
-      let l:mapping = 'autocmd FileType go nmap <buffer>'
+      let l:mapping = 'autocmd BufWinEnter *.go nmap <buffer>'
       if has_key(l:config, 'arguments')
         let l:mapping = printf('%s %s', l:mapping, l:config.arguments)
       endif


### PR DESCRIPTION
Ensure that all buffers' mappings are restored when debugging stops by
saving them on BufWinEnter and restoring them on BufWinLeave. When
debugging stops, the current buffer's mappings are restored.

@kernel-panic96 do you want to test this to make sure it resolves the issue we discussed while collaborating on #3035  ?
