### PR TITLE
The time to wait for the connection to be made in milliseconds.

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -609,7 +609,7 @@ function! s:connect(addr) abort
       return
     endif
   else
-    let l:ch = ch_open(a:addr, {'mode': 'raw', 'timeout': 20000, 'callback': l:state.on_data})
+    let l:ch = ch_open(a:addr, {'mode': 'raw', 'waittime': 5000, 'timeout': 20000, 'callback': l:state.on_data})
     if ch_status(l:ch) !=# 'open'
       call go#util#EchoError("could not connect to debugger")
       if has_key(s:state, 'job')


### PR DESCRIPTION
The time to wait for the connection to be made in
milliseconds.  A negative number waits forever.

The default is zero, don't wait, which is useful if a local
server is supposed to be running already.  On Unix Vim
actually uses a 1 msec timeout, that is required on many
systems.  Use a larger value for a remote server, e.g.  5000 msec.