### PR TITLE
source GOBIN from go env GOBIN

### DIFF
--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -71,24 +71,25 @@ endfunction
 
 " BinPath returns the binary path of installed go tools.
 function! go#path#BinPath() abort
-  let bin_path = go#config#BinPath()
-  if bin_path != ""
-    return bin_path
+  let l:bin_path = go#config#BinPath()
+  if l:bin_path isnot ""
+    return l:bin_path
   endif
 
-  " check if our global custom path is set, if not check if $GOBIN is set so
+  " check if our global custom path is set, if not check if GOBIN is set so
   " we can use it, otherwise use default GOPATH
-  if $GOBIN != ""
-    let bin_path = $GOBIN
+  let l:bin_path = go#util#env('gobin')
+  if l:bin_path isnot ''
+    let l:bin_path = $GOBIN
   else
-    let go_paths = split(go#path#Default(), go#util#PathListSep())
-    if len(go_paths) == 0
-      return "" "nothing found
+    let l:go_paths = split(go#path#Default(), go#util#PathListSep())
+    if len(l:go_paths) == 0
+      return '' "nothing found
     endif
-    let bin_path = expand(go_paths[0] . "/bin/")
+    let l:bin_path = expand(l:go_paths[0] . '/bin/')
   endif
 
-  return bin_path
+  return l:bin_path
 endfunction
 
 " CheckBinPath checks whether the given binary exists or not and returns the

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -90,26 +90,32 @@ function! go#util#env(key) abort
   return l:var
 endfunction
 
+" gobin returns 'go env GOBIN'. This is an internal function and shouldn't be
+" used. Use go#util#env('gobin') instead.
+function! go#util#gobin() abort
+  return substitute(s:exec(['go', 'env', 'GOBIN'])[0], '\n', '', 'g')
+endfunction
+
 " goarch returns 'go env GOARCH'. This is an internal function and shouldn't
-" be used. Instead use 'go#util#env("goarch")'
+" be used. Use go#util#env('goarch') instead.
 function! go#util#goarch() abort
   return substitute(s:exec(['go', 'env', 'GOARCH'])[0], '\n', '', 'g')
 endfunction
 
-" goos returns 'go env GOOS'. This is an internal function and shouldn't
-" be used. Instead use 'go#util#env("goos")'
+" goos returns 'go env GOOS'. This is an internal function and shouldn't be
+" used. Use go#util#env('goos') instead.
 function! go#util#goos() abort
   return substitute(s:exec(['go', 'env', 'GOOS'])[0], '\n', '', 'g')
 endfunction
 
 " goroot returns 'go env GOROOT'. This is an internal function and shouldn't
-" be used. Instead use 'go#util#env("goroot")'
+" be used. Use go#util#env('goroot') instead.
 function! go#util#goroot() abort
   return substitute(s:exec(['go', 'env', 'GOROOT'])[0], '\n', '', 'g')
 endfunction
 
 " gopath returns 'go env GOPATH'. This is an internal function and shouldn't
-" be used. Instead use 'go#util#env("gopath")'
+" be used. Use go#util#env('gopath') instead.
 function! go#util#gopath() abort
   return substitute(s:exec(['go', 'env', 'GOPATH'])[0], '\n', '', 'g')
 endfunction
@@ -120,7 +126,8 @@ function! go#util#gomod() abort
   return substitute(s:exec(['go', 'env', 'GOMOD'])[0], '\n', '', 'g')
 endfunction
 
-" gomodcache returns 'go env GOMODCACHE'. Instead use 'go#util#env("gomodcache")'
+" gomodcache returns 'go env GOMODCACHE'. Use go#util#env('gomodcache')
+" instead.
 function! go#util#gomodcache() abort
   return substitute(s:exec(['go', 'env', 'GOMODCACHE'])[0], '\n', '', 'g')
 endfunction

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1519,7 +1519,7 @@ their mapping variants that cause splits. By default it's disabled. >
                                                              *'g:go_bin_path'*
 
 Use this option to change default path for vim-go tools when using
-|:GoInstallBinaries| and |:GoUpdateBinaries|. If not set `$GOBIN` or
+|:GoInstallBinaries| and |:GoUpdateBinaries|. If not set `go env GOBIN` or
 `$GOPATH/bin` is used. >
 
   let g:go_bin_path = ""


### PR DESCRIPTION
This helps prepare for Go 1.17 when GOPATH will be unsupported.

##### doc: update docs for go_bin_path

Update docs for go_bin_path to prepare for sourcing GOBIN from `go env`.


##### util: add go#util#gobin()

Add go#util#gobin()

Use single quotes in function docs and rewrap those docs.


##### path: source GOBIN from go#util#env

Source GOBIN from go#util#env.

Use the local variable prefix for variables in go#path#BinPath().


Closes #3204 