### PR TITLE
remove unneeded tt := tt in go snippets

### DIFF
--- a/gosnippets/UltiSnips/go.snippets
+++ b/gosnippets/UltiSnips/go.snippets
@@ -453,7 +453,6 @@ var tests = []struct {
 	{"${1}", "${2}", "${3}",},
 }
 for _, tt := range tests {
-	tt := tt
 	t.Run(tt.name, func(t *testing.T){
 		actual := ${0:${VISUAL}}(tt.given)
 		if actual != tt.expected {


### PR DESCRIPTION
I don't think that in table test snipped `tt := tt` is needed:

```
for _, tt := range tests {
	tt := tt
```

am I missing something?
