### PR TITLE
syntax: add new `clear` builtin function

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -47,7 +47,7 @@ hi def link     goFloats            Type
 hi def link     goComplexes         Type
 
 " Predefined functions and values
-syn keyword     goBuiltins                 append cap close complex copy delete imag len
+syn keyword     goBuiltins                 append cap clear close complex copy delete imag len
 syn keyword     goBuiltins                 make new panic print println real recover
 syn keyword     goBoolean                  true false
 syn keyword     goPredefinedIdentifiers    nil iota


### PR DESCRIPTION
Support the new clear(x) builtin function added for Go 1.21.

https://github.com/golang/go/issues/56351
https://github.com/golang/go/commit/b89a840d6572c97a80ac78462b03122b83bc84e9