### PR TITLE
Set `b:main_syntax`, not `g:`

### DIFF
--- a/syntax/gohtmltmpl.vim
+++ b/syntax/gohtmltmpl.vim
@@ -2,8 +2,8 @@ if exists("b:current_syntax")
   finish
 endif
 
-if !exists("g:main_syntax")
-  let g:main_syntax = 'html'
+if !exists("b:main_syntax")
+  let b:main_syntax = 'html'
 endif
 
 runtime! syntax/gotexttmpl.vim


### PR DESCRIPTION
The commit history doesn't indicate if this was intentional or not, but
I can't think of a reason why we'd want to set a _global_ variable
talking about a _buffer's_ main syntax.