### PR TITLE
Fix python linting

### DIFF
--- a/rplugin/python3/denite/source/decls.py
+++ b/rplugin/python3/denite/source/decls.py
@@ -26,6 +26,7 @@ DECLS_SYNTAX_HIGHLIGHT = [
      're': r'type ', 'conceal': True},
     ]
 
+
 class Source(Base):
 
     def __init__(self, vim):


### PR DESCRIPTION
flake8 (python's PEP8 style guide linter) fails on vim-go because of a whitespace issue which is making my dotfiles also unhappy.  Without this pull request, I get this error:

```
$ flake8
./rplugin/python3/denite/source/decls.py:29:1: E302 expected 2 blank lines, found 1
```
Ref: https://www.flake8rules.com/rules/E302.html

This might be the most trivial pull request I've ever made...