### PR TITLE
update for Go 1.19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.17','1.18']
+        go: ['1.18','1.19']
         vim: ['vim-8.0', 'vim-8.2', 'nvim']
     steps:
     - name: setup Go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.1
+FROM golang:1.19.0
 
 RUN apt-get update -y --allow-insecure-repositories && \
   apt-get install -y build-essential curl git libncurses5-dev python3-pip && \

--- a/autoload/go/debug_test.vim
+++ b/autoload/go/debug_test.vim
@@ -28,9 +28,18 @@ function! Test_GoDebugStart_Errors() abort
 
     let l:expected = [
           \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': '# vim-go.test/debug/compilerror'},
-          \ {'lnum': 6, 'bufnr': bufnr('%'), 'col': 22, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': ' syntax error: unexpected newline, expecting comma or )'},
+          \ {'lnum': 6, 'bufnr': bufnr('%'), 'col': 22, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': ' syntax error: unexpected newline in argument list; possibly missing comma or )'},
           \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exit status 2'}
           \]
+  let [l:goversion, l:err] = go#util#Exec(['go', 'env', 'GOVERSION'])
+  let l:goversion = split(l:goversion, "\n")[0]
+  if l:goversion < 'go1.19'
+    let expected = [
+          \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': '# vim-go.test/debug/compilerror'},
+          \ {'lnum': 6, 'bufnr': bufnr('%'), 'col': 22, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': ' syntax error: unexpected newline, expecting comma or )'},
+          \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'valid': 0, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exit status 2'}
+        \ ]
+  endif
     call setqflist([], 'r')
 
     call assert_false(exists(':GoDebugStop'))

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -193,7 +193,7 @@ func! s:gometa_importabs(metalinter) abort
     " clear the quickfix list
     call setqflist([], 'r')
 
-    let g:go_metalinter_enabled = ['revive']
+    let g:go_metalinter_enabled = ['revive', 'typecheck']
 
     call go#lint#Gometa(0, 0)
 
@@ -272,7 +272,7 @@ func! s:gometa_multiple(metalinter) abort
     " clear the quickfix list
     call setqflist([], 'r')
 
-    let g:go_metalinter_enabled = ['revive']
+    let g:go_metalinter_enabled = ['revive', 'typecheck']
 
     call go#lint#Gometa(0, 0)
 
@@ -314,7 +314,7 @@ func! s:gometaautosave_multiple(metalinter) abort
     " clear the location list
     call setloclist(0, [], 'r')
 
-    let g:go_metalinter_autosave_enabled = ['revive']
+    let g:go_metalinter_autosave_enabled = ['revive', 'typecheck']
 
     call go#lint#Gometa(0, 1)
 

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -44,8 +44,8 @@ func! s:gometa(metalinter) abort
       let actual = copy(getqflist())
     endwhile
 
-    " sort the results, because golangci-lint seems to be returning the golint
-    " deprecation notice in a non-deterministic order.
+    " sort the results, because golangci-lint doesn't always return notices in
+    " a deterministic order.
     call sort(l:actual)
     call sort(l:expected)
 
@@ -163,8 +163,8 @@ func! s:gometaautosave(metalinter, withList) abort
       let l:actual = copy(getloclist(0))
     endwhile
 
-    " sort the results, because golangci-lint seems to be returning the golint
-    " deprecation notice in a non-deterministic order.
+    " sort the results, because golangci-lint doesn't always return notices in
+    " a deterministic order.
     call sort(l:actual)
     call sort(l:expected)
 
@@ -189,12 +189,11 @@ func! s:gometa_importabs(metalinter) abort
 
     let expected = [
           \ {'lnum': 3, 'bufnr': bufnr('%'), 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': '"/quux" imported but not used (typecheck)'},
-          \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] The linter ''golint'' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.'},
         \ ]
     " clear the quickfix list
     call setqflist([], 'r')
 
-    let g:go_metalinter_enabled = ['golint']
+    let g:go_metalinter_enabled = ['revive']
 
     call go#lint#Gometa(0, 0)
 
@@ -205,8 +204,8 @@ func! s:gometa_importabs(metalinter) abort
       let actual = copy(getqflist())
     endwhile
 
-    " sort the results, because golangci-lint seems to be returning the golint
-    " deprecation notice in a non-deterministic order.
+    " sort the results, because golangci-lint doesn't always return notices in
+    " a deterministic order.
     call sort(l:actual)
     call sort(l:expected)
 
