### PR TITLE
fix shell commands debug message for GoRun

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -210,7 +210,7 @@ function! go#cmd#Run(bang, ...) abort
     let &errorformat = s:runerrorformat()
 
     if go#util#HasDebug('shell-commands')
-      call go#util#EchoInfo('shell command: ' . l:cmd)
+      call go#util#EchoInfo(printf('shell command: %s', string(l:cmd)))
     endif
 
     if l:listtype == "locationlist"


### PR DESCRIPTION
If I set ` let g:go_debug=['shell-commands']` for debugging shell commands, 
`:GoRun` fails like below

```
Error detected while processing function go#cmd#Run:
line   78:
E730: using List as a String
E116: Invalid arguments for function go#util#EchoInfo
```
this PR hopefully tries to fix it 