### PR TITLE
test with module aware mode enabled

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.1
+FROM golang:1.16.2
 
 RUN apt-get update -y --allow-insecure-repositories && \
   apt-get install -y build-essential curl git libncurses5-dev python3-pip && \

--- a/autoload/go/cmd_test.vim
+++ b/autoload/go/cmd_test.vim
@@ -6,7 +6,6 @@ func! Test_GoBuildErrors()
   try
     let l:filename = 'cmd/bad.go'
     let l:tmp = gotest#load_fixture(l:filename)
-    exe 'cd ' . l:tmp . '/src/cmd'
 
     " set the compiler type so that the errorformat option will be set
     " correctly.

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -734,8 +734,8 @@ function! go#debug#TestFunc(...) abort
   call call('go#debug#Start', extend(['test', '.', '-test.run', printf('%s$', l:test)], a:000))
 endfunction
 
-" Start the debug mode. The first argument is the package name to compile and
-" debug, anything else will be passed to the running program.
+" Start the debug mode. The first variadic argument is the package name to
+" compile and debug, anything else will be passed to the running program.
 function! go#debug#Start(mode, ...) abort
   call go#cmd#autowrite()
 

--- a/autoload/go/debug_test.vim
+++ b/autoload/go/debug_test.vim
@@ -15,7 +15,7 @@ function! Test_GoDebugStart_RelativePackage_NullModule() abort
 endfunction
 
 function! Test_GoDebugStart_Package() abort
-  call s:debug('debug/debugmain')
+  call s:debug('vim-go.test/debug/debugmain')
 endfunction
 
 function! Test_GoDebugStart_Errors() abort
@@ -27,7 +27,7 @@ function! Test_GoDebugStart_Errors() abort
     let l:tmp = gotest#load_fixture('debug/compilerror/main.go')
 
     let l:expected = [
-          \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': '# debug/compilerror'},
+          \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': '# vim-go.test/debug/compilerror'},
           \ {'lnum': 6, 'bufnr': bufnr('%'), 'col': 22, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': ' syntax error: unexpected newline, expecting comma or )'},
           \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exit status 2'}
           \]
@@ -142,7 +142,7 @@ function! s:debug(...) abort
     call assert_false(exists(':GoDebugStop'))
 
     if a:0 == 0
-      call go#util#Chdir('debug/debugmain')
+      call go#util#Chdir(printf('%s/src/debug/debugmain', l:tmp))
       let l:job = go#debug#Start('debug')
     else
       let l:job = go#debug#Start('debug', a:1)

--- a/autoload/go/job_test.vim
+++ b/autoload/go/job_test.vim
@@ -10,7 +10,8 @@ func! Test_JobDirWithSpaces()
   try
     let l:filename = 'job/dir has spaces/main.go'
     let l:tmp = gotest#load_fixture(l:filename)
-    exe 'cd ' . fnameescape(l:tmp . '/src/job/dir has spaces')
+    call go#util#Chdir(printf('%s/src/job/dir has spaces', l:tmp))
+    call go#util#Exec(['go', 'mod', 'init', 'vim-go.test/job'])
 
     " set the compiler type so that the errorformat option will be set
     " correctly.

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -12,17 +12,18 @@ endfunc
 
 func! s:gometa(metalinter) abort
   let RestoreGOPATH = go#util#SetEnv('GOPATH', fnamemodify(getcwd(), ':p') . 'test-fixtures/lint')
