### PR TITLE
Optionally split to definition in the same buffer

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -188,6 +188,10 @@ function! go#config#DefReuseBuffer() abort
   return get(g:, 'go_def_reuse_buffer', 0)
 endfunction
 
+function! go#config#DefSplitSameBuffer() abort
+  return get(g:, 'go_def_split_same_buffer', 0)
+endfunction
+
 function! go#config#DefMode() abort
   return get(g:, 'go_def_mode', 'gopls')
 endfunction

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -167,7 +167,7 @@ function! go#def#jump_to_declaration(out, mode, bin_name) abort
   let old_switchbuf = &switchbuf
 
   normal! m'
-  if filename != fnamemodify(expand("%"), ':p:gs?\\?/?')
+  if go#config#DefSplitSameBuffer() || filename != fnamemodify(expand("%"), ':p:gs?\\?/?')
     " jump to existing buffer if, 1. we have enabled it, 2. the buffer is loaded
     " and 3. there is buffer window number we switch to
     if go#config#DefReuseBuffer() && bufwinnr(filename) != -1

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -1062,16 +1062,25 @@ Goto declaration/definition. Results are shown in the current window.
 
 Goto declaration/definition. Results are shown in a split window.
 Jumps to an existing buffer if |'g:go_def_reuse_buffer'| is enabled.
+By default, if the declaration/definition is in the same buffer, there is no
+split. Enabling |'g:go_def_split_same_buffer'| will split even for the same
+buffer.
 
                                                            *(go-def-vertical)*
 
 Goto declaration/definition. Results are shown in a vertical split window.
 Jumps to an existing buffer if |'g:go_def_reuse_buffer'| is enabled.
+By default, if the declaration/definition is in the same buffer, there is no
+split. Enabling |'g:go_def_split_same_buffer'| will split even for the same
+buffer.
 
                                                                 *(go-def-tab)*
 
 Goto declaration/definition. Results are shown in a tab window.
 Jumps to an existing buffer if |'g:go_def_reuse_buffer'| is enabled.
+By default, if the declaration/definition is in the same buffer, there is no
+split. Enabling |'g:go_def_split_same_buffer'| will split even for the same
+buffer.
 
                                                               *(go-def-type)*
 
@@ -1082,14 +1091,20 @@ Jumps to an existing buffer if |'g:go_def_reuse_buffer'| is enabled.
 Goto type declaration/definition. Results are shown in a vertical split
 window.
 Jumps to an existing buffer if |'g:go_def_reuse_buffer'| is enabled.
+If |'g:go_def_split_same_buffer'| is enabled, this creates a split window even
+if the declaration/definition are in the current buffer.
 
                                                         *(go-def-type-split)*
 Goto type declaration/definition. Results are shown in a split window.
 Jumps to an existing buffer if |'g:go_def_reuse_buffer'| is enabled.
+If |'g:go_def_split_same_buffer'| is enabled, this creates a split window even
+if the declaration/definition are in the current buffer.
 
                                                           *(go-def-type-tab)*
 Goto type declaration/definition. Results are shown in a tab window.
 Jumps to an existing buffer if |'g:go_def_reuse_buffer'| is enabled.
+If |'g:go_def_split_same_buffer'| is enabled, this creates a tab window even
+if the declaration/definition are in the current buffer.
 
                                                               *(go-def-stack)*
 
@@ -1524,16 +1539,24 @@ Valid options are `gopls` and `guru`. By default it's `gopls`.
 Use this option to enable/disable the default mapping of CTRL-],
 <C-LeftMouse>, g<C-LeftMouse> and (`gd`) for GoDef and CTRL-t for :GoDefPop.
 Disabling it allows you to map something else to these keys or mappings.
-Default is enabled. >
-
+Default is enabled.
+>
   let g:go_def_mapping_enabled = 1
 <
                                                      *'g:go_def_reuse_buffer'*
 
 Use this option to jump to an existing buffer for `:GoDef`, `:GoDefType`, and
-their mapping variants that cause splits. By default it's disabled. >
-
+their mapping variants that cause splits. By default it's disabled.
+>
   let g:go_def_reuse_buffer = 0
+<
+                                                *'g:go_def_split_same_buffer'*
+
+Use this option to create a split when jumping to a declaration/definition
+with a split, even if it's in the current buffer. By default, jumping to a
+declaration/definition with a split will not create a split.
+>
+  let g:go_def_split_same_buffer = 1
 <
                                                              *'g:go_bin_path'*
 


### PR DESCRIPTION
My typical workflow in vim when traversing a codebase is to start at a function of interest, then `<C-w>]` my way through various call stacks from there, so I have a full view. As a result of this workflow, splitting when jumping to a definition is an important feature for me. Currently, if a definition is in the same file as the current buffer, the feature to jump to the definition does not open a split when using a command like `<C-w>]`, which typically creates a split.

These changes add a `g:go_def_split_same_buffer` option that, when enabled, will cause jumping to a definition with a split using e.g. `<C-w>]` to always create a split, even if the definition is in the same file that is currently open.