### PR TITLE
Functionality to run single test case in test func

### DIFF
--- a/autoload/go/test.vim
+++ b/autoload/go/test.vim
@@ -122,6 +122,31 @@ function! go#test#Func(bang, ...) abort
   call call('go#test#Test', args)
 endfunction
 
+" Testcase runs a single subtest of a function for a subtest name on the
+" current cursor line.
+" Arguments are passed to the `go test` command.
+function! go#test#Case(bang, ...) abort
+  let l:testParent = go#util#TestName()
+
+  " Check for a struct initialization on the line, and take its value
+  let l:searchPattern = '\s*\:\s*"\zs\w*\ze'
+  let l:subTestName = matchstr(getline("."), l:searchPattern)
+  if l:subTestName == ""
+    call go#util#EchoError('[test] no name for test case found on cursor line')
+    return
+  endif
+
+  let l:args = [a:bang, 0, "-run", l:testParent . "/" . l:subTestName . "$"]
+  if a:0
+    call extend(l:args, a:000)
+  else
+    let l:timeout = go#config#TestTimeout()
+    call add(l:args, printf("-timeout=%s", l:timeout))
+  endif
+
+  call call('go#test#Test', l:args)
+endfunction
+
 function! s:test_job(cmd, args) abort
   " autowrite is not enabled for jobs
   call go#cmd#autowrite()

--- a/autoload/go/test_test.vim
+++ b/autoload/go/test_test.vim
@@ -125,6 +125,25 @@ func! Test_GoTestExample() abort
   call s:test('example/example_test.go', expected)
 endfunc
 
+" Non exhaustive set of tests, to show behaviour and common cases
+func! Test_GoSubTestUnderCursor() abort
+  let l:testCases = [
+        \{'lineContent' : 'name: "myTest"', 'expected': "myTest", 'testName' : 'all letters'},
+        \{'lineContent' : 'nom: "my test"', 'expected' : "my test", 'testName' : 'with space'},
+        \{'lineContent' : 'nombre: "my1test"', 'expected' : "my1test", 'testName' : 'with number'},
+        \{'lineContent' : 'nome : "my_test"', 'expected' : "my_test", 'testName' : 'with underscore, and preceding `:` space'},
+        \{'lineContent' : '      enw :"myTest"', 'expected' : 'myTest', 'testName' : 'with starting tabs'},
+        \{'lineContent' : 'Though this be madness, yet there is method in [i]t.', 'expected' : '', 'testName' : 'no match'},
+        \{'lineContent' : 'namn: "myTest",', 'expected' : 'myTest', 'testName' : 'comma terminated'},
+        \{'lineContent' : 'naam: "myTest" ', 'expected' : 'myTest', 'testName' : 'space terminated'},
+        \{'lineContent' : 'ainm: "myTest",\n', 'expected' : 'myTest', 'testName' : 'newline terminated'},
+        \ ]
+  for l:tc in l:testCases
+    let l:actual = go#test#subtestUnderCursor(l:tc['lineContent'])
+    call assert_equal(l:actual, l:tc['expected'], 'SubTest: ' . l:tc['testName'])
+  endfor
+endfunction
+
 func! s:test(file, expected, ...) abort
   let $GOPATH = fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/test'
   call go#util#Chdir(printf('%s/src/%s', $GOPATH, fnamemodify(a:file, ':h')))

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -423,6 +423,19 @@ CTRL-t
 
     If [!] is not given the first error is jumped to.
 
+
+:GoTestCase[!] [expand]                                          *:GoTestCase*
+
+    Runs :GoTest, but only for a single test case within a single test
+    function immediate to your cursor using 'go test's '-run' flag.
+
+    Lookup of the parent test function is as in `:GoTestFunc`. The test case
+    name lookup is done by taking the cursor line, checking for a struct
+    varliabe initialization, and taking the value of the name. The test
+    is then identified in the format of `TestFunctionName/TestCaseName$` .
+
+    if [!] is not given the first error is jumped to.
+
                                                               *:GoTestCompile*
 :GoTestCompile[!] [expand]
 

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -431,7 +431,7 @@ CTRL-t
 
     Lookup of the parent test function is as in `:GoTestFunc`. The test case
     name lookup is done by taking the cursor line, checking for a struct
-    varliabe initialization, and taking the value of the name. The test
+    variable initialization, and taking the value of the name. The test
     is then identified in the format of `TestFunctionName/TestCaseName$` .
 
     if [!] is not given the first error is jumped to.

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -47,6 +47,7 @@ command! -nargs=* -bang GoInstall call go#cmd#Install(<bang>0, <f-args>)
 " -- test
 command! -nargs=* -bang GoTest call go#test#Test(<bang>0, 0, <f-args>)
 command! -nargs=* -bang GoTestFunc call go#test#Func(<bang>0, <f-args>)
+command! -nargs=* -bang GoTestCase call go#test#Case(<bang>0, <f-args>)
 command! -nargs=* -bang GoTestCompile call go#test#Test(<bang>0, 1, <f-args>)
 
 " -- cover


### PR DESCRIPTION
# What Changed
This adds the ability to run a single case from a table of tests in a similar manner to the Go plugin for IntelliJ (GoLand). Using the line under the cursor, the test case name is extracted from a field initialization and appended to the test function name. Otherwise the test is ran in the same manner as `go#test#Func()`

For example; with a test function like:

```
func FooBar_Test (t *testing.T){
    testCases := []struct {
        name string,
        want int,
        have int,
    }{
        {
            name: "first",
            want: 1,
            have: 1,
        },
        {
            name: "second",
            have: 2,
            want: 3,
        },
    }
    for _, tc := range testCases {
        t.Run(tc.Name, func(t2 *testing.T){
            assert.Equal(t2, tc.have, tc.want)
        }
    }
}
```

If the cursor is on line 8 and `:GoTestCase` is called; the test `./FooBar_Test/first` would be passed as the package parameter to `go test`. 

# How it was tested

Manual testing was done to verify the value initialization was being correctly parsed. I did not write automated tests for this functionality as the functionality is very similar to `go#test#Func` and saw limited value in adding additional automated tests for the regex being used to extract the value. 

# Other considerations

Initially I had attempted to be clever and identify the variable used by `t.Run` to determine which symbol to look for in the testcase, and the LSP `textDocument/foldingRanges` used to determine the scope of the test case surrounding the cursor. This lead to more complexity than I thought necessary just to execute a test case, especially when vim already provides tooling to accurately move the cursor to specific lines or patterns. 

I also attempted using the `textDocument/documentSymbol` LSP functionality too. But determined that the additional complexity for the implementation was also a bit extra for this feature, and increased the error footprint. 