### PR TITLE
fix term flakes that often affect NeoVim tests.

### DIFF
--- a/autoload/go/term.vim
+++ b/autoload/go/term.vim
@@ -88,8 +88,9 @@ function! go#term#newmode(bang, cmd, errorformat, mode) abort
       let l:term["vertical"] = l:mode
     endif
 
-    let l:state.id = term_start(a:cmd, l:term)
-    let l:state.termwinid = win_getid(bufwinnr(l:state.id))
+    let l:termbufnr = term_start(a:cmd, l:term)
+    let l:state.id = term_getjob(l:termbufnr)
+    let l:state.termwinid = win_getid(bufwinnr(l:termbufnr))
     let s:lasttermwinid = l:state.termwinid
     call go#util#Chdir(l:dir)
 

--- a/autoload/go/term_test.vim
+++ b/autoload/go/term_test.vim
@@ -10,7 +10,7 @@ func! Test_GoTermNewMode()
   try
     let l:filename = 'term/term.go'
     let l:tmp = gotest#load_fixture(l:filename)
-    exe 'cd ' . l:tmp . '/src/term'
+    call go#util#Chdir(l:tmp . '/src/term')
 
     let expected = expand('%:p')
 
@@ -35,7 +35,7 @@ func! Test_GoTermNewMode_SplitRight()
   try
     let l:filename = 'term/term.go'
     let l:tmp = gotest#load_fixture(l:filename)
-    exe 'cd ' . l:tmp . '/src/term'
+    call go#util#Chdir(l:tmp . '/src/term')
 
     let expected = expand('%:p')
 
@@ -61,7 +61,8 @@ func! Test_GoTermReuse()
   try
     let l:filename = 'term/term.go'
     let l:tmp = gotest#load_fixture(l:filename)
-    exe 'cd ' . l:tmp . '/src/term'
+
+    call go#util#Chdir(l:tmp . '/src/term')
 
     let expected = expand('%:p')
 

--- a/autoload/go/term_test.vim
+++ b/autoload/go/term_test.vim
@@ -14,16 +14,27 @@ func! Test_GoTermNewMode()
     call go#util#Chdir(l:tmp . '/src/term')
 
     let expected = expand('%:p')
+    let l:winid = win_getid()
+
+    let l:expectedwindows = len(getwininfo()) + 1
 
     let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
 
     set nosplitright
+
     call go#term#new(0, cmd, &errorformat)
+
+    let l:start = reltime()
+    while len(getwininfo()) < l:expectedwindows && reltimefloat(reltime(l:start)) < 10
+      sleep 50m
+    endwhile
+
     let actual = expand('%:p')
     call assert_equal(actual, l:expected)
+    call assert_equal(l:expectedwindows, len(getwininfo()))
 
   finally
-    sleep 50m
+    call win_gotoid(l:winid)
     call delete(l:tmp, 'rf')
     unlet g:go_gopls_enabled
   endtry
@@ -41,16 +52,27 @@ func! Test_GoTermNewMode_SplitRight()
     call go#util#Chdir(l:tmp . '/src/term')
 
     let expected = expand('%:p')
+    let l:winid = win_getid()
+
+    let l:expectedwindows = len(getwininfo()) + 1
 
     let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
 
     set splitright
+
     call go#term#new(0, cmd, &errorformat)
+
+    let l:start = reltime()
+    while len(getwininfo()) < l:expectedwindows && reltimefloat(reltime(l:start)) < 10
+      sleep 50m
+    endwhile
+
     let actual = expand('%:p')
     call assert_equal(actual, l:expected)
+    call assert_equal(l:expectedwindows, len(getwininfo()))
 
   finally
-    sleep 50m
+    call win_gotoid(l:winid)
     call delete(l:tmp, 'rf')
     set nosplitright
     unlet g:go_gopls_enabled
@@ -69,25 +91,42 @@ func! Test_GoTermReuse()
 
     call go#util#Chdir(l:tmp . '/src/term')
 
+    let l:winid = win_getid()
     let expected = expand('%:p')
