### PR TITLE
sameids: remove useless echo info when highlight package references

### DIFF
--- a/autoload/go/sameids.vim
+++ b/autoload/go/sameids.vim
@@ -49,8 +49,6 @@ function! s:same_ids_highlight(exit_val, result, mode) abort
     let l:matches = add(l:matches, [pos[0], pos[1], poslen])
   endfor
 
-  call go#util#EchoInfo(printf('%s', l:matches))
-
   call go#util#HighlightPositions('goSameId', l:matches)
 
   if go#config#AutoSameids()


### PR DESCRIPTION
<img width="703" alt="image" src="https://user-images.githubusercontent.com/1449133/208279452-3e98bcde-4ec7-40f8-9a40-eccbdc16e7bf.png">
