### PR TITLE
chore: vimrc syntax highlight in ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -24,9 +24,12 @@ Use a *minimal* vimrc with other plugins disabled; do not link to a 2,000 line v
 If this is not provided or is obviously incomplete, the issue may be unceremoniously closed.
 -->
 <!-- vimrc -->
-<details><summary>vimrc</summary><br><pre>
+<details><summary>vimrc</summary>
 
-</pre></details>
+```vim
+
+```
+</details>
 
 #### Vim version (first three lines from `:version`):
 <!-- :version -->


### PR DESCRIPTION
The `<pre>` doesn't looks good for code and it's possible to enable GFM inside `<details>` if we add an empty line after `</summary>`.