### PR TITLE
config: add an option to ignore diagnostics warnings

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -576,6 +576,10 @@ function! go#config#DiagnosticsEnabled() abort
   return get(g:, 'go_diagnostics_enabled', 0)
 endfunction
 
+function! go#config#DiagnosticsIgnoreWarnings() abort
+  return get(g:, 'go_diagnostics_ignore_warnings', 0)
+endfunction
+
 function! go#config#GoplsOptions() abort
   return get(g:, 'go_gopls_options', ['-remote=auto'])
 endfunction

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -1393,7 +1393,9 @@ function! s:highlightMatches(errorMatches, warningMatches) abort
     call go#util#ClearHighlights('goDiagnosticWarning')
     if go#config#HighlightDiagnosticWarnings()
       let b:go_diagnostic_matches.warnings = copy(a:warningMatches)
-      call go#util#HighlightPositions('goDiagnosticWarning', a:warningMatches)
+      if !go#config#DiagnosticsIgnoreWarnings()
+        call go#util#HighlightPositions('goDiagnosticWarning', a:warningMatches)
+      endif
     endif
   endif
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1939,6 +1939,14 @@ By default it is disabled.
 >
   let g:go_diagnostics_enabled = 0
 <
+                                        *'g:go_diagnostics_ignore_warnings'*
+
+Specifies whether warnings from  `gopls` diagnostics are ignored.
+
+By default it is disabled.
+>
+  let g:go_diagnostics_ignore_warnings = 0
+<
 
                                                   *'g:go_template_autocreate'*
 


### PR DESCRIPTION
Add an option, g:go_diagnostics_ignore_warnings, to allow diagnostics
provided by gopls to be ignored.

When set, warnings provided by gopls will be neither highlighted nor
shown in the quickfix window after running `:GoDiagnostics` or using
`gopls` as the metalinter.

Closes #2636