+
+    let l:expectedwindows = len(getwininfo())+1
 
     let cmd = "go run ".  go#util#Shelljoin(go#tool#Files())
 
     set nosplitright
 
     let g:go_term_reuse = 1
-    call go#term#new(0, cmd, &errorformat)
-    let actual = expand('%:p')
-    call assert_equal(actual, l:expected)
-    call assert_equal(3, len(getwininfo()))
 
     call go#term#new(0, cmd, &errorformat)
+
+    let l:start = reltime()
+    while len(getwininfo()) < l:expectedwindows && reltimefloat(reltime(l:start)) < 10
+      sleep 50m
+    endwhile
+
+    let actual = expand('%:p')
+    call assert_equal(actual, l:expected)
+    call assert_equal(l:expectedwindows, len(getwininfo()))
+
+    call go#term#new(0, cmd, &errorformat)
+
+    let l:start = reltime()
+    while len(getwininfo()) < l:expectedwindows && reltimefloat(reltime(l:start)) < 10
+      sleep 50m
+    endwhile
+
     let actual = expand('%:p')
     call assert_equal(actual, l:expected)
 
-    call assert_equal(3, len(getwininfo()))
+    call assert_equal(l:expectedwindows, len(getwininfo()))
+
   finally
-    sleep 50m
+    call win_gotoid(l:winid)
     unlet g:go_term_reuse
     call delete(l:tmp, 'rf')
     unlet g:go_gopls_enabled

--- a/autoload/go/term_test.vim
+++ b/autoload/go/term_test.vim
@@ -22,12 +22,9 @@ func! Test_GoTermNewMode()
 
     set nosplitright
 
-    call go#term#new(0, cmd, &errorformat)
+    let l:jobid = go#term#new(0, cmd, &errorformat)
 
-    let l:start = reltime()
-    while len(getwininfo()) < l:expectedwindows && reltimefloat(reltime(l:start)) < 10
-      sleep 50m
-    endwhile
+    call go#job#Wait(l:jobid)
 
     let actual = expand('%:p')
     call assert_equal(actual, l:expected)
@@ -35,6 +32,7 @@ func! Test_GoTermNewMode()
 
   finally
     call win_gotoid(l:winid)
+    only!
     call delete(l:tmp, 'rf')
     unlet g:go_gopls_enabled
   endtry
@@ -60,12 +58,9 @@ func! Test_GoTermNewMode_SplitRight()
 
     set splitright
 
-    call go#term#new(0, cmd, &errorformat)
+    let l:jobid = go#term#new(0, cmd, &errorformat)
 
-    let l:start = reltime()
-    while len(getwininfo()) < l:expectedwindows && reltimefloat(reltime(l:start)) < 10
-      sleep 50m
-    endwhile
+    call go#job#Wait(l:jobid)
 
     let actual = expand('%:p')
     call assert_equal(actual, l:expected)
@@ -73,6 +68,7 @@ func! Test_GoTermNewMode_SplitRight()
 
   finally
     call win_gotoid(l:winid)
+    only!
     call delete(l:tmp, 'rf')
     set nosplitright
     unlet g:go_gopls_enabled
@@ -100,25 +96,24 @@ func! Test_GoTermReuse()
 
     set nosplitright
 
+    " prime the terminal window
+    let l:jobid = go#term#new(0, cmd, &errorformat)
+
+    call go#job#Wait(l:jobid)
+
     let g:go_term_reuse = 1
 
-    call go#term#new(0, cmd, &errorformat)
+    let l:jobid = go#term#new(0, cmd, &errorformat)
 
-    let l:start = reltime()
-    while len(getwininfo()) < l:expectedwindows && reltimefloat(reltime(l:start)) < 10
-      sleep 50m
-    endwhile
+    call go#job#Wait(l:jobid)
 
     let actual = expand('%:p')
     call assert_equal(actual, l:expected)
     call assert_equal(l:expectedwindows, len(getwininfo()))
 
-    call go#term#new(0, cmd, &errorformat)
+    let l:jobid = go#term#new(0, cmd, &errorformat)
 
-    let l:start = reltime()
-    while len(getwininfo()) < l:expectedwindows && reltimefloat(reltime(l:start)) < 10
-      sleep 50m
-    endwhile
+    call go#job#Wait(l:jobid)
 
     let actual = expand('%:p')
     call assert_equal(actual, l:expected)
