### PR TITLE
lint: adjust tests due to recent golangci-lint changes

### DIFF
--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -52,42 +52,42 @@ func! s:gometa(metalinter) abort
   endtry
 endfunc
 
-func! Test_GometaGolangciLint_shadow() abort
-  call s:gometa_shadow('golangci-lint')
-endfunc
-
-func! s:gometa_shadow(metalinter) abort
-  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnamemodify(getcwd(), ':p') . 'test-fixtures/lint')
-  silent exe 'e! ' . $GOPATH . '/src/lint/golangci-lint/problems/shadow/problems.go'
-
-  try
-    let g:go_metalinter_command = a:metalinter
-    let expected = [
-          \ {'lnum': 4, 'bufnr': bufnr('%'), 'col': 7, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] Can''t run linter golint: golint: analysis skipped: errors in package'},
-          \ {'lnum': 4, 'bufnr': bufnr('%'), 'col': 7, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'e', 'module': '', 'text': 'Running error: golint: analysis skipped: errors in package'}
-        \ ]
-
-    " clear the quickfix list
-    call setqflist([], 'r')
-
-    let g:go_metalinter_enabled = ['golint']
-
-    call go#lint#Gometa(0, 0)
-
-    let actual = getqflist()
-    let start = reltime()
-    while len(actual) == 0 && reltimefloat(reltime(start)) < 10
-      sleep 100m
-      let actual = getqflist()
-    endwhile
-
-    call gotest#assert_quickfix(actual, expected)
-  finally
-      call call(RestoreGOPATH, [])
-      unlet g:go_metalinter_enabled
-      unlet g:go_metalinter_command
-  endtry
-endfunc
+"func! Test_GometaGolangciLint_shadow() abort
+"  call s:gometa_shadow('golangci-lint')
+"endfunc
+"
+"func! s:gometa_shadow(metalinter) abort
+"  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnamemodify(getcwd(), ':p') . 'test-fixtures/lint')
+"  silent exe 'e! ' . $GOPATH . '/src/lint/golangci-lint/problems/shadow/problems.go'
+"
+"  try
+"    let g:go_metalinter_command = a:metalinter
+"    let expected = [
+"          \ {'lnum': 4, 'bufnr': bufnr('%'), 'col': 7, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] Can''t run linter golint: golint: analysis skipped: errors in package'},
+"          \ {'lnum': 4, 'bufnr': bufnr('%'), 'col': 7, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'e', 'module': '', 'text': 'Running error: golint: analysis skipped: errors in package'}
+"        \ ]
+"
+"    " clear the quickfix list
+"    call setqflist([], 'r')
+"
+"    let g:go_metalinter_enabled = ['golint']
+"
+"    call go#lint#Gometa(0, 0)
+"
+"    let actual = getqflist()
+"    let start = reltime()
+"    while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+"      sleep 100m
+"      let actual = getqflist()
+"    endwhile
+"
+"    call gotest#assert_quickfix(actual, expected)
+"  finally
+"      call call(RestoreGOPATH, [])
+"      unlet g:go_metalinter_enabled
+"      unlet g:go_metalinter_command
+"  endtry
+"endfunc
 
 func! Test_GometaAutoSaveGolangciLint() abort
   call s:gometaautosave('golangci-lint', 0)
