### PR TITLE
Show the `pos` (file info) column for GoDecls FZF view

### DIFF
--- a/autoload/fzf/decls.vim
+++ b/autoload/fzf/decls.vim
@@ -143,7 +143,7 @@ function! fzf#decls#cmd(...) abort
         \)
   call fzf#run(fzf#wrap('GoDecls', {
         \ 'source': call('<sid>source', a:000),
-        \ 'options': printf('-n 1 --with-nth 1,2 --delimiter=$''\t'' --preview "echo {3}" --preview-window "wrap" --ansi --prompt "GoDecls> " --expect=ctrl-t,ctrl-v,ctrl-x%s', colors),
+        \ 'options': printf('-n 1 --with-nth 1,2,4 --delimiter=$''\t'' --preview "echo {3}" --preview-window "wrap" --ansi --prompt "GoDecls> " --expect=ctrl-t,ctrl-v,ctrl-x%s', colors),
         \ 'sink*': function('s:sink')
         \ }))
 endfunction


### PR DESCRIPTION
For some reason the file info column is not displayed in the FZF GoDecls view.

This PR simply adds that column to the view.

The lack of file info can be seen in the screenshot here: https://github.com/fatih/vim-go/issues/3110

The difference is simply e.g.:

```
main                    func
```

versus:

```
main                    func    |main.go:7:1| 
```