### PR TITLE
guru: re-enable commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,6 @@ IMPROVEMENTS:
   [[GH-3068]](https://github.com/fatih/vim-go/pull/3068)
 * Show identifier in fzf's preview window with `:GoDecls` and `:GoDeclsDir`.
   [[GH-3083]](https://github.com/fatih/vim-go/pull/3083)
-* Do not hookup commands that require `guru` when not in GOPATH mode.
-  [[GH-2704]](https://github.com/fatih/vim-go/pull/2704)
 * Use `gopls` for `:GoCallers`.
   [[GH-3088]](https://github.com/fatih/vim-go/pull/3088)
   [[GH-3090]](https://github.com/fatih/vim-go/pull/3090)

--- a/autoload/go/guru.vim
+++ b/autoload/go/guru.vim
@@ -14,9 +14,9 @@ set cpo&vim
 " example output:
 "  {'cmd' : ['guru', '-json', 'implements', 'demo/demo.go:#66']}
 function! s:guru_cmd(args) range abort
-  if !go#package#InGOPATH()
-    return {'err': 'guru only supports packages within GOPATH'}
-  endif
+  "if !go#package#InGOPATH()
+    "return {'err': 'guru only supports packages within GOPATH'}
+  "endif
   let mode = a:args.mode
 
   let format = a:args.format

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -3,7 +3,7 @@ command! -nargs=? -complete=customlist,go#rename#Complete GoRename call go#renam
 
 " -- guru
 " do not configure commands that _require_ guru when not in GOPATH mode.
-if go#package#InGOPATH()
+"if go#package#InGOPATH()
   command! -nargs=* -complete=customlist,go#package#Complete GoGuruScope call go#guru#Scope(<f-args>)
   command! -range=% GoPointsTo call go#guru#PointsTo(<count>)
   command! -range=% GoWhicherrs call go#guru#Whicherrs(<count>)
@@ -12,7 +12,7 @@ if go#package#InGOPATH()
   command! -range=% GoCallstack call go#guru#Callstack(<count>)
   command! -range=% GoFreevars call go#guru#Freevars(<count>)
   command! -range=% GoChannelPeers call go#guru#ChannelPeers(<count>)
-endif
+"endif
 
 command! -range=% GoImplements call go#implements#Implements(<count>)
 command! -range=% GoReferrers call go#referrers#Referrers(<count>)


### PR DESCRIPTION
Re-enable guru commands. While some won't work correctly in module-aware
mode, some will. It's not clear which ones don't. Until that's clear,
we'll enable them all again.

This reverts #2704