@@ -176,8 +176,7 @@ func! s:gometa_importabs(metalinter) abort
   try
     let g:go_metalinter_command = a:metalinter
     let expected = [
-          \ {'lnum': 3, 'bufnr': bufnr('%'), 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] Can''t run linter golint: golint: analysis skipped: errors in package'},
-          \ {'lnum': 3, 'bufnr': bufnr('%'), 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'e', 'module': '', 'text': 'Running error: golint: analysis skipped: errors in package'},
+          \ {'lnum': 3, 'bufnr': bufnr('%'), 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': '"/quux" imported but not used (typecheck)'}
         \ ]
     " clear the quickfix list
     call setqflist([], 'r')
@@ -201,46 +200,46 @@ func! s:gometa_importabs(metalinter) abort
   endtry
 endfunc
 
-func! Test_GometaAutoSaveGolangciLint_importabs() abort
-  call s:gometaautosave_importabs('golangci-lint')
-endfunc
-
-func! s:gometaautosave_importabs(metalinter) abort
-  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
-  silent exe 'e! ' . $GOPATH . '/src/lint/golangci-lint/problems/importabs/ok.go'
-
-  try
-    let g:go_metalinter_command = a:metalinter
-    let expected = [
-          \ {'lnum': 3, 'bufnr': bufnr('%')+1, 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] Can''t run linter golint: golint: analysis skipped: errors in package'},
-          \ {'lnum': 3, 'bufnr': bufnr('%')+1, 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'e', 'module': '', 'text': 'Running error: golint: analysis skipped: errors in package'}
-        \ ]
-
-    " clear the location list
-    call setloclist(0, [], 'r')
-
-    let g:go_metalinter_autosave_enabled = ['golint']
-
-    call go#lint#Gometa(0, 1)
-
-    let actual = getloclist(0)
-    let start = reltime()
-    while len(actual) == 0 && reltimefloat(reltime(start)) < 10
-      sleep 100m
-      let actual = getloclist(0)
-    endwhile
-
-    call gotest#assert_quickfix(actual, expected)
-  finally
-    call call(RestoreGOPATH, [])
-    unlet g:go_metalinter_autosave_enabled
-    unlet g:go_metalinter_command
-  endtry
-endfunc
-
-func! Test_GometaGolangciLint_multiple() abort
-  call s:gometa_multiple('golangci-lint')
-endfunc
+"func! Test_GometaAutoSaveGolangciLint_importabs() abort
+"  call s:gometaautosave_importabs('golangci-lint')
+"endfunc
+"
+"func! s:gometaautosave_importabs(metalinter) abort
+"  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
+"  silent exe 'e! ' . $GOPATH . '/src/lint/golangci-lint/problems/importabs/ok.go'
+"
+"  try
+"    let g:go_metalinter_command = a:metalinter
+"    let expected = [
+"          \ {'lnum': 3, 'bufnr': bufnr('%')+1, 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] Can''t run linter golint: golint: analysis skipped: errors in package'},
+"          \ {'lnum': 3, 'bufnr': bufnr('%')+1, 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'e', 'module': '', 'text': 'Running error: golint: analysis skipped: errors in package'}
+"        \ ]
+"
+"    " clear the location list
+"    call setloclist(0, [], 'r')
+"
+"    let g:go_metalinter_autosave_enabled = ['golint']
+"
+"    call go#lint#Gometa(0, 1)
+"
+"    let actual = getloclist(0)
+"    let start = reltime()
+"    while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+"      sleep 100m
+"      let actual = getloclist(0)
+"    endwhile
+"
+"    call gotest#assert_quickfix(actual, expected)
+"  finally
+"    call call(RestoreGOPATH, [])
+"    unlet g:go_metalinter_autosave_enabled
+"    unlet g:go_metalinter_command
+"  endtry
+"endfunc
+"
+"func! Test_GometaGolangciLint_multiple() abort
+"  call s:gometa_multiple('golangci-lint')
+"endfunc
 
 func! s:gometa_multiple(metalinter) abort
   let RestoreGOPATH = go#util#SetEnv('GOPATH', fnamemodify(getcwd(), ':p') . 'test-fixtures/lint')
@@ -249,8 +248,7 @@ func! s:gometa_multiple(metalinter) abort
   try
     let g:go_metalinter_command = a:metalinter
     let expected = [
-          \ {'lnum': 8, 'bufnr': bufnr('%'), 'col': 7, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] Can''t run linter golint: golint: analysis skipped: errors in package'},
-          \ {'lnum': 8, 'bufnr': bufnr('%'), 'col': 7, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'e', 'module': '', 'text': 'Running error: golint: analysis skipped: errors in package'},
+          \ {'lnum': 4, 'bufnr': bufnr('%'), 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': '"time" imported but not used (typecheck)'}
         \ ]
 
     " clear the quickfix list
@@ -286,8 +284,7 @@ func! s:gometaautosave_multiple(metalinter) abort
   try
     let g:go_metalinter_command = a:metalinter
     let expected = [
-          \ {'lnum': 8, 'bufnr': bufnr('%'), 'col': 7, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] Can''t run linter golint: golint: analysis skipped: errors in package'},
-          \ {'lnum': 8, 'bufnr': bufnr('%'), 'col': 7, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'e', 'module': '', 'text': 'Running error: golint: analysis skipped: errors in package'},
+          \ {'lnum': 4, 'bufnr': bufnr('%'), 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': '"time" imported but not used (typecheck)'}
         \ ]
 
     " clear the location list
@@ -404,14 +401,16 @@ func! Test_Vet_compilererror() abort
 endfunc
 
 func! Test_Lint_GOPATH() abort
+  let RestoreGO111MODULE = go#util#SetEnv('GO111MODULE', 'off')
   let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
 
+  silent exe 'e! ' . $GOPATH . '/src/lint/quux.go'
   silent exe 'e! ' . $GOPATH . '/src/lint/lint.go'
   compiler go
 
   let expected = [
           \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported'},
-          \ {'lnum': 5, 'bufnr': bufnr('%')+11, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
+          \ {'lnum': 5, 'bufnr': bufnr('test-fixtures/lint/src/lint/quux.go'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
       \ ]
 
   let winnr = winnr()
@@ -430,16 +429,21 @@ func! Test_Lint_GOPATH() abort
 
   call gotest#assert_quickfix(actual, expected)
 
+  "call assert_report(execute('ls'))
+
   call call(RestoreGOPATH, [])
+  call call(RestoreGO111MODULE, [])
 endfunc
 
 func! Test_Lint_NullModule() abort
+  let RestoreGO111MODULE = go#util#SetEnv('GO111MODULE', 'off')
+  silent exe 'e! ' . fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint/src/lint/quux.go'
   silent exe 'e! ' . fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint/src/lint/lint.go'
   compiler go
 
   let expected = [
           \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported'},
-          \ {'lnum': 5, 'bufnr': bufnr('%')+11, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
+          \ {'lnum': 5, 'bufnr': bufnr('test-fixtures/lint/src/lint/quux.go'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
       \ ]
 
   let winnr = winnr()
@@ -457,6 +461,7 @@ func! Test_Lint_NullModule() abort
   endwhile
 
   call gotest#assert_quickfix(actual, expected)
+  call call(RestoreGO111MODULE, [])
 endfunc
 
 func! Test_Errcheck() abort


### PR DESCRIPTION
Golangci-lint seems to have changed how it deals with some kinds of
problems when only a subset of linters are used. Comment out the tests
that no longer seem to be relevant instead of deleting them, because I
don't trust that the original need for the tests won't reappear.