### PR TITLE
lint: add test for using gopls as the metalinter

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -1317,7 +1317,7 @@ function! go#lsp#AnalyzeFile(fname) abort
 
   let l:lastdiagnostics = get(l:lsp.diagnostics, l:fname, [])
 
-  let l:version = l:lsp.fileVersions[a:fname]
+  let l:version = get(l:lsp.fileVersions, a:fname, 0)
   if l:version == getbufvar(a:fname, 'changedtick')
     return l:lastdiagnostics
   endif
@@ -1325,7 +1325,7 @@ function! go#lsp#AnalyzeFile(fname) abort
   call go#lsp#DidChange(a:fname)
 
   let l:diagnostics = go#promise#New(function('s:setDiagnostics', []), 10000, l:lastdiagnostics)
-  let l:lsp.notificationQueue[l:fname] = add(l:lsp.notificationQueue[l:fname], l:diagnostics.wrapper)
+  let l:lsp.notificationQueue[l:fname] = add(get(l:lsp.notificationQueue, l:fname, []), l:diagnostics.wrapper)
   return l:diagnostics.await()
 endfunction
 

--- a/scripts/runtest.vim
+++ b/scripts/runtest.vim
@@ -87,7 +87,7 @@ for s:test in sort(s:tests)
     " in 'stream closed' errors when the events were run _after_ gopls exited.
     sleep 50m
   catch
-    let v:errors += [v:exception]
+    call assert_report(printf('at %s: %s', v:throwpoint, v:exception))
   finally
     call s:clearOptions()
   endtry


### PR DESCRIPTION
##### scripts: use assert_report to capture exceptions

Use assert_report to capture exceptions in scripts/runtest.vim so that
unhandled exceptions in tests will be fully reported and identifiable.


##### lint: add test for using gopls as the metalinter

Add a test for using gopls as the metalinter so that issues like #3054
will be caught by tests in the future.


##### lsp: handle missing values when getting file analysis


