### PR TITLE
syntax: link godebugStracktrace to Function

### DIFF
--- a/syntax/godebugstacktrace.vim
+++ b/syntax/godebugstacktrace.vim
@@ -6,6 +6,6 @@ syn match godebugStacktrace '^\S\+'
 
 let b:current_syntax = "godebugoutput"
 
-hi def link godebugStacktrace SpecialKey
+hi def link godebugStacktrace Function
 
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
Link godebugStracktrace to Function by default instead of to SpecialKey, because Function is more semantically appropriate and is less likely to cause issues with colorschemes that may have neglected to fully implement useful coloring for all the predefined groups.