### PR TITLE
Fix import path for josharian/impl 

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -54,7 +54,7 @@ let s:packages = {
       \ 'gorename':      ['golang.org/x/tools/cmd/gorename@master'],
       \ 'gotags':        ['github.com/jstemmer/gotags@master'],
       \ 'guru':          ['golang.org/x/tools/cmd/guru@master'],
-      \ 'impl':          ['github.com/josharian/impl@master'],
+      \ 'impl':          ['github.com/josharian/impl@main'],
       \ 'keyify':        ['honnef.co/go/tools/cmd/keyify@master'],
       \ 'motion':        ['github.com/fatih/motion@latest'],
       \ 'iferr':         ['github.com/koron/iferr@master'],


### PR DESCRIPTION
Looks like josharian decided to rename the `master` branch to `main`, which unfortunately breaks the vim-go `GoInstallBinaries` / `GoUpdateBinaries` commands for that tool.

Updating the import path.