### PR TITLE
Support non-gopls LSP servers

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -592,6 +592,10 @@ function! go#config#GoplsOptions() abort
   return get(g:, 'go_gopls_options', ['-remote=auto'])
 endfunction
 
+function! go#config#GoplsBinary() abort
+  return get(g:, 'go_gopls_binary', 'gopls')
+endfunction
+
 function! go#config#FillStructMode() abort
   return get(g:, 'go_fillstruct_mode', 'fillstruct')
 endfunction

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -984,19 +984,14 @@ function! s:hoverHandler(next, msg) abort dict
   endif
 
   try
-    let l:hasStructured = 0
     try
       let l:value = json_decode(a:msg.contents.value)
-      let l:hasStructured = 1
     catch /.*/
       " json_decode failed; assume lsp doesn't support structured hover
       " response.
-    endtry
-
-    if l:hasStructured == 0
       call call(a:next, [a:msg.contents.value])
       return
-    endif
+    endtry
 
     let l:signature = split(l:value.signature, "\n")
     let l:msg = l:signature


### PR DESCRIPTION
This change adds g:go_gopls_binary option that specifies path to the LSP
binary.

Gopls uses custom format for hover response [1], and other LSPs do
not, this change adds bare-bones support for plain text hover responses
(no markdown support).  :GoDocBrowser is driven by fields in structured
responses and is not supported at all, and results in "could not find
path for doc URL" error.

Because non-gopls LSP server support is pretty much experimetal, the
options are not documented, and the option name uses "gopls" (as opposed
to "lsp") as to not create an impression that an arbitrary LSP server
would work out of the box.

Tested:
  Manually in my environment with our internal LSP server and confirmed that
  :GoDoc, :GoInfo, :GoDef work. Admittedly, :GoDoc and :GoInfo are pretty
  much the same, except the latter shows results in the command prompt,
  and the former opens up a doc window.

  `make` reports:
  All (vim-8.0) tests PASSED
  All (vim-8.2) tests PASSED
  All (nvim) tests PASSED

Issues:

  :GoInfo doesn't produce any output when the result has several lines.

Related: https://github.com/fatih/vim-go/issues/3284

[1] https://github.com/golang/tools/blob/bf6c7f26e9f0fea5b256f9ef6968435dddc5be25/internal/lsp/source/hover.go#L562