@@ -266,7 +265,6 @@ func! s:gometa_multiple(metalinter) abort
   try
     let g:go_metalinter_command = a:metalinter
     let expected = [
-          \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] The linter ''golint'' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.'},
           \ {'lnum': 8, 'bufnr': bufnr('%'), 'col': 7, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': 'time.Sleep undefined (type int has no field or method Sleep) (typecheck)'},
           \ {'lnum': 4, 'bufnr': bufnr('%'), 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': '"time" imported but not used (typecheck)'}
         \ ]
@@ -285,8 +283,8 @@ func! s:gometa_multiple(metalinter) abort
       let actual = copy(getqflist())
     endwhile
 
-    " sort the results, because golangci-lint seems to be returning the golint
-    " deprecation notice in a non-deterministic order.
+    " sort the results, because golangci-lint doesn't always return notices in
+    " a deterministic order.
     call sort(l:actual)
     call sort(l:expected)
 
@@ -309,7 +307,6 @@ func! s:gometaautosave_multiple(metalinter) abort
   try
     let g:go_metalinter_command = a:metalinter
     let expected = [
-          \ {'lnum': 0, 'bufnr': 0, 'col': 0, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': 'w', 'module': '', 'text': '[runner] The linter ''golint'' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.'},
           \ {'lnum': 8, 'bufnr': bufnr('%'), 'col': 7, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': 'time.Sleep undefined (type int has no field or method Sleep) (typecheck)'},
           \ {'lnum': 4, 'bufnr': bufnr('%'), 'col': 2, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': '"time" imported but not used (typecheck)'}
         \ ]
@@ -317,7 +314,7 @@ func! s:gometaautosave_multiple(metalinter) abort
     " clear the location list
     call setloclist(0, [], 'r')
 
-    let g:go_metalinter_autosave_enabled = ['golint']
+    let g:go_metalinter_autosave_enabled = ['revive']
 
     call go#lint#Gometa(0, 1)
 
@@ -328,8 +325,8 @@ func! s:gometaautosave_multiple(metalinter) abort
       let actual = copy(getloclist(0))
     endwhile
 
-    " sort the results, because golangci-lint seems to be returning the golint
-    " deprecation notice in a non-deterministic order.
+    " sort the results, because golangci-lint doesn't always return notices in
+    " a deterministic order.
     call sort(l:actual)
     call sort(l:expected)
 

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -455,6 +455,7 @@ func! Test_Lint_GOPATH() abort
   compiler go
 
   let expected = [
+          \ {'lnum': 1, 'bufnr': bufnr('%')+10, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'should have a package comment'},
           \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported'},
           \ {'lnum': 5, 'bufnr': bufnr('test-fixtures/lint/src/lint/quux.go'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
       \ ]
@@ -492,6 +493,7 @@ func! Test_Lint_NullModule() abort
   compiler go
 
   let expected = [
+          \ {'lnum': 1, 'bufnr': bufnr('%')+10, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'should have a package comment'},
           \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported'},
           \ {'lnum': 5, 'bufnr': bufnr('test-fixtures/lint/src/lint/quux.go'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
       \ ]

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -176,47 +176,47 @@ func! s:gometaautosave(metalinter, withList) abort
   endtry
 endfunc
 
-func! Test_GometaGolangciLint_importabs() abort
-  call s:gometa_importabs('golangci-lint')
-endfunc
-
-func! s:gometa_importabs(metalinter) abort
-  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnamemodify(getcwd(), ':p') . 'test-fixtures/lint')
-  silent exe 'e! ' . $GOPATH . '/src/lint/golangci-lint/problems/importabs/problems.go'
-
-  try
-    let g:go_metalinter_command = a:metalinter
-
-    let expected = [
-          \ {'lnum': 3, 'bufnr': bufnr('%'), 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': '"/quux" imported but not used (typecheck)'},
-        \ ]
-    " clear the quickfix list
-    call setqflist([], 'r')
-
-    let g:go_metalinter_enabled = ['revive', 'typecheck']
-
-    call go#lint#Gometa(0, 0)
-
-    let actual = getqflist()
-    let start = reltime()
-    while len(actual) == 0 && reltimefloat(reltime(start)) < 10
-      sleep 100m
-      let actual = copy(getqflist())
-    endwhile
-
-    " sort the results, because golangci-lint doesn't always return notices in
-    " a deterministic order.
-    call sort(l:actual)
-    call sort(l:expected)
-
-    call gotest#assert_quickfix(actual, expected)
-  finally
-      call call(RestoreGOPATH, [])
-      unlet g:go_metalinter_enabled
-      unlet g:go_metalinter_command
-  endtry
-endfunc
-
+"func! Test_GometaGolangciLint_importabs() abort
+"  call s:gometa_importabs('golangci-lint')
+"endfunc
+"
+"func! s:gometa_importabs(metalinter) abort
+"  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnamemodify(getcwd(), ':p') . 'test-fixtures/lint')
+"  silent exe 'e! ' . $GOPATH . '/src/lint/golangci-lint/problems/importabs/problems.go'
+"
+"  try
+"    let g:go_metalinter_command = a:metalinter
+"
+"    let expected = [
+"          \ {'lnum': 3, 'bufnr': bufnr('%'), 'col': 8, 'pattern': '', 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'module': '', 'text': '"/quux" imported but not used (typecheck)'},
+"        \ ]
+"    " clear the quickfix list
+"    call setqflist([], 'r')
+"
+"    let g:go_metalinter_enabled = ['revive', 'typecheck']
+"
+"    call go#lint#Gometa(0, 0)
+"
+"    let actual = getqflist()
+"    let start = reltime()
+"    while len(actual) == 0 && reltimefloat(reltime(start)) < 10
+"      sleep 100m
+"      let actual = copy(getqflist())
+"    endwhile
+"
+"    " sort the results, because golangci-lint doesn't always return notices in
+"    " a deterministic order.
+"    call sort(l:actual)
+"    call sort(l:expected)
+"
+"    call gotest#assert_quickfix(actual, expected)
+"  finally
+"      call call(RestoreGOPATH, [])
+"      unlet g:go_metalinter_enabled
+"      unlet g:go_metalinter_command
+"  endtry
+"endfunc
+"
 "func! Test_GometaAutoSaveGolangciLint_importabs() abort
 "  call s:gometaautosave_importabs('golangci-lint')
 "endfunc
@@ -452,7 +452,7 @@ func! Test_Lint_GOPATH() abort
   compiler go
 
   let expected = [
-          \ {'lnum': 1, 'bufnr': bufnr('%')+10, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'should have a package comment'},
+          \ {'lnum': 1, 'bufnr': bufnr('%')+9, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'should have a package comment'},
           \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported'},
           \ {'lnum': 5, 'bufnr': bufnr('test-fixtures/lint/src/lint/quux.go'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
       \ ]
@@ -490,7 +490,7 @@ func! Test_Lint_NullModule() abort
   compiler go
 
   let expected = [
-          \ {'lnum': 1, 'bufnr': bufnr('%')+10, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'should have a package comment'},
+          \ {'lnum': 1, 'bufnr': bufnr('%')+9, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'should have a package comment'},
           \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported'},
           \ {'lnum': 5, 'bufnr': bufnr('test-fixtures/lint/src/lint/quux.go'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
       \ ]

--- a/autoload/go/test_test.vim
+++ b/autoload/go/test_test.vim
@@ -48,8 +48,16 @@ endfunc
 
 func! Test_GoTestCompilerError() abort
   let expected = [
-        \ {'lnum': 6, 'bufnr': 6, 'col': 22, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'syntax error: unexpected newline, expecting comma or )'}
+        \ {'lnum': 6, 'bufnr': 6, 'col': 22, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'syntax error: unexpected newline in argument list; possibly missing comma or )'}
       \ ]
+  let [l:goversion, l:err] = go#util#Exec(['go', 'env', 'GOVERSION'])
+  let l:goversion = split(l:goversion, "\n")[0]
+  if l:goversion < 'go1.19'
+    let expected = [
+          \ {'lnum': 6, 'bufnr': 6, 'col': 22, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'syntax error: unexpected newline, expecting comma or )'}
+        \ ]
+  endif
+
   call s:test('compilerror/compilerror_test.go', expected)
 endfunc
 


### PR DESCRIPTION
##### update test to use Go 1.19


##### update Dockerfile to use Go 1.19


##### adjust tests for go1.19 changes to compiler errors


##### lint: add new expectation

Add new expectation introduced by revive.


##### lint: change metalinter tests to use revive

golangci-lint seems to have finally fully dropped golint support, so
refactor the tests that used golint to use revive instead.


##### lint: refactor for golangci-lint changed expectations


##### lint: adjust tests due to recent golangci-lint changes

Golangci-lint seems to have changed how it deals with some kinds of
problems. Comment out the tests that no longer seem to be relevant
instead of deleting them, because I don't trust that the original need
for the tests won't reappear.


