### PR TITLE
install the latest staticcheck version

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -50,7 +50,7 @@ let s:packages = {
       \ 'revive':        ['github.com/mgechev/revive@latest'],
       \ 'gopls':         ['golang.org/x/tools/gopls@latest', {}, {'after': function('go#lsp#Restart', [])}],
       \ 'golangci-lint': ['github.com/golangci/golangci-lint/cmd/golangci-lint@latest'],
-      \ 'staticcheck':   ['honnef.co/go/tools/cmd/staticcheck@master'],
+      \ 'staticcheck':   ['honnef.co/go/tools/cmd/staticcheck@latest'],
       \ 'gomodifytags':  ['github.com/fatih/gomodifytags@latest'],
       \ 'gorename':      ['golang.org/x/tools/cmd/gorename@master'],
       \ 'gotags':        ['github.com/jstemmer/gotags@master'],


### PR DESCRIPTION
Install the latest staticcheck version instead of from master. This puts
staticcheck back into the desired state after vim-go temporarily
installing staticcheck from its master branch during a period when there
was not a staticcheck release that worked with Go 1.18.