### PR TITLE
debug: set MaxVariableRecurse

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -1162,7 +1162,7 @@ function! s:update_variables() abort
   " MaxStructFields is the maximum number of fields read from a struct, -1 will read all fields.
   let l:cfg = {
         \ 'scope': {'GoroutineID': s:goroutineID()},
-        \ 'cfg':   {'MaxStringLen': 20, 'MaxArrayValues': 20}
+        \ 'cfg':   {'MaxStringLen': 20, 'MaxArrayValues': 20, 'MaxVariableRecurse': 10}
         \ }
 
   try


### PR DESCRIPTION
Set MaxVariableRecurse for listing local variables to the same value
that's used when listing call results.

Closes #3342