### PR TITLE
debug: add explicit preserve layout setting

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -212,7 +212,7 @@ function! go#config#DebugWindows() abort
 endfunction
 
 function! go#config#DebugPreserveLayout() abort
-  return get(g:, 'go_debug_preserve_layout', -1)
+  return get(g:, 'go_debug_preserve_layout', 0)
 endfunction
 
 function! go#config#DebugAddress() abort

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -211,6 +211,10 @@ function! go#config#DebugWindows() abort
 
 endfunction
 
+function! go#config#DebugPreserveLayout() abort
+  return get(g:, 'go_debug_preserve_layout', -1)
+endfunction
+
 function! go#config#DebugAddress() abort
   return get(g:, 'go_debug_address', '127.0.0.1:8181')
 endfunction

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -459,10 +459,7 @@ function! s:start_cb() abort
   let l:debugwindows = go#config#DebugWindows()
   let l:debugpreservelayout = go#config#DebugPreserveLayout()
 
-  " If g:go_debug_preserve_layout is not explicitly set, for backwards
-  " compatibility defer to g:go_debug_windows for :only behavior (ie if
-  " empty, preserve layout).
-  if (l:debugpreservelayout == -1 && !empty(l:debugwindows)) || l:debugpreservelayout == 0
+  if !(empty(l:debugwindows) || l:debugpreservelayout)
     silent! only!
   endif
 

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -305,10 +305,26 @@ function! go#debug#Stop() abort
   else
     wincmd p
   endif
-  silent! exe bufwinnr(bufnr('__GODEBUG_STACKTRACE__')) 'wincmd c'
-  silent! exe bufwinnr(bufnr('__GODEBUG_VARIABLES__')) 'wincmd c'
-  silent! exe bufwinnr(bufnr('__GODEBUG_OUTPUT__')) 'wincmd c'
-  silent! exe bufwinnr(bufnr('__GODEBUG_GOROUTINES__')) 'wincmd c'
+
+  let stackbufnr = bufnr('__GODEBUG_STACKTRACE__')
+  if stackbufnr != -1
+    silent! exe bufwinnr(stackbufnr) 'wincmd c'
+  endif
+
+  let varbufnr = bufnr('__GODEBUG_VARIABLES__')
+  if varbufnr != -1
+    silent! exe bufwinnr(varbufnr) 'wincmd c'
+  endif
+
+  let outbufnr = bufnr('__GODEBUG_OUTPUT__')
+  if outbufnr != -1
+    silent! exe bufwinnr(outbufnr) 'wincmd c'
+  endif
+
+  let gorobufnr = bufnr('__GODEBUG_GOROUTINES__')
+  if gorobufnr != -1
+    silent! exe bufwinnr(gorobufnr) 'wincmd c'
+  endif
 
   if has('balloon_eval')
     let &ballooneval=s:ballooneval
@@ -441,7 +457,8 @@ endfunction
 function! s:start_cb() abort
   let l:winid = win_getid()
   let l:debugwindows = go#config#DebugWindows()
-  if !empty(l:debugwindows)
+  let l:debugpreservelayout = go#config#DebugPreserveLayout()
+  if (empty(l:debugwindows) && l:debugpreservelayout == -1) || l:debugpreservelayout != 1
     silent! only!
   endif
 

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -458,7 +458,11 @@ function! s:start_cb() abort
   let l:winid = win_getid()
   let l:debugwindows = go#config#DebugWindows()
   let l:debugpreservelayout = go#config#DebugPreserveLayout()
-  if (empty(l:debugwindows) && l:debugpreservelayout == -1) || l:debugpreservelayout != 1
+
+  " If g:go_debug_preserve_layout is not explicitly set, for backwards
+  " compatibility defer to g:go_debug_windows for :only behavior (ie if
+  " empty, preserve layout).
+  if (l:debugpreservelayout == -1 && !empty(l:debugwindows)) || l:debugpreservelayout == 0
     silent! only!
   endif
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2494,12 +2494,10 @@ Show only variables on the right-hand side: >
 
                                                 *'g:go_debug_preserve_layout'*
 
-Preserve window layout in debugging mode. Valid values are -1, 0, 1. Defaults
-to -1 which, for backwards compatibility, defers to |'g:go_debug_windows'| for
-preserving behavior (if `g:go_debug_windows` is empty, preserve layout). If
-set to 0 or 1, it takes precedence over `g:go_debug_windows`.
+Preserve window layout in debugging mode. This setting is considered only when
+|'g:go_debug_windows'| is not empty.
 >
-  let g:go_debug_preserve_layout = -1
+  let g:go_debug_preserve_layout = 0
 <
                                                        *'g:go_debug_mappings'*
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2472,7 +2472,7 @@ Controls the window layout for debugging mode. This is a |dict| with four
 possible keys: "vars", "stack", "goroutines", and "out"; each of the new
 windows will be created in that that order with the commands in the value. The
 current window is made the only window before creating the debug windows
-unless `g:go_debug_windows` is empty.
+unless `g:go_debug_windows` is empty. See also |'g:go_debug_preserve_layout'|.
 
 A window will not be created if a key is missing or empty.
 
@@ -2490,7 +2490,15 @@ Show only variables on the right-hand side: >
   let g:go_debug_windows = {
         \ 'vars':  'rightbelow 60vnew',
   \ }
+<
 
+                                                *'g:go_debug_preserve_layout'*
+
+Preserve window layout in debugging mode. If explicitly set, it will override
+the preserving behavior when |'g:go_debug_windows'| is empty.
+>
+  let g:go_debug_preserve_layout = 0
+<
                                                        *'g:go_debug_mappings'*
 
 Contains custom key mapping information to customize the active mappings

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2494,10 +2494,12 @@ Show only variables on the right-hand side: >
 
                                                 *'g:go_debug_preserve_layout'*
 
-Preserve window layout in debugging mode. If explicitly set, it will override
-the preserving behavior when |'g:go_debug_windows'| is empty.
+Preserve window layout in debugging mode. Valid values are -1, 0, 1. Defaults
+to -1 which, for backwards compatibility, defers to |'g:go_debug_windows'| for
+preserving behavior (if `g:go_debug_windows` is empty, preserve layout). If
+set to 0 or 1, it takes precedence over `g:go_debug_windows`.
 >
-  let g:go_debug_preserve_layout = 0
+  let g:go_debug_preserve_layout = -1
 <
                                                        *'g:go_debug_mappings'*
 


### PR DESCRIPTION
Adds a new setting, `g:go_debug_preserve_layout`, which, when explicitly set, will preserve the current window layout, irrespective of the value of `g:go_debug_windows`. Default value keeps current behavior (does not preserve). Fixes #3020.