### PR TITLE
test: add :GoTestFile

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -411,6 +411,14 @@ CTRL-t
     in the background according to |'g:go_term_enabled'|. You can set the mode
     of the new terminal with |'g:go_term_mode'|.
 
+                                                                 *:GoTestFile*
+:GoTestFile[!] [expand]
+
+    Runs :GoTest, but only on the tests in the current file using 'go test's
+    '-run' flag.
+
+    If [!] is not given the first error is jumped to.
+
                                                                  *:GoTestFunc*
 :GoTestFunc[!] [expand]
 

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -46,8 +46,9 @@ command! -nargs=* -bang GoInstall call go#cmd#Install(<bang>0, <f-args>)
 
 " -- test
 command! -nargs=* -bang GoTest call go#test#Test(<bang>0, 0, <f-args>)
-command! -nargs=* -bang GoTestFunc call go#test#Func(<bang>0, <f-args>)
 command! -nargs=* -bang GoTestCompile call go#test#Test(<bang>0, 1, <f-args>)
+command! -nargs=* -bang GoTestFile call go#test#File(<bang>0, <f-args>)
+command! -nargs=* -bang GoTestFunc call go#test#Func(<bang>0, <f-args>)
 
 " -- cover
 command! -nargs=* -bang GoCoverage call go#coverage#Buffer(<bang>0, <f-args>)


### PR DESCRIPTION
Add :GoTestFile command to run all tests in the current file.

Fix two bugs in :GoTestFunc.
* Change the test name search pattern to ensure the line begins with "func Test" (e.g. stop matching "// func Test").
* Ensure that names of tests that run match exactly by including a ^ in the pattern given to go test's -run flag (e.g. stop matching both TestFoo and TestBarTestFoo when the cursor is in TestFoo).

Closes #2138