### PR TITLE
Delete a param that is removed in Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: set up python
-      uses: actions/setup-python@v1.2.0
+      uses: actions/setup-python@v2.1.4
       with:
         python-version: 3.6
     - name: install vim-vint
@@ -35,7 +35,7 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
     - name: set up python
-      uses: actions/setup-python@v1.2.0
+      uses: actions/setup-python@v2.1.4
       with:
         python-version: 3.6
     - name: install covimerage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         vim: ['vim-8.0', 'vim-8.2', 'nvim']
     steps:
     - name: setup Go
-      uses: actions/setup-go@v2.0.3
+      uses: actions/setup-go@v2.1.3
       with:
         go-version: ${{ matrix.go }}
     - name: set up python

--- a/rplugin/python3/denite/source/decls.py
+++ b/rplugin/python3/denite/source/decls.py
@@ -65,7 +65,7 @@ class Source(Base):
             return []
 
         txt = cmd.stdout.decode('utf-8')
-        output = json.loads(txt, encoding='utf-8')
+        output = json.loads(txt)
 
         def make_candidates(row):
             name = self.vim.funcs.fnamemodify(row['filename'], ':~:.')


### PR DESCRIPTION
https://docs.python.org/3/library/json.html#json.loads

`encoding` option in `json.loads` has been removed in Python 3.9. This param has been being deprecated from long time ago (since 3.1), so it should not affect users.