### PR TITLE
Fix play url and add additional curl header

### DIFF
--- a/autoload/go/play.vim
+++ b/autoload/go/play.vim
@@ -26,7 +26,7 @@ function! go#play#Share(count, line1, line2) abort
     return
   endif
 
-  let url = printf("http://go.dev/play/p/%s", snippet_id)
+  let url = printf("https://go.dev/play/p/%s", snippet_id)
 
   " copy to clipboard
   if has('unix') && !has('xterm_clipboard') && !has('clipboard')

--- a/autoload/go/play.vim
+++ b/autoload/go/play.vim
@@ -12,7 +12,9 @@ function! go#play#Share(count, line1, line2) abort
   let share_file = tempname()
   call writefile(split(content, "\n"), share_file, "b")
 
-  let l:cmd = ['curl', '-s', '-X', 'POST', 'https://go.dev/_/share',
+  let l:cmd = ['curl', '-s',
+        \ '-H', 'Content-Type: text/plain; charset=utf-8',
+        \ '-X', 'POST', 'https://go.dev/_/share',
         \ '--data-binary', '@' . l:share_file]
   let [l:snippet_id, l:err] = go#util#Exec(l:cmd)
 
@@ -24,7 +26,7 @@ function! go#play#Share(count, line1, line2) abort
     return
   endif
 
-  let url = printf("http://go.dev/play/%s", snippet_id)
+  let url = printf("http://go.dev/play/p/%s", snippet_id)
 
   " copy to clipboard
   if has('unix') && !has('xterm_clipboard') && !has('clipboard')


### PR DESCRIPTION
Hi!

I was having some trouble getting `:GoPlay` to actuall work correctly - the share would "work" but the resulting url was a 404. I discovered two small issues after looking at the play site's source code that I have included in this patch:

1. The `go.dev` url needed an additional `/p/` item in the url path, otherwise it will 404
2. The curl needed to explicitly specify the content type as `text/plain`, otherwise the resulting play share is just url encoded text.

I also noticed that the share url was not using https, so I modified that as well.

Thanks!