### PR TITLE
Feature: syntax highlight for //go:build directives

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -454,6 +454,10 @@ function! go#config#HighlightTypes() abort
   return get(g:, 'go_highlight_types', 0)
 endfunction
 
+function! go#config#HighlightBuildConstraintsNewFormat() abort
+  return get(g:, 'go_highlight_build_constraints_new_format', 0)
+endfunction
+
 function! go#config#HighlightBuildConstraints() abort
   return get(g:, 'go_highlight_build_constraints', 0)
 endfunction

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -454,10 +454,6 @@ function! go#config#HighlightTypes() abort
   return get(g:, 'go_highlight_types', 0)
 endfunction
 
-function! go#config#HighlightBuildConstraintsNewFormat() abort
-  return get(g:, 'go_highlight_build_constraints_new_format', 0)
-endfunction
-
 function! go#config#HighlightBuildConstraints() abort
   return get(g:, 'go_highlight_build_constraints', 0)
 endfunction

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -345,6 +345,12 @@ if go#config#HighlightVariableDeclarations()
   hi def link   goVarDefs           Special
 endif
 
+" Build Constraints in new format //go:build ...
+if go#config#HighlightBuildConstraintsNewFormat()
+  syn region      goGenerate          start="^\s*//go:build" end="$" contains=goBuildKeyword,goBuildDirectives
+  hi def link     goGenerate          PreProc
+endif
+
 " Build Constraints
 if go#config#HighlightBuildConstraints()
   syn match   goBuildKeyword      display contained "+build"

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -345,15 +345,9 @@ if go#config#HighlightVariableDeclarations()
   hi def link   goVarDefs           Special
 endif
 
-" Build Constraints in new format //go:build ...
-if go#config#HighlightBuildConstraintsNewFormat()
-  syn region      goGenerate          start="^\s*//go:build" end="$" contains=goBuildKeyword,goBuildDirectives
-  hi def link     goGenerate          PreProc
-endif
-
 " Build Constraints
 if go#config#HighlightBuildConstraints()
-  syn match   goBuildKeyword      display contained "+build"
+  syn match   goBuildKeyword      display contained "+build\|go:build"
   " Highlight the known values of GOOS, GOARCH, and other +build options.
   syn keyword goBuildDirectives   contained
         \ android darwin dragonfly freebsd linux nacl netbsd openbsd plan9
@@ -367,7 +361,7 @@ if go#config#HighlightBuildConstraints()
   " The rs=s+2 option lets the \s*+build portion be part of the inner region
   " instead of the matchgroup so it will be highlighted as a goBuildKeyword.
   syn region  goBuildComment      matchgroup=goBuildCommentStart
-        \ start="//\s*+build\s"rs=s+2 end="$"
+        \ start="//\(\s*+build\s\|go:build\)"rs=s+2 end="$"
         \ contains=goBuildKeyword,goBuildDirectives
   hi def link goBuildCommentStart Comment
   hi def link goBuildDirectives   Type


### PR DESCRIPTION
The new style replacement for // +build directives is
now highlighted.

This is probably still missing, but it's a start. 


![image](https://user-images.githubusercontent.com/1083045/132178994-12c890f3-18a6-443f-a13b-b8a884e6c18d.png)
