### PR TITLE
Fix Highlight for template's dot-identifier

### DIFF
--- a/syntax/gotexttmpl.vim
+++ b/syntax/gotexttmpl.vim
@@ -66,7 +66,7 @@ syn cluster     gotplLiteral     contains=goString,goRawString,goCharacter,@goIn
 syn keyword     gotplControl     contained   if else end range with template
 syn keyword     gotplFunctions   contained   and html index js len not or print printf println urlquery eq ne lt le gt ge
 syn match       gotplVariable    contained   /\$[a-zA-Z0-9_]*\>/
-syn match       goTplIdentifier  contained   /\.[^\s}]+\>/
+syn match       goTplIdentifier  contained   /\.[^[:blank:]}]\+\>/
 
 hi def link     gotplControl        Keyword
 hi def link     gotplFunctions      Function


### PR DESCRIPTION
Currently, Dot-identifiers `{{ .foo.bar }}` are not highlighted.
https://github.com/fatih/vim-go/blob/bd89f4734555c60f53acaf21731bd43617e6e526/syntax/gotexttmpl.vim#L69
In character range `[a-z]` of vim pattern, it is necessary to use `[:blank:]` as spaces instead of `\s`.
Also, `+` needs escape for working as 'one or more' in vim magic pattern (default mode).
This PR fixes it.