### PR TITLE
Added preview-window flag to GoDecls fzf for text wrapping

### DIFF
--- a/autoload/fzf/decls.vim
+++ b/autoload/fzf/decls.vim
@@ -143,7 +143,7 @@ function! fzf#decls#cmd(...) abort
         \)
   call fzf#run(fzf#wrap('GoDecls', {
         \ 'source': call('<sid>source', a:000),
-        \ 'options': printf('-n 1 --with-nth 1,2 --delimiter=$''\t'' --preview "echo {3}" --ansi --prompt "GoDecls> " --expect=ctrl-t,ctrl-v,ctrl-x%s', colors),
+        \ 'options': printf('-n 1 --with-nth 1,2 --delimiter=$''\t'' --preview "echo {3}" --preview-window "wrap" --ansi --prompt "GoDecls> " --expect=ctrl-t,ctrl-v,ctrl-x%s', colors),
         \ 'sink*': function('s:sink')
         \ }))
 endfunction


### PR DESCRIPTION
As reported in: https://github.com/fatih/vim-go/issues/3307

Found that, at least in my version, fzf doesn't automatically text wrap and you need a preview-window setting.

Concerns (as per https://github.com/fatih/vim-go/issues/3307) is that it may break existing users (assuming they have a version older than when fzf added `--preview-wrap`. I'm not sure if thats a real concern.

Ideal solution would be parameterization but I don't have any skills in vimscript so I'd need handholding.