### PR TITLE
Fix typo in manual

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1995,7 +1995,7 @@ use different templates for different projects.
                                                    *'g:go_template_test_file'*
 
 Like with |'g:go_template_file'|, this specifies the file to use for test
-tempaltes. The template file should be under the `templates` folder,
+templates. The template file should be under the `templates` folder,
 alternatively absolute paths can be used, too. Checkout
 |'g:go_template_autocreate'| for more info. By default, the
 `hello_world_test.go` file is used.


### PR DESCRIPTION
It is a very minimal fix of a typo in the manual. The word 'templates' was incorrectly spelled.