### PR TITLE
ci: pin the click version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     - name: install covimerage
       run: |
         python -m pip install --upgrade pip
-        pip install covimerage==0.2.1 codecov pathlib
+        pip install click==7.1.2 covimerage==0.2.1 codecov pathlib
     - name: checkout
       uses: actions/checkout@v2.1.0
     - name: install vim


### PR DESCRIPTION
Pin the version of click to v7.1.2, because covimerage tries to import
string_types from click.utils, which seems to have been removed in click
v8.0.0