### PR TITLE
set comments to two slashes only for go.mod

### DIFF
--- a/ftplugin/gomod.vim
+++ b/ftplugin/gomod.vim
@@ -14,7 +14,7 @@ let b:undo_ftplugin = "setl fo< com< cms<
 
 setlocal formatoptions-=t
 
-setlocal comments=s1:/*,mb:*,ex:*/,://
+setlocal comments=://
 setlocal commentstring=//\ %s
 
 " Autocommands


### PR DESCRIPTION
According to Go Modules Reference: [Lexical elements](https://go.dev/ref/mod#go-mod-file-lexical):

> Comments start with // and run to the end of a line. /* */ comments are not allowed.

Also go toolchain throws an error if comment of wrong format appears:

```
$ go mod tidy
go: errors parsing go.mod:
<path>/go.mod:<line>:<column>: mod files must use // comments (not /* */ comments)
```

This PR sets comments to `//` only in `go.mod` (`gomod` filetype).

Same can be set for `go.work` file too ([Lexical elements](https://go.dev/ref/mod#go-work-file-lexical)), but currently `vim-go` doesn't provide filetype plugin for it.