### PR TITLE
return early from CompleteDone handler

### DIFF
--- a/autoload/go/auto.vim
+++ b/autoload/go/auto.vim
@@ -12,6 +12,10 @@ function! go#auto#template_autocreate()
 endfunction
 
 function! go#auto#complete_done()
+  if &omnifunc isnot 'go#complete#Complete'
+    return
+  endif
+
   call s:echo_go_info()
   call s:ExpandSnippet()
 endfunction


### PR DESCRIPTION
Return early from the CompleteDone handler when omnifunc is not set to
go#complete#Complete.

This should help interactions with other plugins like coc.nvim that some
users leverage to do completion.

Relates to #3272