### PR TITLE
install staticcheck from its master branch

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -50,7 +50,7 @@ let s:packages = {
       \ 'revive':        ['github.com/mgechev/revive@latest'],
       \ 'gopls':         ['golang.org/x/tools/gopls@latest', {}, {'after': function('go#lsp#Restart', [])}],
       \ 'golangci-lint': ['github.com/golangci/golangci-lint/cmd/golangci-lint@latest'],
-      \ 'staticcheck':   ['honnef.co/go/tools/cmd/staticcheck@latest'],
+      \ 'staticcheck':   ['honnef.co/go/tools/cmd/staticcheck@master'],
       \ 'gomodifytags':  ['github.com/fatih/gomodifytags@latest'],
       \ 'gorename':      ['golang.org/x/tools/cmd/gorename@master'],
       \ 'gotags':        ['github.com/jstemmer/gotags@master'],


### PR DESCRIPTION
Install staticcheck from its master branch so that it will work with Go
1.18.