### PR TITLE
fmt: adjust imports after formatting on autosave

### DIFF
--- a/autoload/go/auto.vim
+++ b/autoload/go/auto.vim
@@ -141,21 +141,28 @@ function! go#auto#fmt_autosave()
     return
   endif
 
-  if go#config#ImportsAutosave() && !(go#config#FmtAutosave() && go#config#FmtCommand() == 'goimports')
-    call go#fmt#Format(1)
+  " Order matters when formatting and adjusting imports, because of gopls'
+  " support for gofumpt. Gofumpt formatting will group all imports that look
+  " like a stdlib package (e.g. there's no '.' in the package path) together.
+  " When the local setting is provided, the only way to get the local imports
+  " grouped separately when gofumpt is used to format is to format first and
+  " then organize imports.
+
+  if go#config#FmtAutosave() && !(go#config#ImportsAutosave() && go#config#ImportsMode() == 'goimports')
+    call go#fmt#Format(0)
 
     " return early when the imports mode is goimports, because there's no need
     " to format again when goimports was run
-    if go#config#ImportsMode() == 'goimports'
+    if go#config#FmtCommand() == 'goimports'
       return
     endif
   endif
 
-  if !go#config#FmtAutosave()
+  if !go#config#ImportsAutosave()
     return
   endif
 
-  call go#fmt#Format(-1)
+  call go#fmt#Format(1)
 endfunction
 
 function! go#auto#metalinter_autosave()

--- a/autoload/go/fmt.vim
+++ b/autoload/go/fmt.vim
@@ -35,7 +35,7 @@ function! go#fmt#Format(withGoimport) abort
 
   if l:bin_name == 'gopls'
     if !go#config#GoplsEnabled()
-      call go#util#EchoError("go_def_mode is 'gopls', but gopls is disabled")
+      call go#util#EchoError("go_fmt_command is 'gopls', but gopls is disabled")
       return
     endif
     call go#lsp#Format()


### PR DESCRIPTION
Order matters when formatting and adjusting imports, because of gopls'
support for gofumpt. Gofumpt formatting will group all imports that look
like a stdlib package (e.g. there's no '.' in the package path)
together. When the local setting is provided, the only way to get the
local imports grouped separately when gofumpt is used to format is to
format first and then organize imports.

Fixes #3151