### PR TITLE
Fix GoDef E474: Invalid argument

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -138,10 +138,10 @@ function! go#def#jump_to_declaration(out, mode, bin_name) abort
   let ident = 0
   let filename = parts[0]
   if len(parts) > 1
-    let line = parts[1]
+    let line = str2nr(parts[1])
   endif
   if len(parts) > 2
-    let col = parts[2]
+    let col = str2nr(parts[2])
   endif
   if len(parts) > 3
     let ident = parts[3]


### PR DESCRIPTION
This fixes an error when you execute `:GoDef` in Vim 8.2.2324 or newer.
Actually, the error is due to some changes in Vim itself here: https://github.com/vim/vim/commit/6f02b00bb0
The commit makes `lnum` and `col` for `cursor()` function has to be an integer if it's not a list; it was ok to pass string values for that.
You can confirm this behaviour easily like this:

```vim
" this doesn't work Vim 8.2.2324 or newer, but works with Vim 8.2.2323 or older
:cal cursor('1', '1')

" Interestingly this works, it could be a bug may be?
:cal cursor(['1', '1'])

" {lnum} and {col} have to be an integer in >= Vim 8.2.234
:cal cursor(1, 1)
```

```
vim-go: [definition] SUCCESS
"/usr/local/bin/go1.15.5/src/flag/flag.go" [readonly] 1045L, 34608B
Error detected while processing function 271[13]..273[37]..function 271[13]..273[26]..<SNR>104_definitionHandler[8]..<SNR>179_jump_to_declaration_cb[5]..go#def#jump_to_declaration:
line   92:
E474: Invalid argument
Error detected while processing function 271:
line   13:
E171: Missing :endif
```