### PR TITLE
Don't treat `[[...]]` as template syntax region

### DIFF
--- a/syntax/gotexttmpl.vim
+++ b/syntax/gotexttmpl.vim
@@ -73,9 +73,7 @@ hi def link     gotplFunctions      Function
 hi def link     goTplVariable       Special
 
 syn region gotplAction start="{{" end="}}" contains=@gotplLiteral,gotplControl,gotplFunctions,gotplVariable,goTplIdentifier display
-syn region gotplAction start="\[\[" end="\]\]" contains=@gotplLiteral,gotplControl,gotplFunctions,gotplVariable display
 syn region goTplComment start="{{\(- \)\?/\*" end="\*/\( -\)\?}}" display
-syn region goTplComment start="\[\[\(- \)\?/\*" end="\*/\( -\)\?\]\]" display
 
 hi def link gotplAction PreProc
 hi def link goTplComment Comment


### PR DESCRIPTION
[The official template doc](https://pkg.go.dev/text/template)
> The input text for a template is UTF-8-encoded text in any format. "Actions"--data evaluations or control structures--are delimited by "{{" and "}}"; all text outside actions is copied to the output unchanged. Except for raw strings, actions may not span newlines, although comments can.

Double angle brackets `[[` is not syntax for starting go template region.
This PR removes the highlight for it.