@@ -127,6 +122,7 @@ func! Test_GoTermReuse()
 
   finally
     call win_gotoid(l:winid)
+    only!
     unlet g:go_term_reuse
     call delete(l:tmp, 'rf')
     unlet g:go_gopls_enabled

--- a/autoload/go/term_test.vim
+++ b/autoload/go/term_test.vim
@@ -8,6 +8,7 @@ func! Test_GoTermNewMode()
   endif
 
   try
+    let g:go_gopls_enabled = 0
     let l:filename = 'term/term.go'
     let l:tmp = gotest#load_fixture(l:filename)
     call go#util#Chdir(l:tmp . '/src/term')
@@ -24,6 +25,7 @@ func! Test_GoTermNewMode()
   finally
     sleep 50m
     call delete(l:tmp, 'rf')
+    unlet g:go_gopls_enabled
   endtry
 endfunc
 
@@ -33,6 +35,7 @@ func! Test_GoTermNewMode_SplitRight()
   endif
 
   try
+    let g:go_gopls_enabled = 0
     let l:filename = 'term/term.go'
     let l:tmp = gotest#load_fixture(l:filename)
     call go#util#Chdir(l:tmp . '/src/term')
@@ -50,6 +53,7 @@ func! Test_GoTermNewMode_SplitRight()
     sleep 50m
     call delete(l:tmp, 'rf')
     set nosplitright
+    unlet g:go_gopls_enabled
   endtry
 endfunc
 
@@ -59,6 +63,7 @@ func! Test_GoTermReuse()
   endif
 
   try
+    let g:go_gopls_enabled = 0
     let l:filename = 'term/term.go'
     let l:tmp = gotest#load_fixture(l:filename)
 
@@ -85,6 +90,7 @@ func! Test_GoTermReuse()
     sleep 50m
     unlet g:go_term_reuse
     call delete(l:tmp, 'rf')
+    unlet g:go_gopls_enabled
   endtry
 endfunc
 

--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -39,8 +39,10 @@ fun! gotest#write_file(path, contents) abort
       call setline('.', substitute(getline('.'), "\x1f", '', ''))
       silent noautocmd w!
 
-      call go#lsp#DidClose(expand('%:p'))
-      call go#lsp#DidOpen(expand('%:p'))
+      if go#config#GoplsEnabled()
+        call go#lsp#DidClose(expand('%:p'))
+        call go#lsp#DidOpen(expand('%:p'))
+      endif
 
       break
     endif
@@ -63,7 +65,7 @@ endfun
 " The current directory will be changed to the parent directory of module
 " root.
 fun! gotest#load_fixture(path) abort
-  if go#util#has_job()
+  if go#util#has_job() && go#config#GoplsEnabled()
     call go#lsp#CleanWorkspaces()
   endif
   let l:dir = go#util#tempdir("vim-go-test/testrun/")
@@ -75,7 +77,7 @@ fun! gotest#load_fixture(path) abort
   silent exe 'noautocmd e! ' . a:path
   silent exe printf('read %s/test-fixtures/%s', g:vim_go_root, a:path)
   silent noautocmd w!
-  if go#util#has_job()
+  if go#util#has_job() && go#config#GoplsEnabled()
     call go#lsp#AddWorkspaceDirectory(fnamemodify(l:full_path, ':p:h'))
   endif
 


### PR DESCRIPTION
##### use go#util#Chdir in term tests


##### term: do not start gopls

The terminal tests do not need gopls, so disable it so that the output
from gopls as directories are deleted do not muddy the logs with the
noise of gopls not being able to find deleted directories.


##### term: return the job id properly


##### term: fix flaky tests

* stop sleeping to try to give Vim time to execute the job
  asynchronously. Instead, look for the expected windows.
* always return to the starting window before exiting the terminal test.
* verify that the expected number of windows are open (i.e. each
  terminal execution should open one more than existed before the job
  was executed).


##### term: wait for terminal job to finish

Wait for the terminal job to finish instead of trying to count windows.


