### PR TITLE
Make go-debug-stepout available for debug mapping

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -552,7 +552,7 @@ function! s:continue()
   call s:restoreMappings()
   augroup vim-go-debug
     autocmd! *
-    call s:configureMappings('(go-debug-breakpoint)', '(go-debug-continue)', '(go-debug-halt)', '(go-debug-next)', '(go-debug-print)', '(go-debug-step)')
+    call s:configureMappings('(go-debug-breakpoint)', '(go-debug-continue)', '(go-debug-halt)', '(go-debug-next)', '(go-debug-print)', '(go-debug-step)', '(go-debug-stepout)')
   augroup END
   doautocmd vim-go-debug BufWinEnter *.go
 endfunction


### PR DESCRIPTION
Now go-debug-stepout could be used like this:

`let g:go_debug_mappings = { '(go-debug-stepout)': {'key': '<F12>'} }`