### PR TITLE
lsp: fix the command for fillstruct

### DIFF
--- a/autoload/go/fillstruct_test.vim
+++ b/autoload/go/fillstruct_test.vim
@@ -115,8 +115,10 @@ func! Test_gopls_fillstruct() abort
     endwhile
 
     call gotest#assert_buffer(1, [
-          \ 'var addr = mail.Address{}',
-         \ ])
+          \ 'var addr = mail.Address{',
+          \ '\tName:    "",',
+          \ '\tAddress: "",',
+          \ '}'])
   finally
     unlet g:go_fillstruct_mode
     call delete(l:tmp, 'rf')
@@ -139,8 +141,10 @@ func! Test_gopls_fillstruct_line() abort
     endwhile
 
     call gotest#assert_buffer(1, [
-          \ 'var addr = mail.Address{}',
-         \ ])
+          \ 'var addr = mail.Address{',
+          \ '\tName:    "",',
+          \ '\tAddress: "",',
+          \ '}'])
   finally
     unlet g:go_fillstruct_mode
     call delete(l:tmp, 'rf')
@@ -203,14 +207,15 @@ func! Test_gopls_fillstruct_two_cursor() abort
           \ '"fmt"',
           \ '"net/mail"',
           \ ')',
-          \ 'func x() { fmt.Println(mail.Address{}, mail.Address{}) }',
-         \ ])
+          \ 'func x() { fmt.Println(mail.Address{}, mail.Address{',
+          \ '\tName:    "",',
+          \ '\tAddress: "",',
+          \ '}) }'])
   finally
     unlet g:go_fillstruct_mode
     call delete(l:tmp, 'rf')
   endtry
 endfunc
-
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -1564,7 +1564,7 @@ function! go#lsp#FillStruct() abort
   let l:lsp = s:lspfactory.get()
 
   let l:state = s:newHandlerState('')
-  let l:handler = go#promise#New(function('s:handleCodeAction', ['refactor.rewrite', 'fill_struct'], l:state), 10000, '')
+  let l:handler = go#promise#New(function('s:handleCodeAction', ['refactor.rewrite', 'apply_fix'], l:state), 10000, '')
   let l:state.handleResult = l:handler.wrapper
   let l:state.error = l:handler.wrapper
   let l:state.handleError = function('s:handleCodeActionError', [l:fname], l:state)


### PR DESCRIPTION
Fix the command for fillstruct and revert
17955710b44532e1a7e4ff41ff7dcb730e3bc1d3, which was masking this
problem.

Fixes #3279