### PR TITLE
Improved highlighting for generate and build directives

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2154,7 +2154,8 @@ Highlight trailing white space. >
 <
                                                   *'g:go_highlight_operators'*
 
-Highlight operators such as `:=` , `==`, `-=`, etc.
+Highlight operators such as `:=` , `==`, `-=`, etc. Also works for `,` and `!`
+on +build directives.
 >
   let g:go_highlight_operators = 0
 <

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -73,7 +73,7 @@ hi def link     goTodo              Todo
 
 if go#config#HighlightGenerateTags()
   syn match       goGenerateVariables contained /\%(\$GOARCH\|\$GOOS\|\$GOFILE\|\$GOLINE\|\$GOPACKAGE\|\$DOLLAR\)\>/
-  syn region      goGenerate          start="^\s*//go:generate" end="$" contains=goGenerateVariables
+  syn region      goGenerate          start="go:generate" end="$" contains=goGenerateVariables
   hi def link     goGenerate          PreProc
   hi def link     goGenerateVariables Special
 endif
@@ -362,10 +362,14 @@ if go#config#HighlightBuildConstraints()
   " instead of the matchgroup so it will be highlighted as a goBuildKeyword.
   syn region  goBuildComment      matchgroup=goBuildCommentStart
         \ start="//\s*+build\s"rs=s+2 end="$"
-        \ contains=goBuildKeyword,goBuildDirectives
+        \ contains=goBuildKeyword,goBuildDirectives,goBuildOperators
   hi def link goBuildCommentStart Comment
   hi def link goBuildDirectives   Type
   hi def link goBuildKeyword      PreProc
+  if go#config#HighlightOperators()
+    syn match   goBuildOperators display contained /,\|!/
+    hi def link goBuildOperators Operator
+  endif
 endif
 
 if go#config#HighlightBuildConstraints() || go#config#FoldEnable('package_comment')


### PR DESCRIPTION
When creating a go:generate directive, the `//` is now highlighted as a normal comment, since it looked too different from other comments before, particularly from build directives.
Speaking of build directives, the `,` and `!` operators in the line will be highlighted as any other operator, provided `g:go_highlight_operators` is true