### PR TITLE
fix go work syntax having wrong highlighting entirely

### DIFF
--- a/syntax/gowork.vim
+++ b/syntax/gowork.vim
@@ -12,13 +12,11 @@ syntax case match
 
 " match keywords
 syntax keyword goworkGo      go      contained
-syntax keyword goworkUse use
-syntax keyword goworkExclude exclude
+syntax keyword goworkUse     use
 syntax keyword goworkReplace replace
-syntax keyword goworkRetract retract
 
-" require, exclude, replace, and go can be also grouped into block
-syntax region goworkUse start='require (' end=')' transparent contains=goworkUse,goworkPath
+" use, exclude, replace, and go can be also grouped into block
+syntax region goworkUse     start='use (' end=')'     transparent contains=goworkUse
 syntax region goworkReplace start='replace (' end=')' transparent contains=goworkReplace,goworkVersion
 syntax match  goworkGo            '^go .*$'           transparent contains=goworkGo,goworkGoVersion
 
@@ -43,11 +41,6 @@ highlight default link goworkReplaceOperator Operator
 syntax match goworkGoVersion "1\.\d\+" contained
 highlight default link goworkGoVersion Identifier
 
-
-" match paths in use directives
-syntax match goworkPath "\f\+"
-
-highlight default link goworkPath Identifier
 " highlight versions:
 "  * vX.Y.Z-pre
 "  * vX.Y.Z


### PR DESCRIPTION
`go.work` file has wrong syntax highlighting:

<img width="353" alt="image" src="https://user-images.githubusercontent.com/26388769/198687386-50085e54-b2d6-465b-9e6d-6129a696077f.png">

The reason is broken regexp that colors all file wrong:
```vim
syntax match goworkPath "\f\+"
```

I suggest to drop this regexp, because path can be treated like module name without version, and provide the same highligthing for `use` block as for `require` block in `go.mod`:

<img width="1512" alt="image" src="https://user-images.githubusercontent.com/26388769/198688159-0bb256c9-06a7-4305-8257-6fbf43a3a029.png">

Also I did some housekeeping in file.

PR with the same changes is opened in `vim-polyglot`: https://github.com/sheerun/vim-polyglot/pull/819.