### PR TITLE
lint: pass whole directory to staticcheck on write

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -49,7 +49,7 @@ function! go#lint#Gometa(bang, autosave, ...) abort
     redraw
 
     let l:goargs[0] = expand('%:p')
-    if l:metalinter == "golangci-lint"
+    if l:metalinter == 'staticcheck' || l:metalinter == "golangci-lint"
       let l:goargs[0] = expand('%:p:h')
     endif
   endif
@@ -395,7 +395,7 @@ function! s:lint_job(metalinter, args, bang, autosave)
 
   if a:autosave
     let l:opts.for = 'GoMetaLinterAutoSave'
-    " s:metalinterautosavecomplete is really only needed for golangci-lint
+    " s:metalinterautosavecomplete is needed for staticcheck and golangci-lint
     let l:opts.complete = funcref('s:metalinterautosavecomplete', [a:metalinter, expand('%:p:t')])
     let l:opts.preserveerrors = funcref('s:preserveerrors', [a:autosave])
   endif
@@ -438,7 +438,7 @@ function! s:golangcilintcmd(bin_path, haslinter)
 endfunction
 
 function! s:metalinterautosavecomplete(metalinter, filepath, job, exit_code, messages)
-  if a:metalinter != 'golangci-lint'
+  if !(a:metalinter == 'golangci-lint' || a:metalinter == 'staticcheck')
     return
   endif
 
@@ -451,7 +451,7 @@ function! s:metalinterautosavecomplete(metalinter, filepath, job, exit_code, mes
     " leave in any messages that report errors about a:filepath or that report
     " more general problems that prevent golangci-lint from linting
     " a:filepath.
-    if l:item =~# '^' . a:filepath . ':' || l:item =~# '^level='
+    if l:item =~# '^' . a:filepath . ':' || (a:metalinter == 'golangci-lint' && l:item =~# '^level=')
       let l:idx += 1
       continue
     endif

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -122,8 +122,6 @@ func! s:gometaautosave(metalinter, withList) abort
     let l:vim = s:vimdir()
     let l:expected = [
           \ {'lnum': 1, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'at least one file in a package should have a package comment (ST1000)'},
-          \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'pattern': '', 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': ''},
-          \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'pattern': '', 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': 'Run ''/tmp/vim-go-test/' . l:vim . '-install/bin/staticcheck -explain <check>'' or visit https://staticcheck.io/docs/checks for documentation on checks.'}
         \ ]
     if a:metalinter == 'gopls'
       let l:expected = [


### PR DESCRIPTION
Pass the whole directory of the buffer being saved when staticcheck is
the metalinter to use; it needs all the files necessary to analyze the
package. Like with golangci-lint, problems with other files are filtered
out of the results.

Fixes #3132