### PR TITLE
debug: preserve the current window layout

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -440,16 +440,18 @@ endfunction
 
 function! s:start_cb() abort
   let l:winid = win_getid()
-  silent! only!
+  let l:debugwindows = go#config#DebugWindows()
+  if !empty(l:debugwindows)
+    silent! only!
+  endif
 
   let winnum = bufwinnr(bufnr('__GODEBUG_STACKTRACE__'))
   if winnum != -1
     return
   endif
 
-  let debugwindows = go#config#DebugWindows()
-  if has_key(debugwindows, "vars") && debugwindows['vars'] != ''
-    exe 'silent ' . debugwindows['vars']
+  if has_key(l:debugwindows, "vars") && l:debugwindows['vars'] != ''
+    exe 'silent ' . l:debugwindows['vars']
     silent file `='__GODEBUG_VARIABLES__'`
     setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
     setlocal filetype=godebugvariables
@@ -458,8 +460,8 @@ function! s:start_cb() abort
     nmap <buffer> q <Plug>(go-debug-stop)
   endif
 
-  if has_key(debugwindows, "stack") && debugwindows['stack'] != ''
-    exe 'silent ' . debugwindows['stack']
+  if has_key(l:debugwindows, "stack") && l:debugwindows['stack'] != ''
+    exe 'silent ' . l:debugwindows['stack']
     silent file `='__GODEBUG_STACKTRACE__'`
     setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
     setlocal filetype=godebugstacktrace
@@ -467,8 +469,8 @@ function! s:start_cb() abort
     nmap <buffer> q <Plug>(go-debug-stop)
   endif
 
-  if has_key(debugwindows, "goroutines") && debugwindows['goroutines'] != ''
-    exe 'silent ' . debugwindows['goroutines']
+  if has_key(l:debugwindows, "goroutines") && l:debugwindows['goroutines'] != ''
+    exe 'silent ' . l:debugwindows['goroutines']
     silent file `='__GODEBUG_GOROUTINES__'`
     setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
     setlocal filetype=godebugvariables
@@ -476,8 +478,8 @@ function! s:start_cb() abort
     nmap <buffer> <silent> <cr> :<c-u>call go#debug#Goroutine()<cr>
   endif
 
-  if has_key(debugwindows, "out") && debugwindows['out'] != ''
-    exe 'silent ' . debugwindows['out']
+  if has_key(l:debugwindows, "out") && l:debugwindows['out'] != ''
+    exe 'silent ' . l:debugwindows['out']
     silent file `='__GODEBUG_OUTPUT__'`
     setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
     setlocal filetype=godebugoutput

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2481,7 +2481,8 @@ DEBUGGER SETTINGS~
 Controls the window layout for debugging mode. This is a |dict| with four
 possible keys: "vars", "stack", "goroutines", and "out"; each of the new
 windows will be created in that that order with the commands in the value. The
-current window is made the only window before creating the debug windows.
+current window is made the only window before creating the debug windows
+unless `g:go_debug_windows` is empty.
 
 A window will not be created if a key is missing or empty.
 


### PR DESCRIPTION
Preserve the curent window layout when g:go_debug_windows is empty.

Fixes #3020.