-  silent exe 'e! ' . $GOPATH . '/src/lint/lint.go'
+  call go#util#Chdir('test-fixtures/lint/src/foo')
+  silent exe 'e! ' . $GOPATH . '/src/foo/foo.go'
 
   try
     let g:go_metalinter_command = a:metalinter
     let l:vim = s:vimdir()
     let expected = [
-          \ {'lnum': 1, 'bufnr': bufnr('%')+9, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'at least one file in a package should have a package comment (ST1000)'},
+          \ {'lnum': 1, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'at least one file in a package should have a package comment (ST1000)'},
         \ ]
     if a:metalinter == 'golangci-lint'
       let expected = [
-            \ {'lnum': 5, 'bufnr': bufnr('%')+9, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function `MissingFooDoc` should have comment or be unexported (golint)'}
+            \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function `MissingFooDoc` should have comment or be unexported (golint)'}
           \ ]
     endif
 

--- a/autoload/go/test-fixtures/lint/src/errcheck/go.mod
+++ b/autoload/go/test-fixtures/lint/src/errcheck/go.mod
@@ -1,0 +1,3 @@
+module vim-go.test/errcheck
+
+go 1.16

--- a/autoload/go/test-fixtures/lint/src/foo/go.mod
+++ b/autoload/go/test-fixtures/lint/src/foo/go.mod
@@ -1,0 +1,3 @@
+module vim-go.test/foo
+
+go 1.16

--- a/autoload/go/test-fixtures/lint/src/lint/go.mod
+++ b/autoload/go/test-fixtures/lint/src/lint/go.mod
@@ -1,0 +1,3 @@
+module vim-go.test/lint
+
+go 1.16

--- a/autoload/go/test-fixtures/lint/src/vet/go.mod
+++ b/autoload/go/test-fixtures/lint/src/vet/go.mod
@@ -1,0 +1,3 @@
+module vim-go.test/vet
+
+go 1.16

--- a/autoload/go/test-fixtures/test/src/compilerror/go.mod
+++ b/autoload/go/test-fixtures/test/src/compilerror/go.mod
@@ -1,0 +1,3 @@
+module vim-go.test/compilerror
+
+go 1.16

--- a/autoload/go/test-fixtures/test/src/example/go.mod
+++ b/autoload/go/test-fixtures/test/src/example/go.mod
@@ -1,0 +1,3 @@
+module vim-go.test/example
+
+go 1.16

--- a/autoload/go/test-fixtures/test/src/play/go.mod
+++ b/autoload/go/test-fixtures/test/src/play/go.mod
@@ -1,0 +1,3 @@
+module vim-go.test/play
+
+go 1.16

--- a/autoload/go/test-fixtures/test/src/play/play_test.go
+++ b/autoload/go/test-fixtures/test/src/play/play_test.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 	"testing"
 
-	"play/mock"
+	"vim-go.test/play/mock"
 )
 
 func TestTopSubHelper(t *testing.T) {

--- a/autoload/go/test-fixtures/test/src/showname/go.mod
+++ b/autoload/go/test-fixtures/test/src/showname/go.mod
@@ -1,0 +1,3 @@
+module vim-go.test/showname
+
+go 1.16

--- a/autoload/go/test-fixtures/test/src/testcompilerror/go.mod
+++ b/autoload/go/test-fixtures/test/src/testcompilerror/go.mod
@@ -1,0 +1,3 @@
+module vim-go.test/testcompilerror
+
+go 1.16

--- a/autoload/go/test-fixtures/test/src/timeout/go.mod
+++ b/autoload/go/test-fixtures/test/src/timeout/go.mod
@@ -1,0 +1,3 @@
+module vim-go.test/timeout
+
+go 1.16

--- a/autoload/go/test-fixtures/test/src/veterror/go.mod
+++ b/autoload/go/test-fixtures/test/src/veterror/go.mod
@@ -1,0 +1,3 @@
+module vim-go.test/veterror
+
+go 1.16

--- a/autoload/go/test_test.vim
+++ b/autoload/go/test_test.vim
@@ -101,6 +101,7 @@ endfunc
 
 func! s:test(file, expected, ...) abort
   let $GOPATH = fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/test'
+  call go#util#Chdir(printf('%s/src/%s', $GOPATH, fnamemodify(a:file, ':h')))
   silent exe 'e ' . $GOPATH . '/src/' . a:file
 
   " clear the quickfix lists

--- a/autoload/go/tool_test.vim
+++ b/autoload/go/tool_test.vim
@@ -5,7 +5,9 @@ set cpo&vim
 func! Test_ExecuteInDir() abort
   let l:tmp = gotest#write_file('a/a.go', ['package a'])
   try
+    let l:cwd = go#util#Exec(['pwd'])
     let l:out = go#util#ExecInDir(['pwd'])
+    call assert_notequal(l:cwd, l:out)
     call assert_equal([l:tmp . "/src/a\n", 0], l:out)
   finally
     call delete(l:tmp, 'rf')

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -715,7 +715,7 @@ function! go#util#Chdir(dir) abort
   if !exists('*chdir')
     let l:olddir = getcwd()
     let cd = exists('*haslocaldir') && haslocaldir() ? 'lcd ' : 'cd '
-    execute cd . fnameescape(a:dir)
+    execute printf('cd %s', fnameescape(a:dir))
     return l:olddir
   endif
   return chdir(a:dir)

--- a/scripts/install-tools
+++ b/scripts/install-tools
@@ -17,7 +17,7 @@ installdir="/tmp/vim-go-test/$1-install"
 # Make sure all Go tools and other dependencies are installed.
 echo "Installing Go binaries"
 export GOPATH=$installdir
-export GO111MODULE=off
+export GO111MODULE=on
 export PATH=${GOPATH}/bin:$PATH
 "$vimgodir/scripts/run-vim" $vim +':silent :GoUpdateBinaries' +':qa'
 

--- a/scripts/run-vim
+++ b/scripts/run-vim
@@ -23,7 +23,7 @@ fi
 
 dir="/tmp/vim-go-test/$1-install"
 export GOPATH=$dir
-export GO111MODULE=auto
+export GO111MODULE=on
 export PATH=${GOPATH}/bin:$PATH
 shift
 


### PR DESCRIPTION
Run tests with module aware mode enabled in preparation for the removal
of GOPATH mode coming in Go 1.17.