### PR TITLE
Add `shadow` tool on goVet command

### DIFF
--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -221,6 +221,7 @@ function! go#lint#Vet(bang, ...) abort
   call go#cmd#autowrite()
 
   let l:cmd = ['go', 'vet']
+  let l:cmd = add(l:cmd, '-vettool=' . go#util#env('gopath') . '/bin/shadow')
 
   let buildtags = go#config#BuildTags()
   if buildtags isnot ''

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -58,6 +58,7 @@ let s:packages = {
       \ 'keyify':        ['honnef.co/go/tools/cmd/keyify@master'],
       \ 'motion':        ['github.com/fatih/motion@master'],
       \ 'iferr':         ['github.com/koron/iferr@master'],
+      \ 'shadow':        ['golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow@master'],
 \ }
 
 " These commands are available on any filetypes


### PR DESCRIPTION
Hi everyone, I want to check for shadowed variables on `:GoVet` command.
I don't know if it's the better way to do that (ok, I need to say: _"it's working on my machine"_), so I really appreciate if someone helps me.