### PR TITLE
plugin: allow tool versions to be specified explicitly

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -113,10 +113,20 @@ function! s:GoInstallBinaries(updateBinaries, ...)
   let l:packages = {}
   if a:0 > 0
     for l:bin in a:000
+      let l:version = substitute(l:bin, '.*@', '', '')
+      if l:version == l:bin
+        let l:version = ''
+      endif
+      let l:bin = substitute(l:bin, '@.*', '', '')
+
       let l:pkg = get(s:packages, l:bin, [])
       if len(l:pkg) == 0
         call go#util#EchoError('unknown binary: ' . l:bin)
         return
+      endif
+
+      if l:version isnot ''
+        let l:pkg[0] = substitute(l:pkg[0], '@\zs.*', l:version, '')
       endif
       let l:packages[l:bin] = l:pkg
     endfor


### PR DESCRIPTION
Add support to GoUpdateBinaries and GoInstallBinaries to allow a
specific version to be installed. This is useful when the user needs to
install a specific version of one of the external tools