### PR TITLE
Delve options

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -785,6 +785,9 @@ function! go#debug#Start(mode, ...) abort
       if a:mode is 'debug' || a:mode is 'test'
         let l:cmd = extend(l:cmd, s:package(a:000))
         let l:cmd = extend(l:cmd, ['--output', tempname()])
+        if get(g:, "go_debug_use_getcwd", "false") ==? "true"
+          let l:cmd = extend(l:cmd, ['--wd', getcwd()])
+        endif
       elseif a:mode is 'attach'
         let l:cmd = add(l:cmd, a:1)
         let s:state['kill_on_detach'] = v:false
@@ -1166,7 +1169,7 @@ function! s:update_variables() abort
   " MaxStructFields is the maximum number of fields read from a struct, -1 will read all fields.
   let l:cfg = {
         \ 'scope': {'GoroutineID': s:goroutineID()},
-        \ 'cfg':   {'MaxStringLen': 20, 'MaxArrayValues': 20, 'MaxVariableRecurse': 10}
+        \ 'cfg':   {'MaxStringLen': get(g:, "go_debug_maxstringlen", 20), 'MaxArrayValues': get(g:, "go_debug_maxarrayvalues", 20), 'MaxVariableRecurse': get(g:, "go_debug_maxvariablerecur", 10)}
         \ }
 
   try

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2107,6 +2107,41 @@ Currently accepted values:
       let g:go_debug = []
 <
 
+                                                     *'g:go_debug_use_getcwd'*
+
+Pass vim's getcwd() to delve's --wd parameter.  This will allow the vim
+current working directory to be used as the working directory for the debugged
+program. By default it is disabled and the directory of the executable will
+be used.
+>
+      let g:go_debug_use_cwd = 1
+<
+
+
+                                                   *'g:go_debug_maxstringlen'*
+
+Set the max string length to be returned from debug when requesting variables.
+By default it is 20
+>
+      let g:go_debug_maxstringlen = 20
+<
+
+                                                 *'g:go_debug_maxarrayvalues'*
+
+Set the max array values to be returned from debug when requesting variables.
+By default it is 20
+>
+      let g:go_debug_maxarrayvalues = 20
+<
+
+                                               *'g:go_debug_maxvariablerecur'*
+
+Set the max recursion of nested variables to be returned from debug when
+requesting variables. By default it is 10
+>
+      let g:go_debug_maxvariablerecur = 10
+<
+
 ==============================================================================
 SYNTAX HIGHLIGHTING                                 *ft-go-syntax* *go-syntax*
 


### PR DESCRIPTION
* Allowing delve to use the current working directory
Currently, I am working on a code base where executables are defined inside of a `/cmd/{exename}/` folder and share code, including a configuration file from the parent folder.  This can be accomplished with VSCode in the `launch.json` file using the property `cwd`.

* max string length, max array, and max recursion
Reading variables, especially strings, with a max length of 20 is limiting. I decided not to change the defaults here, but allow the end user to expand them.