### PR TITLE
syntax: support new predefined types `any` and `comparable` for Go 1.18

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -34,7 +34,7 @@ hi def link     goLabel             Label
 hi def link     goRepeat            Repeat
 
 " Predefined types
-syn keyword     goType              chan map bool string error
+syn keyword     goType              chan map bool string error any comparable
 syn keyword     goSignedInts        int int8 int16 int32 int64 rune
 syn keyword     goUnsignedInts      byte uint uint8 uint16 uint32 uint64 uintptr
 syn keyword     goFloats            float32 float64


### PR DESCRIPTION
Go 1.18 introduces two new predeclared identifiers `any` and `comparable`:

https://pkg.go.dev/builtin@go1.18beta2#any

https://pkg.go.dev/builtin@go1.18beta2#comparable

This pull request adds syntax highlighting for them.