### PR TITLE
correct and extend use of g:go_diagnostics_level

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -1428,11 +1428,13 @@ function! s:highlightMatches(errorMatches, warningMatches) abort
 
   if hlexists('goDiagnosticError')
     " clear the old matches just before adding the new ones to keep flicker
-    " to a minimum.
+    " to a minimum and clear before checking the level so that if the user
+    " changed the level since the last highlighting, the highlighting will be
+    " be properly cleared.
     call go#util#ClearHighlights('goDiagnosticError')
-    if go#config#HighlightDiagnosticErrors()
+    if go#config#DiagnosticsLevel() >= 2
       let b:go_diagnostic_matches.errors = copy(a:errorMatches)
-      if go#config#DiagnosticsLevel() >= 2
+      if go#config#HighlightDiagnosticErrors()
         call go#util#HighlightPositions('goDiagnosticError', a:errorMatches)
       endif
     endif
@@ -1440,11 +1442,13 @@ function! s:highlightMatches(errorMatches, warningMatches) abort
 
   if hlexists('goDiagnosticWarning')
     " clear the old matches just before adding the new ones to keep flicker
-    " to a minimum.
+    " to a minimum and clear before checking the level so that if the user
+    " changed the level since the last highlighting, the highlighting will be
+    " be properly cleared.
     call go#util#ClearHighlights('goDiagnosticWarning')
-    if go#config#HighlightDiagnosticWarnings()
+    if go#config#DiagnosticsLevel() >= 2
       let b:go_diagnostic_matches.warnings = copy(a:warningMatches)
-      if go#config#DiagnosticsLevel() >= 2
+      if go#config#HighlightDiagnosticWarnings()
         call go#util#HighlightPositions('goDiagnosticWarning', a:warningMatches)
       endif
     endif

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -259,6 +259,9 @@ function! s:newlsp() abort
           endif
 
           for l:diag in l:data.diagnostics
+            if l:level < l:diag.severity
+              continue
+            endif
             let [l:error, l:matchpos] = s:errorFromDiagnostic(l:diag, l:bufname, l:fname)
             let l:diagnostics = add(l:diagnostics, l:error)
 


### PR DESCRIPTION
##### lsp: use diagnostic options properly

Use the diagnostics level to determine whether to store the diagnostics
with the buffer and the diagnostic highlight options to determine
whether to highlight the relevent text.

This will allow users to toggle highlighting to affect whether text is
highlighted and adjust the level to determine whether there are any
diagnostics stored at all.


##### lsp: ignore diagnostics that do not satisfy g:go_diagnostics_level


