### PR TITLE
Fix go-callers signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ IMPROVEMENTS:
   [[GH-3088]](https://github.com/fatih/vim-go/pull/3088)
   [[GH-3090]](https://github.com/fatih/vim-go/pull/3090)
   [[GH-3141]](https://github.com/fatih/vim-go/pull/3141)
+  [[GH-3142]](https://github.com/fatih/vim-go/pull/3142)
 * Update denite integration to work with python3.9.
   [[GH-3097]](https://github.com/fatih/vim-go/pull/3097)
 * Add syntax highlighting for go.sum files.

--- a/ftplugin/go/mappings.vim
+++ b/ftplugin/go/mappings.vim
@@ -37,7 +37,7 @@ nnoremap <silent> <Plug>(go-imports) :<C-u>call go#fmt#Format(1)<CR>
 
 nnoremap <silent> <Plug>(go-implements) :<C-u>call go#implements#Implements(-1)<CR>
 nnoremap <silent> <Plug>(go-callees) :<C-u>call go#guru#Callees(-1)<CR>
-nnoremap <silent> <Plug>(go-callers) :<C-u>call go#calls#Callers(-1)<CR>
+nnoremap <silent> <Plug>(go-callers) :<C-u>call go#calls#Callers()<CR>
 nnoremap <silent> <Plug>(go-describe) :<C-u>call go#guru#Describe(-1)<CR>
 nnoremap <silent> <Plug>(go-callstack) :<C-u>call go#guru#Callstack(-1)<CR>
 xnoremap <silent> <Plug>(go-freevars) :<C-u>call go#guru#Freevars(0)<CR>


### PR DESCRIPTION
#3141 was, probably, too quick..

```
E118: Too many arguments for function: go#calls#Callers
```