### PR TITLE
Add commentstring to gohtml template files

### DIFF
--- a/ftplugin/gohtmltmpl.vim
+++ b/ftplugin/gohtmltmpl.vim
@@ -4,4 +4,6 @@ endif
 
 runtime! ftplugin/html.vim
 
+setlocal commentstring={{/*%s*/}}
+
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
Currently gohtmltmpl files use html commentstrings . I've changed this option so [`{{/* comment */}}`](https://golang.org/pkg/text/template/#hdr-Actions) notation is used instead.