### PR TITLE
Update parse.go

### DIFF
--- a/test/parse.go
+++ b/test/parse.go
@@ -11,8 +11,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
-
-	a "golang.org/x/net/html/atom"
+	"golang.org/x/net/html/atom"
 )
 
 // A parser implements the HTML5 parsing algorithm:


### PR DESCRIPTION
Import function included extra text which causes error while building.
