### PR TITLE
lint: fix test to work on all version of Vim

### DIFF
--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -449,12 +449,13 @@ func! Test_Lint_GOPATH() abort
   let RestoreGO111MODULE = go#util#SetEnv('GO111MODULE', 'off')
   let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
 
+  silent exe 'e! ' . $GOPATH . '/src/lint/baz.go'
   silent exe 'e! ' . $GOPATH . '/src/lint/quux.go'
   silent exe 'e! ' . $GOPATH . '/src/lint/lint.go'
   compiler go
 
   let expected = [
-          \ {'lnum': 1, 'bufnr': bufnr('%')+11, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'should have a package comment'},
+          \ {'lnum': 1, 'bufnr': bufnr('test-fixtures/lint/src/lint/baz.go'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'should have a package comment'},
           \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported'},
           \ {'lnum': 5, 'bufnr': bufnr('test-fixtures/lint/src/lint/quux.go'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
       \ ]
@@ -487,12 +488,13 @@ endfunc
 
 func! Test_Lint_NullModule() abort
   let RestoreGO111MODULE = go#util#SetEnv('GO111MODULE', 'off')
+  silent exe 'e! ' . fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint/src/lint/baz.go'
   silent exe 'e! ' . fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint/src/lint/quux.go'
   silent exe 'e! ' . fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint/src/lint/lint.go'
   compiler go
 
   let expected = [
-          \ {'lnum': 1, 'bufnr': bufnr('%')+11, 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'should have a package comment'},
+          \ {'lnum': 1, 'bufnr': bufnr('test-fixtures/lint/src/lint/baz.go'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'should have a package comment'},
           \ {'lnum': 5, 'bufnr': bufnr('%'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function MissingDoc should have comment or be unexported'},
           \ {'lnum': 5, 'bufnr': bufnr('test-fixtures/lint/src/lint/quux.go'), 'col': 1, 'valid': 1, 'vcol': 0, 'nr': -1, 'type': '', 'pattern': '', 'text': 'exported function AlsoMissingDoc should have comment or be unexported'}
       \ ]


### PR DESCRIPTION
Fix tests to get the buffer number from the expected path instead of
trying to predict what the buffer number for the expected buffer will be
to resolve what seems to be a difference between how Vim 8.0 and Vim 8.2
are handling this situation.