### PR TITLE
config: consolidate diagnostics options

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -572,12 +572,19 @@ function! go#config#GoplsEnabled() abort
   return get(g:, 'go_gopls_enabled', 1)
 endfunction
 
+" TODO(bc): remove support for g:go_diagnostics_enabled;
+" g:go_diagnostics_level is the replacement.
 function! go#config#DiagnosticsEnabled() abort
   return get(g:, 'go_diagnostics_enabled', 0)
 endfunction
 
-function! go#config#DiagnosticsIgnoreWarnings() abort
-  return get(g:, 'go_diagnostics_ignore_warnings', 0)
+function! go#config#DiagnosticsLevel() abort
+  let l:default = 2
+  if has_key(g:, 'go_diagnostics_enabled') && !g:go_diagnostics_enabled
+    let l:default = 0
+  endif
+
+  return get(g:, 'go_diagnostics_level', l:default)
 endfunction
 
 function! go#config#GoplsOptions() abort

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -468,8 +468,13 @@ function! s:errorformat(metalinter) abort
   elseif a:metalinter == 'staticcheck'
     return '%f:%l:%c:\ %m'
   elseif a:metalinter == 'gopls'
-    let l:efm = ''
-    if go#config#DiagnosticsIgnoreWarnings()
+    let l:level = go#config#DiagnosticsLevel()
+
+    if l:level == 0
+      return '%-G%f:%l:%c:%t:\ %m,%-G%f:%l:%c::\ %m,%-G%f:%l::%t:\ %m'
+    endif
+
+    if l:level < 2
       let l:efm = '%-G%f:%l:%c:W:\ %m,%-G%f:%l::W:\ %m,'
     endif
     return l:efm . '%f:%l:%c:%t:\ %m,%f:%l:%c::\ %m,%f:%l::%t:\ %m'

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1931,21 +1931,20 @@ default it is `v:null`.
 <
                                                  *'g:go_diagnostics_enabled'*
 
-Specifies whether `gopls` diagnostics are enabled. Only the diagnostics for
-the current buffer will be processed when it is not set; all others will be
-ignored.
-
-By default it is disabled.
+Deprecated. See `'g:go_diagnostics_level'`. Specifies whether `gopls`
+diagnostics are enabled. Only the diagnostics for the current buffer will be
+processed when it is not set; all others will be ignored. By default it is
+disabled.
 >
   let g:go_diagnostics_enabled = 0
 <
-                                        *'g:go_diagnostics_ignore_warnings'*
+                                                  *'g:go_diagnostics_level'*
 
-Specifies whether warnings from  `gopls` diagnostics are ignored.
-
-By default it is disabled.
+Specifies the `gopls` diagnostics level. Valid values are 0, 1, and 2. 0
+ignores `gopls` diagnostics, 1 is for errors only, and 2 is for errors and
+warnings. By default it is 2.
 >
-  let g:go_diagnostics_ignore_warnings = 0
+  let g:go_diagnostics_level = 2
 <
 
                                                   *'g:go_template_autocreate'*


### PR DESCRIPTION
Replace g:go_diagnostics_enabled and g:go_diagnostics_ignore_warnings
into a single new option, g:go_diagnostics_level.