### PR TITLE
Add GoCyclo command

### DIFF
--- a/autoload/go/cyclo.vim
+++ b/autoload/go/cyclo.vim
@@ -1,0 +1,32 @@
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+function! go#cyclo#Cyclo() abort
+  let l:cmd = ['gocyclo', bufname('')]
+
+  " Read from stdin if modified.
+  if &modified
+    let [l:out, l:err] = go#util#Exec(l:cmd, go#util#archive())
+  else
+    let [l:out, l:err] = go#util#Exec(l:cmd)
+  endif
+
+  if l:err
+    call go#util#EchoError(l:out)
+    return
+  endif
+  " maybe errformat=",%m\ %f:%l:%c" would be clearer
+  let errformat = ",%n\ %m\ %f:%l:%c"
+  let l:listtype = go#list#Type("GoCyclo")
+  call go#list#ParseFormat(l:listtype, errformat, l:out, 'Cyclomatic complexity', 0)
+
+  let errors = go#list#Get(l:listtype)
+  call go#list#Window(l:listtype, len(errors))
+endfunction
+
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/list.vim
+++ b/autoload/go/list.vim
@@ -151,6 +151,7 @@ let s:default_list_type_commands = {
       \ "GoDiagnostics":        "quickfix",
       \ "GoDebug":              "quickfix",
       \ "GoErrCheck":           "quickfix",
+      \ "GoCyclo":              "quickfix",
       \ "GoFmt":                "locationlist",
       \ "GoGenerate":           "quickfix",
       \ "GoInstall":            "quickfix",

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -131,4 +131,7 @@ command! -nargs=* -bang GoDiagnostics call go#lint#Diagnostics(<bang>0, <f-args>
 " -- term
 command! GoToggleTermCloseOnExit call go#term#ToggleCloseOnExit()
 
+" -- cyclo
+command! GoCyclo call go#cyclo#Cyclo()
+
 " vim: sw=2 ts=2 et

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -58,6 +58,7 @@ let s:packages = {
       \ 'keyify':        ['honnef.co/go/tools/cmd/keyify@master'],
       \ 'motion':        ['github.com/fatih/motion@master'],
       \ 'iferr':         ['github.com/koron/iferr@master'],
+      \ 'gocyclo':       ['github.com/fzipp/gocyclo/cmd/gocyclo@master'],
 \ }
 
 " These commands are available on any filetypes


### PR DESCRIPTION
Just a crude implementation. Added a quick `:GoCyclo` command to list the cyclomatic complexity for a given file to the plugin. I'm happy to work on this some more, adding things like `-top N` and `-over N` support, perhaps being able to get the complexity for the entire package, or instead of displaying just the quickfix buffer, perhaps add some type of bookmarks to the worst functions etc..

I just wanted to get some eyes on this before I started investing too much time on this stuff. I get that cyclomatic complexity is somewhat of a grey area, especially in golang, but I figured if enough people thought that this would be a worthwhile addition, I might as well go ahead and implement the command.