### PR TITLE
lint: use revive instead of golint

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -287,7 +287,7 @@ function! go#config#MetalinterEnabled() abort
 endfunction
 
 function! go#config#GolintBin() abort
-  return get(g:, "go_golint_bin", "golint")
+  return get(g:, "go_golint_bin", "revive")
 endfunction
 
 function! go#config#ErrcheckBin() abort

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -271,7 +271,7 @@ endfunction
 function! go#config#MetalinterAutosaveEnabled() abort
   let l:default = []
   if get(g:, 'go_metalinter_command', s:default_metalinter) == 'golangci-lint'
-    let l:default = ['govet', 'golint']
+    let l:default = ['govet', 'revive']
   endif
 
   return get(g:, 'go_metalinter_autosave_enabled', l:default)
@@ -280,7 +280,7 @@ endfunction
 function! go#config#MetalinterEnabled() abort
   let l:default = []
   if get(g:, 'go_metalinter_command', s:default_metalinter) == 'golangci-lint'
-    let l:default = ['vet', 'golint', 'errcheck']
+    let l:default = ['vet', 'revive', 'errcheck']
   endif
 
   return get(g:, 'go_metalinter_enabled', l:default)

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -23,8 +23,7 @@ func! s:gometa(metalinter) abort
         \ ]
     if a:metalinter == 'golangci-lint'
       let expected = [
-            \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] The linter ''golint'' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.'},
-            \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function `MissingFooDoc` should have comment or be unexported (golint)'}
+            \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': 'exported: exported function MissingFooDoc should have comment or be unexported (revive)'}
           \ ]
     endif
 
@@ -33,7 +32,7 @@ func! s:gometa(metalinter) abort
 
     let g:go_metalinter_enabled = ['ST1000']
     if a:metalinter == 'golangci-lint'
-      let g:go_metalinter_enabled = ['golint']
+      let g:go_metalinter_enabled = ['revive']
     endif
 
     call go#lint#Gometa(0, 0, $GOPATH . '/src/foo')
@@ -135,8 +134,7 @@ func! s:gometaautosave(metalinter, withList) abort
 "          \ ]
     elseif a:metalinter == 'golangci-lint'
       let l:expected = [
-            \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] The linter ''golint'' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.'},
-            \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function `MissingDoc` should have comment or be unexported (golint)'}
+            \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': 'exported: exported function MissingDoc should have comment or be unexported (revive)'}
           \ ]
     endif
 
@@ -153,7 +151,7 @@ func! s:gometaautosave(metalinter, withList) abort
 
     let g:go_metalinter_autosave_enabled = ['ST1000']
     if a:metalinter == 'golangci-lint'
-      let g:go_metalinter_autosave_enabled = ['golint']
+      let g:go_metalinter_autosave_enabled = ['revive']
     endif
 
     call go#lint#Gometa(0, 1)
@@ -276,7 +274,7 @@ func! s:gometa_multiple(metalinter) abort
     " clear the quickfix list
     call setqflist([], 'r')
 
-    let g:go_metalinter_enabled = ['golint']
+    let g:go_metalinter_enabled = ['revive']
 
     call go#lint#Gometa(0, 0)
 

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -459,6 +459,10 @@ func! Test_Lint_GOPATH() abort
     let actual = getqflist()
   endwhile
 
+  " sort the results for deterministic ordering
+  call sort(actual)
+  call sort(expected)
+
   call gotest#assert_quickfix(actual, expected)
 
   "call assert_report(execute('ls'))
@@ -491,6 +495,10 @@ func! Test_Lint_NullModule() abort
     sleep 100m
     let actual = getqflist()
   endwhile
+
+  " sort the results for deterministic ordering
+  call sort(actual)
+  call sort(expected)
 
   call gotest#assert_quickfix(actual, expected)
   call call(RestoreGO111MODULE, [])

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1625,7 +1625,7 @@ an empty list; `staticcheck`'s `-checks` flag will not be used.
 
 When `g:go_metalinter_command is set to `golangci-lint'`, the default value is
 >
-  let g:go_metalinter_autosave_enabled = ['vet', 'golint']
+  let g:go_metalinter_autosave_enabled = ['vet', 'revive']
 <
                                                    *'g:go_metalinter_enabled'*
 
@@ -1642,7 +1642,7 @@ an empty list; `staticcheck`'s `-checks` flag will not be used.
 When `g:go_metalinter_command` is set to `golangci-lint'`, the default value
 is
 >
-  let g:go_metalinter_enabled = ['vet', 'golint', 'errcheck']
+  let g:go_metalinter_enabled = ['vet', 'revive', 'errcheck']
 <
                                                    *'g:go_metalinter_command'*
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -47,6 +47,7 @@ let s:packages = {
       \ 'godef':         ['github.com/rogpeppe/godef@latest'],
       \ 'goimports':     ['golang.org/x/tools/cmd/goimports@master'],
       \ 'golint':        ['golang.org/x/lint/golint@master'],
+      \ 'revive':        ['github.com/mgechev/revive@latest'],
       \ 'gopls':         ['golang.org/x/tools/gopls@latest', {}, {'after': function('go#lsp#Restart', [])}],
       \ 'golangci-lint': ['github.com/golangci/golangci-lint/cmd/golangci-lint@latest'],
       \ 'staticcheck':   ['honnef.co/go/tools/cmd/staticcheck@latest'],


### PR DESCRIPTION
##### lint: replace golint with revive in golangci-lint linters

Use revive with golangci-lint instead of golint; golint is officially
deprecated.


##### lint: use revive for :GoLint


