### PR TITLE
config: disable diagnostics by default

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -579,9 +579,9 @@ function! go#config#DiagnosticsEnabled() abort
 endfunction
 
 function! go#config#DiagnosticsLevel() abort
-  let l:default = 2
-  if has_key(g:, 'go_diagnostics_enabled') && !g:go_diagnostics_enabled
-    let l:default = 0
+  let l:default = 0
+  if has_key(g:, 'go_diagnostics_enabled') && g:go_diagnostics_enabled
+    let l:default = 2
   endif
 
   return get(g:, 'go_diagnostics_level', l:default)

--- a/autoload/go/highlight_test.vim
+++ b/autoload/go/highlight_test.vim
@@ -272,6 +272,7 @@ endfunction
 
 function! Test_diagnostic_after_fmt() abort
   let g:go_fmt_command = 'gofmt'
+  let g:go_diagnostics_level = 2
   try
     call s:diagnostic_after_write( [
           \ 'package main',
@@ -290,6 +291,7 @@ endfunction
 function! Test_diagnostic_after_fmt_change() abort
   " craft a file that will be changed when its written (gofmt will change it).
   let g:go_fmt_command = 'gofmt'
+  let g:go_diagnostics_level = 2
   try
     call s:diagnostic_after_write( [
           \ 'package main',
@@ -308,6 +310,7 @@ endfunction
 function! Test_diagnostic_after_fmt_cleared() abort
   " craft a file that will be fixed when it is written.
   let g:go_fmt_command = 'gofmt'
+  let g:go_diagnostics_level = 2
   try
     call s:diagnostic_after_write( [
           \ 'package main',
@@ -324,6 +327,7 @@ function! Test_diagnostic_after_fmt_cleared() abort
 endfunction
 
 function! Test_diagnostic_after_reload() abort
+  let g:go_diagnostics_level = 2
   let l:dir = gotest#write_file('diagnostic/after-reload.go', [
               \ 'package main',
               \ 'import "fmt"',
@@ -347,6 +351,7 @@ endfunction
 function! s:diagnostic_after_write(contents, changes) abort
   syntax on
 
+  let g:go_diagnostics_level = 2
   let l:dir = gotest#write_file('diagnostic/after-write.go', a:contents)
 
   try

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1946,9 +1946,9 @@ disabled.
 
 Specifies the `gopls` diagnostics level. Valid values are 0, 1, and 2. 0
 ignores `gopls` diagnostics, 1 is for errors only, and 2 is for errors and
-warnings. By default it is 2.
+warnings. By default it is 0.
 >
-  let g:go_diagnostics_level = 2
+  let g:go_diagnostics_level = 0
 <
 
                                                   *'g:go_template_autocreate'*


### PR DESCRIPTION
Disable diagnostics by default so that the default behavior is preserved
to be as it was before g:go_diagnostics_level was introduced.