### PR TITLE
Code to always display the current goroutine first in the list of gor…

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -1100,7 +1100,7 @@ function! s:show_goroutines(currentGoroutineID, res) abort
     setlocal modifiable
     silent %delete _
 
-    let v = ['# Goroutines']
+    let v = []
 
     if type(a:res) isnot type({}) || !has_key(a:res, 'result') || empty(a:res['result'])
       call setline(1, v)
@@ -1141,11 +1141,15 @@ function! s:show_goroutines(currentGoroutineID, res) abort
       " changed if needed.
       if l:goroutine.id == a:currentGoroutineID
         let l:g = printf("* Goroutine %s - %s: %s:%s %s (thread: %s)", l:goroutine.id, l:goroutineType, s:substituteRemotePath(l:loc.file), l:loc.line, l:loc.function.name, l:goroutine.threadID)
+        let l:currentGoroutine = [l:g]
+        continue
       else
         let l:g = printf("  Goroutine %s - %s: %s:%s %s (thread: %s)", l:goroutine.id, l:goroutineType, s:substituteRemotePath(l:loc.file), l:loc.line, l:loc.function.name, l:goroutine.threadID)
       endif
       let v += [l:g]
     endfor
+
+    let v = ['# Goroutines'] + l:currentGoroutine + v
 
     call setline(1, v)
   finally


### PR DESCRIPTION
Simple change to make the current go routine running always be displayed first on the goroutine output at the bottom of the debug screen:

<img width="1512" alt="Screen Shot 2022-03-20 at 12 51 19" src="https://user-images.githubusercontent.com/66622793/159148732-efdd2ff1-f6d7-40e2-b693-508b3f21c197.png">
