### PR TITLE
Add a new snippet for t.Run

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -436,6 +436,13 @@ func Test${1:Function}(t *testing.T) {
 }
 endsnippet
 
+# test t.Run
+snippet tr "t.Run(XYZ, func(t *testing.T){ ... })"
+t.Run("${0}", func(t *testing){
+
+})
+endsnippet
+
 # test table snippet
 snippet tt
 var tests = []struct {

--- a/gosnippets/snippets/go.snip
+++ b/gosnippets/snippets/go.snip
@@ -315,6 +315,12 @@ abbr func TestXYZ(t *testing.T) { ... }
 	func Test${1:Function}(t *testing.T) {
 		${0}
 	}
+# test t.Run
+snippet tr
+abbr t.Run("test name", func(t *testing.T){ ... })
+  t.Run("${0}", func(t *testing){
+
+  })
 # test table snippet
 snippet tt
 abbr var test = {...}{...} for {t.Run(){...}}


### PR DESCRIPTION
Adding a new snippet so that developers can easily start a `t.Run("",  func(t *testing.T){})` unit test.