### PR TITLE
Fixed indent for functions with parameters on one line

### DIFF
--- a/indent/go.vim
+++ b/indent/go.vim
@@ -56,7 +56,8 @@ function! GoIndent(lnum) abort
   let num_parenthases = s:CountIndent(prevl, '(', ')')
   let num_brackets = s:CountIndent(prevl, '{', '}')
 
-  if num_parenthases > 0 || num_brackets > 0
+  " The } check is for else and else if statements
+  if num_parenthases > 0 || num_brackets > 0 || prevl =~ '^\s*}'
     " previous line opened a block
     let ind += shiftwidth()
   endif

--- a/indent/go.vim
+++ b/indent/go.vim
@@ -57,7 +57,7 @@ function! GoIndent(lnum) abort
   let num_brackets = s:CountIndent(prevl, '{', '}')
 
   " The } check is for else and else if statements
-  if num_parenthases > 0 || num_brackets > 0 || prevl =~ '^\s*}'
+  if num_parenthases > 0 || num_brackets > 0 || (prevl =~ '^\s*}' && num_brackets == 0)
     " previous line opened a block
     let ind += shiftwidth()
   endif
@@ -70,7 +70,8 @@ function! GoIndent(lnum) abort
   let num_parenthases = s:CountIndent(thisl, '(', ')')
   let num_brackets = s:CountIndent(thisl, '{', '}')
 
-  if num_parenthases < 0 || num_brackets < 0
+  " The } check is for else and else if statements
+  if num_parenthases < 0 || num_brackets < 0 || (thisl =~ '^\s*}' && num_brackets == 0)
     " this line closed a block
     let ind -= shiftwidth()
   endif


### PR DESCRIPTION
I was having the same issue as #2769, which was bugging me. I do not use `gofmt`, and I would prefer it if live indents worked as they should. This function makes sure that indents always work as expected, no matter what comments/arguments exist on the previous/current line. It's not the most performant function, but I couldn't find a better way with regex, so iterating through the whole line seemed like the best option to me.

I understand that I should use `gofmt`, but I couldn't be bothered to deal with tabs in vim. I know this issue is partially fixed when using `gofmt`, but that only applies when you save. This PR fixes the indents all the time, and makes the code you're in the middle of writing much cleaner.