### PR TITLE
Set shellxquote properly for cmd.exe

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -194,8 +194,8 @@ function! s:system(cmd, ...) abort
     if executable($COMSPEC)
       let &shell = $COMSPEC
       set shellcmdflag=/C
-      set shellquote=
-      set shellxquote=\"
+      set shellquote&
+      set shellxquote&
     endif
   endif
 

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -183,6 +183,8 @@ function! s:system(cmd, ...) abort
   let l:shell = &shell
   let l:shellredir = &shellredir
   let l:shellcmdflag = &shellcmdflag
+  let l:shellquote = &shellquote
+  let l:shellxquote = &shellxquote
 
   if !go#util#IsWin() && executable('/bin/sh')
       set shell=/bin/sh shellredir=>%s\ 2>&1 shellcmdflag=-c
@@ -192,6 +194,8 @@ function! s:system(cmd, ...) abort
     if executable($COMSPEC)
       let &shell = $COMSPEC
       set shellcmdflag=/C
+      set shellquote=
+      set shellxquote=\"
     endif
   endif
 
@@ -202,6 +206,8 @@ function! s:system(cmd, ...) abort
     let &shell = l:shell
     let &shellredir = l:shellredir
     let &shellcmdflag = l:shellcmdflag
+    let &shellquote = l:shellquote
+    let &shellxquote = l:shellxquote
   endtry
 endfunction
 


### PR DESCRIPTION
I have custom `shellxquote` in my config and it breaks the plugin. Setting it to quote and restoring after the fact fixes the issue.