### PR TITLE
rename: rename with gopls using requests

### DIFF
--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -390,6 +390,15 @@ function! go#lsp#message#ApplyWorkspaceEditResponse(ok) abort
        \ }
 endfunction
 
+function! go#lsp#message#PrepareRename(file, line, col) abort
+  let l:params = s:textDocumentPositionParams(a:file,  a:line, a:col)
+  return {
+          \ 'notification': 0,
+          \ 'method': 'textDocument/prepareRename',
+          \ 'params': l:params,
+       \ }
+endfunction
+
 function! s:workspaceFolder(key, val) abort
   return {'uri': go#path#ToURI(a:val), 'name': a:val}
 endfunction

--- a/autoload/go/rename.vim
+++ b/autoload/go/rename.vim
@@ -32,12 +32,14 @@ function! go#rename#Rename(bang, ...) abort
   let pos = go#util#OffsetCursor()
   let offset = printf('%s:#%d', fname, pos)
 
+  if l:bin == 'gopls'
+    call go#lsp#Rename(to_identifier)
+    return
+  endif
+
   let args = []
   if l:bin == 'gorename'
     let l:args = extend(l:args, ['-tags', go#config#BuildTags(), '-offset', offset, '-to', to_identifier])
-  elseif l:bin == 'gopls'
-    " TODO(bc): use -tags when gopls supports it
-    let l:args = extend(l:args, ['rename', '-w', l:offset, to_identifier])
   else
     call go#util#EchoWarning('unexpected rename command')
   endif

--- a/ftplugin/go.vim
+++ b/ftplugin/go.vim
@@ -101,6 +101,8 @@ augroup vim-go-buffer
   autocmd BufWritePre <buffer> call go#auto#fmt_autosave()
   autocmd BufWritePost <buffer> call go#auto#metalinter_autosave()
 
+  " TODO(bc): autocmd BufWinLeave call go#lsp#DidChange(expand('<afile>:p'))
+
   if !has('textprop')
     "TODO(bc): how to clear sameids and diagnostics when a non-go buffer is
     " loaded into a window and the previously loaded buffer is still loaded in


### PR DESCRIPTION
Use textDocument/rename to rename identifiers instead of shelling out to
gopls rename when renaming with gopls.

Fixes #3177