### PR TITLE
fix: make on macos

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -490,6 +490,10 @@ function! go#util#tempdir(prefix) abort
     return
   endif
 
+  " $TEMPDIR on macos has / in the end of the path.
+  " Use substitute() for backwards compatibility, as trim() was added to vim v8.0.1630
+  let l:dir = substitute(l:dir, '/$', '', '')
+
   " Not great randomness, but "good enough" for our purpose here.
   let l:rnd = sha256(printf('%s%s', reltimestr(reltime()), fnamemodify(bufname(''), ":p")))
   let l:tmp = printf("%s/%s%s", l:dir, a:prefix, l:rnd)

--- a/scripts/install-vim
+++ b/scripts/install-vim
@@ -62,13 +62,15 @@ cd "$srcdir"
 
 # Neovim build requires more deps than Vim and is annoying, so we use the
 # binary.
-# 0.2.0 doesn't have a binary build for Linux, so we use 0.2.1-dev for now.
 if [ "$1" = "nvim" ]; then
 
-  # TODO: Use macOS binaries on macOS
-  curl -Ls https://github.com/neovim/neovim/releases/download/$tag/nvim-linux64.tar.gz |
+  case "$(uname -s)" in
+    Darwin*)  arch=osx64    uri=macos;;
+    *)        arch=linux64  uri=linux64
+  esac
+  curl -Ls https://github.com/neovim/neovim/releases/download/$tag/nvim-$uri.tar.gz |
     tar xzf - -C /tmp/vim-go-test/
-  mv /tmp/vim-go-test/nvim-linux64 /tmp/vim-go-test/nvim-install
+  mv /tmp/vim-go-test/nvim-$arch /tmp/vim-go-test/nvim-install
   mkdir -p "$installdir/share/nvim/runtime/pack/vim-go/start"
   ln -s "$vimgodir" "$installdir/share/nvim/runtime/pack/vim-go/start/vim-go"
 


### PR DESCRIPTION
- Add support for macos nvim binary
- fix go#util#tempdir which causes test fails on mac.

Output on mac without the fix:
```
--- FAIL Test_ExecuteInDir (0.222883s)
vim-go: Error loading packages: invalid workspace folder path: no such file or directory; check that the casing of the configured workspace folder path agrees with the casing reported by the operating system: no such file or directory
vim-go: Error loading workspace folders (expected 1, got 0)
vim-go: failed to load view for file:///private/var/folders/pd/zlm4qxk13jj3rd4809mg3sr00000gn/T/vim-go-test/testrun/61f122c89f41967f85a55f150ab83bdb2516e82db4671d3bc6cedcc445604442/src/a: invalid workspace folder path: no such file or directory; check that the casing of the configured workspace folder path agrees with the casing reported by the operating system: no such file or directory
vim-go: Error loading packages: invalid workspace folder path: no such file or directory; check that the casing of the configured workspace folder path agrees with the casing reported by the operating system: no such file or directory
vim-go: Error loading workspace folders (expected 1, got 0)
vim-go: failed to load view for file:///private/var/folders/pd/zlm4qxk13jj3rd4809mg3sr00000gn/T/vim-go-test/testrun/61f122c89f41967f85a55f150ab83bdb2516e82db4671d3bc6cedcc445604442/src/a: invalid workspace folder path: no such file or directory; check that the casing of the configured workspace folder path agrees with the casing reported by the operating system: no such file or directory
vim-go: Error loading packages: invalid workspace folder path: no such file or directory; check that the casing of the configured workspace folder path agrees with the casing reported by the operating system: no such file or directory
vim-go: Error loading workspace folders (expected 1, got 0)
vim-go: failed to load view for file:///private/var/folders/pd/zlm4qxk13jj3rd4809mg3sr00000gn/T/vim-go-test/testrun/61f122c89f41967f85a55f150ab83bdb2516e82db4671d3bc6cedcc445604442/src/a: invalid workspace folder path: no such file or directory; check that the casing of the configured workspace folder path agrees with the casing reported by the operating system: no such file or directory
        function Test_ExecuteInDir line 6: Expected ['/var/folders/pd/zlm4qxk13jj3rd4809mg3sr00000gn/T//vim-go-test/testrun/61f122c89f41967f85a55f150ab83bdb2516e82db4671d3bc6cedcc445604442/src/a\n', 0] but got ['/private/var/folders/pd/zlm4qxk13jj3rd4809mg3sr00000gn/T/vim-go-test/testrun/61f122c89f41967f85a55f150ab83bdb2516e82db4671d3bc6cedcc445604442/src/a\n', 0]
FAIL tool_test.vim              0.287383s / 2 tests
```