### PR TITLE
lsp: improve rename experience

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -533,6 +533,8 @@ function! s:requestComplete(ok) abort dict
   endif
 
   if go#config#EchoCommandInfo()
+    " redraw to avoid messages piling up
+    redraw
     let prefix = '[' . self.statustype . '] '
     if a:ok
       call go#util#EchoSuccess(prefix . "SUCCESS")


### PR DESCRIPTION
##### lsp: redraw before display status messages

Redraw before displaying status messages so that synchronous preparation
requests followed by requests that do work don't cause multiple status
messages to be output resulting in prompting the user to press Enter.


##### handle rename errors


