### PR TITLE
Include sub-packages in golangci-lint command

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -6,7 +6,12 @@ function! go#lint#Gometa(bang, autosave, ...) abort
   let l:metalinter = go#config#MetalinterCommand()
 
   if a:0 == 0
-    let l:goargs = [expand('%:p:h')]
+    let l:filepath = expand('%:p:h')
+    if l:metalinter == 'golangci-lint'
+      let l:filepath = printf('%s/...', l:filepath)
+    endif
+
+    let l:goargs = [l:filepath]
     if l:metalinter == 'gopls' || l:metalinter == 'staticcheck'
       let l:pkg = go#package#ImportPath()
       if l:pkg == -1


### PR DESCRIPTION
With current vim-go version, executing metalinter using `golangci-lint` runs the following command:
```
vim-go: [golangci-lint] dispatched
vim-go: job command: ['/Users/yury/go/bin/golangci-lint', 'run', 
    '--print-issued-lines=false', '--build-tags', '', '--exclude-use-default=false', 
    '--disable-all', '--enable=vet', '--enable=golint', '--enable=errcheck', 
    '/Users/yury/go/src/github.com/orlangure/gnomock']
```

The last argument is the path of currently opened file (folder). When golangci-lint is executed with folder path, it only runs the linter on this folder, and not its subfolders. So this PR adds `/...` in the end so that all subpackages are checked as well.

golangci-lint version: v1.39.1