### PR TITLE
Fix: Ensure filetype is set for Go templates 

### DIFF
--- a/ftdetect/gofiletype.vim
+++ b/ftdetect/gofiletype.vim
@@ -7,7 +7,7 @@ set cpo&vim
 " Note: should not use augroup in ftdetect (see :help ftdetect)
 au BufRead,BufNewFile *.go setfiletype go
 au BufRead,BufNewFile *.s setfiletype asm
-au BufRead,BufNewFile *.tmpl setfiletype gohtmltmpl
+au BufRead,BufNewFile *.tmpl set filetype=gohtmltmpl
 au BufRead,BufNewFile go.sum set filetype=gosum
 
 " remove the autocommands for modsim3, and lprolog files so that their


### PR DESCRIPTION
*.tmpl is already detected and a filetype is already set here:
https://github.com/vim/vim/blob/e0e3917554327f2524066f89fbbef9c83c1535da/runtime/filetype.vim#L744

Using `setfiletype` prevents this from being overridden, and the filetype is left as "template" and not set to "gohtmltmpl" as intended.

<img width="543" alt="Screenshot 2021-01-26 at 15 07 18" src="https://user-images.githubusercontent.com/2363556/105862954-4800de80-5fe8-11eb-9e68-c865e882d05e.png">

