### PR TITLE
gomod: fix go#lsp#ModReload argument

### DIFF
--- a/ftplugin/gomod.vim
+++ b/ftplugin/gomod.vim
@@ -25,7 +25,7 @@ augroup vim-go-gomod-buffer
 
   autocmd BufWritePre <buffer> call go#auto#modfmt_autosave()
   if go#util#has_job()
-    autocmd BufWritePost,FileChangedShellPost <buffer> call go#lsp#ModReload(resolve(expand(<'afile>:p')))
+    autocmd BufWritePost,FileChangedShellPost <buffer> call go#lsp#ModReload(resolve(expand('<afile>:p')))
   endif
 augroup end
 


### PR DESCRIPTION
Quote the string argument correctly.

Fixes #3388