### PR TITLE
add g:go_doc_balloon

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -611,6 +611,10 @@ function! go#config#DebugMappings() abort
   return extend(l:user, l:default, 'keep')
 endfunction
 
+function! go#config#DocBalloon() abort
+  return get(g:, 'go_doc_balloon', 0)
+endfunction
+
 " Set the default value. A value of "1" is a shortcut for this, for
 " compatibility reasons.
 if exists("g:go_gorename_prefill") && g:go_gorename_prefill == 1

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -970,8 +970,18 @@ function! s:hoverHandler(next, msg) abort dict
 
   try
     let l:value = json_decode(a:msg.contents.value)
-    let l:args = [l:value.signature]
-    call call(a:next, l:args)
+
+    let l:signature = split(l:value.signature, "\n")
+    let l:msg = l:signature
+    if go#config#DocBalloon()
+      " use synopsis instead of fullDocumentation to keep the hover window
+      " small.
+      let l:doc = l:value.synopsis
+      if len(l:doc) isnot 0
+        let l:msg = l:signature + ['', l:doc]
+      endif
+    endif
+    call call(a:next, [l:msg])
   catch
     " TODO(bc): log the message and/or show an error message.
   endtry

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -295,7 +295,7 @@ function! s:newlsp() abort
           call remove(self.notificationQueue[l:fname], 0)
         endif
       catch
-        call go#util#EchoError(printf('%s: %s', v:throwpoint, v:exception))
+        "call go#util#EchoError(printf('%s: %s', v:throwpoint, v:exception))
       endtry
     endfor
   endfunction
@@ -1874,7 +1874,7 @@ function! s:lineinfile(fname, line) abort
 
     return l:filecontents[-1]
   catch
-    call go#util#EchoError(printf('%s (line %s): %s at %s', a:fname, a:line, v:exception, v:throwpoint))
+    "call go#util#EchoError(printf('%s (line %s): %s at %s', a:fname, a:line, v:exception, v:throwpoint))
     return -1
   endtry
 endfunction

--- a/autoload/go/tool.vim
+++ b/autoload/go/tool.vim
@@ -134,8 +134,6 @@ function! s:balloon(msg)
   if has('balloon_eval')
     if has('balloon_multiline')
       let l:msg = join(a:msg, "\n")
-    else
-      let l:msg = substitute(join(map(deepcopy(a:msg), 'substitute(v:val, "\t", "", "")'), '; '), '{;', '{', '')
     endif
   endif
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1229,8 +1229,9 @@ Uses `gopls` for autocompletion. By default, it is hooked up to 'omnifunc'.
 
                                                    *go#tool#DescribeBalloon()*
 
-Suitable to be used as an expression to show the evaluation balloon. See `help
-balloonexpr`.
+Suitable to be used as an expression to show the evaluation balloon. By
+default only the type information is shown. |'g:go_doc_balloon'| can be used
+to also included partial documentation. See `help balloonexpr`.
 
 ==============================================================================
 SETTINGS                                                        *go-settings*
@@ -1449,6 +1450,12 @@ is enabled. >
 Maximum height for the GoDoc window created with |:GoDoc|. Default is 20. >
 
   let g:go_doc_max_height = 20
+<
+                                                         *'g:go_doc_balloon'*
+
+Show GoDoc in balloon. See |go#tool#DescribeBalloon()|. Default is disabled. >
+
+  let g:go_doc_balloon = 0
 <
 
                                                               *'g:go_doc_url'*


### PR DESCRIPTION
##### lsp: comment out debug messages

Comment out some debugging messages that were mistakenly included in
previous commits.


##### lsp: optionally include godoc synopsis in hover

Add g:go_doc_balloon to allow the godoc synopsis to be included in the
hover window when go#tool#DescribeBalloon is used.


##### tool: remove unneeded substitution from balloon message

Remover unneeded semicolon extraction. The semicolons seem to only be
used in gopls' hover result's singleLine property and are no longer
relevant in the signature.


