### PR TITLE
syntax: add highlight for Go templates within YAML

### DIFF
--- a/syntax/goyamltmpl.vim
+++ b/syntax/goyamltmpl.vim
@@ -1,0 +1,20 @@
+if exists("b:current_syntax")
+  finish
+endif
+
+if !exists("g:main_syntax")
+  let g:main_syntax = 'yaml'
+endif
+
+set filetype=yaml
+unlet b:current_syntax
+
+syn include @yamlGoTextTmpl syntax/gotexttmpl.vim
+
+syn region goTextTmpl start=/{{/ end=/}}/ contains=@gotplLiteral,gotplControl,gotplFunctions,gotplVariable,goTplIdentifier containedin=ALLBUT,goTextTmpl keepend
+hi def link goTextTmpl PreProc
+
+let b:current_syntax = "goyamltmpl"
+
+" vim: sw=2 ts=2 et
+


### PR DESCRIPTION
This can enable highlight for Go templates within YAML. Like `helm template` files.

The syntax won't be automatically enabled, we need to enable it by `set syntax=goyamltmpl`.

Screenshot:

![ss](https://www.linkpicture.com/q/企业微信截图_21d499b8-8e64-4cb1-b782-e2a459df0f2b.png)