### PR TITLE
lint: drop golint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This plugin adds Go language support for Vim, with the following main features:
 * See which code is covered by tests with `:GoCoverage`.
 * Add or remove tags on struct fields with `:GoAddTags` and `:GoRemoveTags`.
 * Call [`staticcheck`](https://staticcheck.io/) with `:GoMetaLinter` to invoke all possible linters
-  (`golint`, `vet`, `errcheck`, `deadcode`, etc.) and put the result in the
+  (e.g. `golint`, `vet`, `errcheck`, `deadcode`, etc.) and put the result in the
   quickfix or location list.
 * Lint your code with `:GoLint`, run your code through `:GoVet` to catch static
   errors, or make sure errors are checked with `:GoErrCheck`.

--- a/autoload/go/lint.vim
+++ b/autoload/go/lint.vim
@@ -169,7 +169,7 @@ endfunction
 function! go#lint#Golint(bang, ...) abort
   call go#cmd#autowrite()
 
-  let l:type = 'golint'
+  let l:type = 'lint'
   let l:status = {
         \ 'desc': 'current status',
         \ 'type': l:type,

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -200,7 +200,7 @@ COMMANDS                                                         *go-commands*
                                                                      *:GoLint*
 :GoLint! [packages]
 
-    Run golint for the directory under your current file, or for the given
+    Run the linter for the directory under your current file, or for the given
     packages.
 
     If [!] is not given the first error is jumped to.
@@ -1008,7 +1008,7 @@ Adjust imports for the current buffer.
 
                                                                    *(go-lint)*
 
-Calls `golint` for the current package.
+Lints for the current package.
 
                                                                     *(go-vet)*
 

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -46,7 +46,6 @@ let s:packages = {
       \ 'fillstruct':    ['github.com/davidrjenni/reftools/cmd/fillstruct@master'],
       \ 'godef':         ['github.com/rogpeppe/godef@latest'],
       \ 'goimports':     ['golang.org/x/tools/cmd/goimports@master'],
-      \ 'golint':        ['golang.org/x/lint/golint@master'],
       \ 'revive':        ['github.com/mgechev/revive@latest'],
       \ 'gopls':         ['golang.org/x/tools/gopls@latest', {}, {'after': function('go#lsp#Restart', [])}],
       \ 'golangci-lint': ['github.com/golangci/golangci-lint/cmd/golangci-lint@latest'],


### PR DESCRIPTION
golint is officially archived and has been for a while, so it's time to
stop installing it.

Change some references to refer to linting instead of golint
specifically.

This leaves some references to golint (e.g. golangci-lint
documentation).