### PR TITLE
staticcheck: update staticcheck to use latest

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -50,7 +50,7 @@ let s:packages = {
       \ 'revive':        ['github.com/mgechev/revive@latest'],
       \ 'gopls':         ['golang.org/x/tools/gopls@latest', {}, {'after': function('go#lsp#Restart', [])}],
       \ 'golangci-lint': ['github.com/golangci/golangci-lint/cmd/golangci-lint@latest'],
-      \ 'staticcheck':   ['honnef.co/go/tools/cmd/staticcheck@master'],
+      \ 'staticcheck':   ['honnef.co/go/tools/cmd/staticcheck@latest'],
       \ 'gomodifytags':  ['github.com/fatih/gomodifytags@latest'],
       \ 'gorename':      ['golang.org/x/tools/cmd/gorename@master'],
       \ 'gotags':        ['github.com/jstemmer/gotags@master'],


### PR DESCRIPTION
Update staticcheck to use the latest instead of master. It was using
master for the last couple of weeks in order to get the Go 1.18 support
that the latest release now includes.