### PR TITLE
lint: adjust staticcheck expectations

### DIFF
--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -19,8 +19,6 @@ func! s:gometa(metalinter) abort
     let l:vim = s:vimdir()
     let expected = [
           \ {'lnum': 1, 'bufnr': bufnr('%')+9, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'at least one file in a package should have a package comment (ST1000)'},
-          \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'pattern': '', 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': ''},
-          \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'pattern': '', 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': 'Run ''/tmp/vim-go-test/' . l:vim . '-install/bin/staticcheck -explain <check>'' or visit https://staticcheck.io/docs/checks for documentation on checks.'}
         \ ]
     if a:metalinter == 'golangci-lint'
       let expected = [


### PR DESCRIPTION
Remove the expected messages about staticcheck's -explain flag;
staticcheck 2020.2.1 no longer outputs those.