### PR TITLE
Quote usage of PATH in test scripts

### DIFF
--- a/scripts/install-tools
+++ b/scripts/install-tools
@@ -18,7 +18,7 @@ installdir="/tmp/vim-go-test/$1-install"
 echo "Installing Go binaries"
 export GOPATH=$installdir
 export GO111MODULE=on
-export PATH=${GOPATH}/bin:$PATH
+export PATH="${GOPATH}/bin:$PATH"
 "$vimgodir/scripts/run-vim" $vim +':silent :GoUpdateBinaries' +':qa'
 
 echo "Installing lint tools"

--- a/scripts/lint
+++ b/scripts/lint
@@ -18,7 +18,7 @@ fi
 vim=$1
 vimdir="/tmp/vim-go-test/$vim-install"
 export GOPATH=$vimdir
-export PATH=${GOPATH}/bin:$PATH
+export PATH="${GOPATH}/bin:$PATH"
 
 if [ ! -f "$vimdir/bin/vim" ]; then
 	echo "$vimdir/bin/vim doesn't exist; did you install it with the install-vim script?"

--- a/scripts/run-vim
+++ b/scripts/run-vim
@@ -24,7 +24,7 @@ fi
 dir="/tmp/vim-go-test/$1-install"
 export GOPATH=$dir
 export GO111MODULE=on
-export PATH=${GOPATH}/bin:$PATH
+export PATH="${GOPATH}/bin:$PATH"
 shift
 
 if [ ! -f "$dir/bin/vim" ]; then

--- a/scripts/test
+++ b/scripts/test
@@ -50,7 +50,7 @@ fi
 vim=$1
 vimdir="/tmp/vim-go-test/$vim-install"
 export GOPATH=$vimdir
-export PATH=${GOPATH}/bin:$PATH
+export PATH="${GOPATH}/bin:$PATH"
 
 if [ ! -f "$vimdir/bin/vim" ]; then
   echo "$vimdir/bin/vim doesn't exist; did you install it with the install-vim script?"


### PR DESCRIPTION
This allows the test suite to function in WSL environments and other places where the existing `PATH` value may contain spaces.