### PR TITLE
lsp: restore ignoring diagnostics

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -248,7 +248,7 @@ function! s:newlsp() abort
         " Vim says that a buffer name can't be an absolute path.
         let l:bufname = fnamemodify(l:fname, ':.')
 
-        if len(l:data.diagnostics) > 0
+        if len(l:data.diagnostics) > 0 && (l:level > 0 || bufnr(l:bufname) == bufnr(''))
           " make sure the buffer is listed and loaded before calling getbufline() on it
           if !bufexists(l:bufname)
             call bufadd(l:bufname)


### PR DESCRIPTION
Restore the ignoring of diagnostics when diagnostics are off and the
diagnostic is not for the current buffer.

This restores behavior originally created in
https://github.com/fatih/vim-go/pull/2612 and adjusts it for the other
changes made in https://github.com/fatih/vim-go/pull/3052.