### PR TITLE
Add basic GoDebugConnect command

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -760,6 +760,8 @@ function! go#debug#Start(mode, ...) abort
     elseif a:mode is 'attach'
       let l:cmd = add(l:cmd, a:1)
       let s:state['kill_on_detach'] = v:false
+    elseif a:mode is 'connect'
+      let l:cmd = add(l:cmd, a:1)
     else
       call go#util#EchoError('Unknown dlv command')
     endif

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -114,6 +114,7 @@ if !exists(':GoDebugStart')
   command! -nargs=* -complete=customlist,go#package#Complete GoDebugTest  call go#debug#Start('test', <f-args>)
   command! -nargs=* GoDebugTestFunc  call go#debug#TestFunc(<f-args>)
   command! -nargs=1 GoDebugAttach call go#debug#Start('attach', <f-args>)
+  command! -nargs=1 GoDebugConnect call go#debug#Start('connect', <f-args>)
   command! -nargs=? GoDebugBreakpoint call go#debug#Breakpoint(<f-args>)
 endif
 


### PR DESCRIPTION
Just noticed this issue, and seeing as I'll probably need to connect to a container when debugging soon, I went ahead and added the suggested `GoDebugConnect` command. It's untested ATM, but thought I'd push it to see if this works (yay, testing in production).