### PR TITLE
plugin: set -mod=readonly when installing binaries

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -108,7 +108,7 @@ function! s:GoInstallBinaries(updateBinaries, ...)
     set noshellslash
   endif
 
-  let l:get_base_cmd = ['go', 'install', '-v']
+  let l:get_base_cmd = ['go', 'install', '-v', '-mod=readonly']
 
   " Filter packages from arguments (if any).
   let l:packages = {}


### PR DESCRIPTION
Set -mod=readonly when installing binaries so that go install can be
used even when GOFLAGS sets -mod=vendor.