### PR TITLE
tests: disable gopls when it's not needed

### DIFF
--- a/autoload/go/cmd_test.vim
+++ b/autoload/go/cmd_test.vim
@@ -4,6 +4,7 @@ set cpo&vim
 
 func! Test_GoBuildErrors()
   try
+    let g:go_gopls_enabled = 0
     let l:filename = 'cmd/bad.go'
     let l:tmp = gotest#load_fixture(l:filename)
 

--- a/autoload/go/complete_test.vim
+++ b/autoload/go/complete_test.vim
@@ -5,7 +5,6 @@ set cpo&vim
 func! Test_GetInfo_gopls()
     let g:go_info_mode = 'gopls'
     call s:getinfo()
-    unlet g:go_info_mode
 endfunction
 
 func! s:getinfo()

--- a/autoload/go/config_test.vim
+++ b/autoload/go/config_test.vim
@@ -49,7 +49,6 @@ func! Test_SetBuildTags() abort
       sleep 50m
       let l:lsplog = getbufline('__GOLSP_LOG__', 1, '$')
     endwhile
-    unlet g:go_debug
     " close the __GOLSP_LOG__ window
     only
 
@@ -75,7 +74,6 @@ func! Test_SetBuildTags() abort
 
   finally
     call go#config#SetBuildTags('')
-    unlet g:go_def_mode
   endtry
 endfunc
 
@@ -96,10 +94,10 @@ func! Test_GoplsEnabled_Clear() abort
           \ ] )
 
   finally
-    unlet g:go_gopls_enabled
     call delete(l:tmp, 'rf')
   endtry
 endfunc
+
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/autoload/go/debug_test.vim
+++ b/autoload/go/debug_test.vim
@@ -24,6 +24,7 @@ function! Test_GoDebugStart_Errors() abort
   endif
 
   try
+    let g:go_gopls_enabled = 0
     let l:tmp = gotest#load_fixture('debug/compilerror/main.go')
 
     let l:expected = [
@@ -71,6 +72,7 @@ function! Test_GoDebugModeRemapsAndRestoresKeys() abort
   endif
 
   try
+    let g:go_gopls_enabled = 0
     let g:go_debug_mappings = {'(go-debug-continue)': {'key': 'q', 'arguments': '<nowait>'}}
     let l:tmp = gotest#load_fixture('debug/debugmain/debugmain.go')
 
@@ -104,6 +106,7 @@ function! Test_GoDebugStopRemovesPlugMappings() abort
   endif
 
   try
+    let g:go_gopls_enabled = 0
     let l:tmp = gotest#load_fixture('debug/debugmain/debugmain.go')
 
     call assert_false(exists(':GoDebugStop'))
@@ -139,6 +142,7 @@ function! s:debug(...) abort
   endif
 
   try
+    let g:go_gopls_enabled = 0
     let $oldgopath = $GOPATH
     let l:tmp = gotest#load_fixture('debug/debugmain/debugmain.go')
 

--- a/autoload/go/def_test.vim
+++ b/autoload/go/def_test.vim
@@ -6,6 +6,7 @@ scriptencoding utf-8
 
 func! Test_jump_to_declaration_guru() abort
   try
+    let g:go_gopls_enabled = 0
     let l:filename = 'def/jump.go'
     let l:lnum = 5
     let l:col = 6
@@ -24,6 +25,7 @@ endfunc
 
 func! Test_jump_to_declaration_godef() abort
   try
+    let g:go_gopls_enabled = 0
     let l:filename = 'def/jump.go'
     let l:lnum = 5
     let l:col = 6
@@ -59,7 +61,6 @@ func! Test_Jump_leaves_lists() abort
     call go#def#Jump('', 0)
 
     if !go#util#has_job()
-      unlet g:go_def_mode
     endif
 
     let l:start = reltime()
@@ -108,7 +109,6 @@ func! Test_DefJump_gopls_simple_first() abort
     call assert_equal(l:expected, getpos('.'))
   finally
     call delete(l:tmp, 'rf')
-    unlet g:go_def_mode
   endtry
 endfunc
 
@@ -143,7 +143,6 @@ func! Test_DefJump_gopls_simple_last() abort
     call assert_equal(l:expected, getpos('.'))
   finally
     call delete(l:tmp, 'rf')
-    unlet g:go_def_mode
   endtry
 endfunc
 
@@ -177,7 +176,6 @@ func! Test_DefJump_gopls_MultipleCodeUnit_first() abort
     call assert_equal(l:expected, getpos('.'))
   finally
     call delete(l:tmp, 'rf')
-    unlet g:go_def_mode
   endtry
 endfunc
 
@@ -212,7 +210,6 @@ func! Test_DefJump_gopls_MultipleCodeUnit_last() abort
     call assert_equal(l:expected, getpos('.'))
   finally
     call delete(l:tmp, 'rf')
-    unlet g:go_def_mode
   endtry
 endfunc
 

--- a/autoload/go/fillstruct_test.vim
+++ b/autoload/go/fillstruct_test.vim
@@ -4,6 +4,7 @@ set cpo&vim
 
 func! Test_fillstruct() abort
   try
+    let g:go_gopls_enabled = 0
     let g:go_fillstruct_mode = 'fillstruct'
     let l:tmp = gotest#write_file('a/a.go', [
           \ 'package a',
@@ -17,13 +18,13 @@ func! Test_fillstruct() abort
           \ '\tAddress: "",',
           \ '}'])
   finally
-    unlet g:go_fillstruct_mode
     call delete(l:tmp, 'rf')
   endtry
 endfunc
 
 func! Test_fillstruct_line() abort
   try
+    let g:go_gopls_enabled = 0
     let g:go_fillstruct_mode = 'fillstruct'
     let l:tmp = gotest#write_file('a/a.go', [
           \ 'package a',
@@ -37,7 +38,6 @@ func! Test_fillstruct_line() abort
           \ '\tAddress: "",',
           \ '}'])
   finally
-    unlet g:go_fillstruct_mode
     call delete(l:tmp, 'rf')
   endtry
 endfunc
@@ -45,6 +45,7 @@ endfunc
 func! Test_fillstruct_two_line() abort
   try
     let g:go_fillstruct_mode = 'fillstruct'
+    let g:go_gopls_enabled = 0
     let l:tmp = gotest#write_file('a/a.go', [
           \ 'package a',
           \ 'import (',
@@ -67,7 +68,6 @@ func! Test_fillstruct_two_line() abort
           \ '\tAddress: "",',
           \ '}) }'])
   finally
-    unlet g:go_fillstruct_mode
     call delete(l:tmp, 'rf')
   endtry
 endfunc
@@ -75,6 +75,7 @@ endfunc
 func! Test_fillstruct_two_cursor() abort
   try
     let g:go_fillstruct_mode = 'fillstruct'
+    let g:go_gopls_enabled = 0
     let l:tmp = gotest#write_file('a/a.go', [
           \ 'package a',
           \ 'import (',
@@ -94,7 +95,6 @@ func! Test_fillstruct_two_cursor() abort
           \ '\tAddress: "",',
           \ '}) }'])
   finally
-    unlet g:go_fillstruct_mode
     call delete(l:tmp, 'rf')
   endtry
 endfunc
@@ -120,7 +120,6 @@ func! Test_gopls_fillstruct() abort
           \ '\tAddress: "",',
           \ '}'])
   finally
-    unlet g:go_fillstruct_mode
     call delete(l:tmp, 'rf')
   endtry
 endfunc
@@ -146,7 +145,6 @@ func! Test_gopls_fillstruct_line() abort
           \ '\tAddress: "",',
           \ '}'])
   finally
-    unlet g:go_fillstruct_mode
     call delete(l:tmp, 'rf')
   endtry
 endfunc
@@ -179,7 +177,6 @@ func! Test_gopls_fillstruct_two_line() abort
           \ ')',
           \ 'func x() { fmt.Println(mail.Address{}, mail.Address{}) }'])
   finally
-    unlet g:go_fillstruct_mode
     call delete(l:tmp, 'rf')
   endtry
 endfunc
@@ -212,7 +209,6 @@ func! Test_gopls_fillstruct_two_cursor() abort
           \ '\tAddress: "",',
           \ '}) }'])
   finally
-    unlet g:go_fillstruct_mode
     call delete(l:tmp, 'rf')
   endtry
 endfunc

--- a/autoload/go/fmt_test.vim
+++ b/autoload/go/fmt_test.vim
@@ -3,6 +3,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 func! Test_run_fmt() abort
+  let g:go_gopls_enabled = 0
   let actual_file = tempname()
   call writefile(readfile("test-fixtures/fmt/hello.go"), actual_file)
 
@@ -18,6 +19,7 @@ func! Test_run_fmt() abort
 endfunc
 
 func! Test_update_file() abort
+  let g:go_gopls_enabled = 0
   let expected = join(readfile("test-fixtures/fmt/hello_golden.go"), "\n")
   let source_file = tempname()
   call writefile(readfile("test-fixtures/fmt/hello_golden.go"), source_file)
@@ -35,6 +37,7 @@ func! Test_update_file() abort
 endfunc
 
 func! Test_goimports() abort
+  let g:go_gopls_enabled = 0
   let $GOPATH = printf('%s/%s', fnamemodify(getcwd(), ':p'), 'test-fixtures/fmt')
   let actual_file = tempname()
   call writefile(readfile("test-fixtures/fmt/src/imports/goimports.go"), actual_file)

--- a/autoload/go/guru_test.vim
+++ b/autoload/go/guru_test.vim
@@ -10,10 +10,6 @@ function Test_GuruScope_Set() abort
   silent call go#guru#Scope('""')
   silent let actual = go#config#GuruScope()
   call assert_equal([], actual, "setting scope to empty string should clear")
-
-  if exists('g:go_guru_scope')
-    unlet g:go_guru_scope
-  endif
 endfunction
 
 " restore Vi compatibility settings

--- a/autoload/go/highlight_test.vim
+++ b/autoload/go/highlight_test.vim
@@ -6,6 +6,7 @@ function! Test_gomodVersion_highlight() abort
   try
     syntax on
 
+    let g:go_gopls_enabled = 0
     let l:dir = gotest#write_file('gomodtest/go.mod', [
           \ 'module github.com/fatih/vim-go',
           \ '',
@@ -58,6 +59,7 @@ function! Test_gomodVersion_incompatible_highlight() abort
   try
     syntax on
 
+    let g:go_gopls_enabled = 0
     let l:dir = gotest#write_file('gomodtest/go.mod', [
           \ 'module github.com/fatih/vim-go',
           \ '',
@@ -100,6 +102,7 @@ endfunc
 
 function! Test_numeric_literal_highlight() abort
   syntax on
+  let g:go_gopls_enabled = 0
 
   let l:tests = {
         \ 'lone zero': {'group': 'goDecimalInt', 'value': '0'},
@@ -149,6 +152,7 @@ endfunction
 
 function! Test_zero_as_index_element() abort
   syntax on
+  let g:go_gopls_enabled = 0
 
   let l:actual = s:numericHighlightGroupInSliceElement('zero-element', '0')
   call assert_equal('goDecimalInt', l:actual)
@@ -158,6 +162,7 @@ endfunction
 
 function! Test_zero_as_slice_index() abort
   syntax on
+  let g:go_gopls_enabled = 0
 
   let l:actual = s:numericHighlightGroupInSliceIndex('zero-index', '0')
   call assert_equal('goDecimalInt', l:actual)
@@ -168,6 +173,7 @@ endfunction
 
 function! Test_zero_as_start_slicing_slice() abort
   syntax on
+  let g:go_gopls_enabled = 0
 
   let l:actual = s:numericHighlightGroupInSliceSlicing('slice-slicing', '0', '1')
   call assert_equal('goDecimalInt', l:actual)
@@ -301,7 +307,6 @@ function! Test_diagnostic_after_fmt() abort
           \ '}',
           \ ], [])
   finally
-    unlet g:go_fmt_command
   endtry
 endfunction
 
@@ -320,7 +325,6 @@ function! Test_diagnostic_after_fmt_change() abort
           \ '}',
           \ ], [])
   finally
-    unlet g:go_fmt_command
   endtry
 endfunction
 
@@ -339,7 +343,6 @@ function! Test_diagnostic_after_fmt_cleared() abort
           \ '}',
           \ ], ['hello := "hello, vim-go"'])
   finally
-    unlet g:go_fmt_command
   endtry
 endfunction
 
@@ -442,6 +445,7 @@ endfunction
 
 function! Test_goStringHighlight() abort
   syntax on
+  let g:go_gopls_enabled = 0
 
   let l:dir = gotest#write_file('highlight/gostring.go', [
         \ 'package highlight',
@@ -464,6 +468,7 @@ endfunc
 
 function! Test_goImportStringHighlight() abort
   syntax on
+  let g:go_gopls_enabled = 0
 
   let l:dir = gotest#write_file('highlight/import.go', [
         \ 'package highlight',
@@ -486,6 +491,7 @@ endfunc
 
 function! Test_goReceiverHighlight() abort
   syntax on
+  let g:go_gopls_enabled = 0
 
   let l:tests = {
       \ 'PointerReceiverVar': {'group': 'goReceiverVar', 'value': "t\x1f *T"},
@@ -507,7 +513,6 @@ function! Test_goReceiverHighlight() abort
     let l:actual = s:receiverHighlightGroup(l:kv[0], l:kv[1].value)
     call assert_equal(l:kv[1].group, l:actual, l:kv[0])
   endfor
-  unlet g:go_highlight_function_parameters
 endfunc
 
 function! s:receiverHighlightGroup(testname, value)
@@ -531,6 +536,7 @@ endfunc
 
 function! Test_GoTypeHighlight() abort
   syntax on
+  let g:go_gopls_enabled = 0
 
   let l:tests = {
       \ 'StandardType': {'group': 'goTypeName', 'value': "T\x1f"},
@@ -542,7 +548,6 @@ function! Test_GoTypeHighlight() abort
     let l:actual = s:typeHighlightGroup(l:kv[0], l:kv[1].value)
     call assert_equal(l:kv[1].group, l:actual, l:kv[0])
   endfor
-  unlet g:go_highlight_types
 endfunc
 
 function! s:typeHighlightGroup(testname, value)
@@ -564,6 +569,7 @@ endfunc
 
 function! Test_goFunction() abort
   syntax on
+  let g:go_gopls_enabled = 0
 
   let l:tests = {
         \ 'StandardFunction': {'group': 'goFunction', 'value': "F\x1f(){}"},
@@ -575,7 +581,6 @@ function! Test_goFunction() abort
     let l:actual = s:functionHighlightGroup(l:kv[0], l:kv[1].value)
     call assert_equal(l:kv[1].group, l:actual, l:kv[0])
   endfor
-  unlet g:go_highlight_functions
 endfunc
 
 function! s:functionHighlightGroup(testname, value)
@@ -597,6 +602,7 @@ endfunc
 
 function! Test_goFunctionCall() abort
   syntax on
+  let g:go_gopls_enabled = 0
 
   let l:tests = {
       \ 'StandardFunctionCall': {'group': 'goFunctionCall', 'value': "f\x1f()"},
@@ -608,7 +614,6 @@ function! Test_goFunctionCall() abort
     let l:actual = s:functionCallHighlightGroup(l:kv[0], l:kv[1].value)
     call assert_equal(l:kv[1].group, l:actual, l:kv[0])
   endfor
-  unlet g:go_highlight_function_calls
 endfunc
 
 function! s:functionCallHighlightGroup(testname, value)

--- a/autoload/go/impl_test.vim
+++ b/autoload/go/impl_test.vim
@@ -4,6 +4,7 @@ set cpo&vim
 
 func! Test_impl() abort
   try
+    let g:go_gopls_enabled = 0
     let l:tmp = gotest#write_file('a/a.go', [
           \ 'package a',
           \ '',
@@ -21,6 +22,7 @@ endfunc
 
 func! Test_impl_get() abort
   try
+    let g:go_gopls_enabled = 0
     let l:tmp = gotest#write_file('a/a.go', [
           \ 'package a',
           \ '',

--- a/autoload/go/import_test.vim
+++ b/autoload/go/import_test.vim
@@ -4,6 +4,7 @@ set cpo&vim
 
 func! Test_SwitchImportAddIgnoresCommented()
   try
+    let g:go_gopls_enabled = 0
     let l:tmp = gotest#write_file('import/import.go', [
           \ 'package import',
           \ '',

--- a/autoload/go/indent_test.vim
+++ b/autoload/go/indent_test.vim
@@ -5,6 +5,7 @@ set cpo&vim
 func! Test_indent_raw_string() abort
   " The goRawString discovery requires that syntax be enabled.
   syntax on
+  let g:go_gopls_enabled = 0
 
   try
     let l:dir= gotest#write_file('indent/indent.go', [

--- a/autoload/go/job_test.vim
+++ b/autoload/go/job_test.vim
@@ -8,6 +8,7 @@ func! Test_JobDirWithSpaces()
   endif
 
   try
+    let g:go_gopls_enabled = 0
     let l:filename = 'job/dir has spaces/main.go'
     let l:tmp = gotest#load_fixture(l:filename)
     call go#util#Chdir(printf('%s/src/job/dir has spaces', l:tmp))

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -3,10 +3,12 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 func! Test_GometaGolangciLint() abort
+  let g:go_gopls_enabled = 0
   call s:gometa('golangci-lint')
 endfunc
 
 func! Test_GometaStaticcheck() abort
+  let g:go_gopls_enabled = 0
   call s:gometa('staticcheck')
 endfunc
 
@@ -53,8 +55,6 @@ func! s:gometa(metalinter) abort
     call gotest#assert_quickfix(actual, expected)
   finally
       call call(RestoreGOPATH, [])
-      unlet g:go_metalinter_enabled
-      unlet g:go_metalinter_command
   endtry
 endfunc
 
@@ -90,16 +90,16 @@ endfunc
 "    call gotest#assert_quickfix(actual, expected)
 "  finally
 "      call call(RestoreGOPATH, [])
-"      unlet g:go_metalinter_enabled
-"      unlet g:go_metalinter_command
 "  endtry
 "endfunc
 
 func! Test_GometaAutoSaveGolangciLint() abort
+  let g:go_gopls_enabled = 0
   call s:gometaautosave('golangci-lint', 0)
 endfunc
 
 func! Test_GometaAutoSaveStaticcheck() abort
+  let g:go_gopls_enabled = 0
   call s:gometaautosave('staticcheck', 0)
 endfunc
 
@@ -107,15 +107,15 @@ func! Test_GometaAutoSaveGopls() abort
   let g:go_gopls_staticcheck = 1
   let g:go_diagnostics_level = 2
   call s:gometaautosave('gopls', 0)
-  unlet g:go_gopls_staticcheck
-  unlet g:go_diagnostics_level
 endfunc
 
 func! Test_GometaAutoSaveGolangciLintKeepsErrors() abort
+  let g:go_gopls_enabled = 0
   call s:gometaautosave('golangci-lint', 1)
 endfunc
 
 func! Test_GometaAutoSaveStaticcheckKeepsErrors() abort
+  let g:go_gopls_enabled = 0
   call s:gometaautosave('staticcheck', 1)
 endfunc
 
@@ -173,8 +173,6 @@ func! s:gometaautosave(metalinter, withList) abort
     call gotest#assert_quickfix(l:actual, l:expected)
   finally
     call delete(l:tmp, 'rf')
-    unlet g:go_metalinter_autosave_enabled
-    unlet g:go_metalinter_command
   endtry
 endfunc
 
@@ -214,8 +212,6 @@ endfunc
 "    call gotest#assert_quickfix(actual, expected)
 "  finally
 "      call call(RestoreGOPATH, [])
-"      unlet g:go_metalinter_enabled
-"      unlet g:go_metalinter_command
 "  endtry
 "endfunc
 "
@@ -251,8 +247,6 @@ endfunc
 "    call gotest#assert_quickfix(actual, expected)
 "  finally
 "    call call(RestoreGOPATH, [])
-"    unlet g:go_metalinter_autosave_enabled
-"    unlet g:go_metalinter_command
 "  endtry
 "endfunc
 "
@@ -294,12 +288,11 @@ func! s:gometa_multiple(metalinter) abort
     call gotest#assert_quickfix(actual, expected)
   finally
       call call(RestoreGOPATH, [])
-      unlet g:go_metalinter_enabled
-      unlet g:go_metalinter_command
   endtry
 endfunc
 
 func! Test_GometaAutoSaveGolangciLint_multiple() abort
+  let g:go_gopls_enabled = 0
   call s:gometaautosave_multiple('golangci-lint')
 endfunc
 
@@ -360,12 +353,11 @@ func! s:gometaautosave_multiple(metalinter) abort
     call gotest#assert_quickfix(actual, expected)
   finally
     call call(RestoreGOPATH, [])
-    unlet g:go_metalinter_autosave_enabled
-    unlet g:go_metalinter_command
   endtry
 endfunc
 
 func! Test_Vet() abort
+  let g:go_gopls_enabled = 0
   let l:tmp = gotest#load_fixture('lint/src/vet/vet.go')
 
   try
@@ -402,6 +394,7 @@ func! Test_Vet() abort
 endfunc
 
 func! Test_Vet_subdir() abort
+  let g:go_gopls_enabled = 0
   let l:tmp = gotest#load_fixture('lint/src/vet/vet.go')
 
   " go up one directory to easily test that go vet's file paths are handled
@@ -443,6 +436,7 @@ func! Test_Vet_subdir() abort
 endfunc
 
 func! Test_Vet_compilererror() abort
+  let g:go_gopls_enabled = 0
   let l:tmp = gotest#load_fixture('lint/src/vet/compilererror/compilererror.go')
 
   try
@@ -471,6 +465,7 @@ func! Test_Vet_compilererror() abort
 endfunc
 
 func! Test_Lint_GOPATH() abort
+  let g:go_gopls_enabled = 0
   let RestoreGO111MODULE = go#util#SetEnv('GO111MODULE', 'off')
   let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
 
@@ -512,6 +507,7 @@ func! Test_Lint_GOPATH() abort
 endfunc
 
 func! Test_Lint_NullModule() abort
+  let g:go_gopls_enabled = 0
   let RestoreGO111MODULE = go#util#SetEnv('GO111MODULE', 'off')
   silent exe 'e! ' . fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint/src/lint/baz.go'
   silent exe 'e! ' . fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint/src/lint/quux.go'
@@ -547,6 +543,7 @@ func! Test_Lint_NullModule() abort
 endfunc
 
 func! Test_Errcheck() abort
+  let g:go_gopls_enabled = 0
   let RestoreGOPATH = go#util#SetEnv('GOPATH', fnamemodify(getcwd(), ':p') . 'test-fixtures/lint')
   silent exe 'e! ' . $GOPATH . '/src/errcheck/errcheck.go'
 
@@ -570,6 +567,7 @@ func! Test_Errcheck() abort
 endfunc
 
 func! Test_Errcheck_options() abort
+  let g:go_gopls_enabled = 0
   let RestoreGOPATH = go#util#SetEnv('GOPATH', fnamemodify(getcwd(), ':p') . 'test-fixtures/lint')
   silent exe 'e! ' . $GOPATH . '/src/errcheck/errcheck.go'
 
@@ -592,6 +590,7 @@ func! Test_Errcheck_options() abort
 endfunc
 
 func! Test_Errcheck_compilererror() abort
+  let g:go_gopls_enabled = 0
   let l:tmp = gotest#load_fixture('lint/src/errcheck/compilererror/compilererror.go')
 
   try

--- a/autoload/go/lsp_test.vim
+++ b/autoload/go/lsp_test.vim
@@ -38,7 +38,6 @@ function! s:getinfo(str, name)
     call assert_equal(l:expected, l:actual)
   finally
     call delete(l:tmp, 'rf')
-    unlet g:go_info_mode
   endtry
 endfunction
 

--- a/autoload/go/tags_test.vim
+++ b/autoload/go/tags_test.vim
@@ -4,6 +4,7 @@ set cpo&vim
 
 func! TestAddTags() abort
   try
+    let g:go_gopls_enabled = 0
     let l:tmp = gotest#load_fixture('tags/add_all_input.go')
     silent call go#tags#run(0, 0, 40, "add", bufname(''), 1)
     call gotest#assert_fixture('tags/add_all_golden.go')
@@ -15,6 +16,7 @@ endfunc
 
 func! TestAddTags_WithOptions() abort
   try
+    let g:go_gopls_enabled = 0
     let l:tmp = gotest#load_fixture('tags/add_all_input.go')
     silent call go#tags#run(0, 0, 40, "add", bufname(''), 1, 'json,omitempty')
     call gotest#assert_fixture('tags/add_all_golden_options.go')
@@ -25,6 +27,7 @@ endfunc
 
 func! TestAddTags_AddOptions() abort
   try
+    let g:go_gopls_enabled = 0
     let l:tmp = gotest#load_fixture('tags/add_all_input.go')
     silent call go#tags#run(0, 0, 40, "add", bufname(''), 1, 'json')
     call gotest#assert_fixture('tags/add_all_golden.go')
@@ -37,6 +40,7 @@ endfunc
 
 func! Test_remove_tags() abort
   try
+    let g:go_gopls_enabled = 0
     let l:tmp = gotest#load_fixture('tags/remove_all_input.go')
     silent call go#tags#run(0, 0, 40, "remove", bufname(''), 1)
     call gotest#assert_fixture('tags/remove_all_golden.go')

--- a/autoload/go/template_test.vim
+++ b/autoload/go/template_test.vim
@@ -3,6 +3,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 func! Test_TemplateCreate() abort
+  let g:go_gopls_enabled = 0
   try
     let l:tmp = gotest#write_file('foo/empty.txt', [''])
 
@@ -31,6 +32,7 @@ endfunc
 
 func! Test_TemplateCreate_UsePkg() abort
   try
+    let g:go_gopls_enabled = 0
     let l:tmp = gotest#write_file('foo/empty.txt', [''])
 
     let g:go_template_use_pkg = 1
@@ -38,13 +40,13 @@ func! Test_TemplateCreate_UsePkg() abort
 
     call gotest#assert_buffer(0, ['package foo'])
   finally
-    unlet g:go_template_use_pkg
     call delete(l:tmp, 'rf')
   endtry
 endfunc
 
 func! Test_TemplateCreate_PackageExists() abort
   try
+    let g:go_gopls_enabled = 0
     let l:tmp = gotest#write_file('quux/quux.go', ['package foo'])
 
     edit quux/bar.go

--- a/autoload/go/term_test.vim
+++ b/autoload/go/term_test.vim
@@ -34,7 +34,6 @@ func! Test_GoTermNewMode()
     call win_gotoid(l:winid)
     only!
     call delete(l:tmp, 'rf')
-    unlet g:go_gopls_enabled
   endtry
 endfunc
 
@@ -71,7 +70,6 @@ func! Test_GoTermNewMode_SplitRight()
     only!
     call delete(l:tmp, 'rf')
     set nosplitright
-    unlet g:go_gopls_enabled
   endtry
 endfunc
 
@@ -123,9 +121,7 @@ func! Test_GoTermReuse()
   finally
     call win_gotoid(l:winid)
     only!
-    unlet g:go_term_reuse
     call delete(l:tmp, 'rf')
-    unlet g:go_gopls_enabled
   endtry
 endfunc
 

--- a/autoload/go/test_test.vim
+++ b/autoload/go/test_test.vim
@@ -80,7 +80,6 @@ func! Test_GoTestTimeout() abort
 
   let g:go_test_timeout="500ms"
   call s:test('timeout/timeout_test.go', expected)
-  unlet g:go_test_timeout
 endfunc
 
 func! Test_GoTestShowName() abort
@@ -93,7 +92,6 @@ func! Test_GoTestShowName() abort
 
   let g:go_test_show_name=1
   call s:test('showname/showname_test.go', expected)
-  unlet g:go_test_show_name
 endfunc
 
 func! Test_GoTestVet() abort
@@ -137,6 +135,7 @@ func! Test_GoTestExample() abort
 endfunc
 
 func! s:test(file, expected, ...) abort
+  let g:go_gopls_enabled = 0
   let $GOPATH = fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/test'
   call go#util#Chdir(printf('%s/src/%s', $GOPATH, fnamemodify(a:file, ':h')))
   silent exe 'e ' . $GOPATH . '/src/' . a:file

--- a/autoload/go/tool_test.vim
+++ b/autoload/go/tool_test.vim
@@ -3,6 +3,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 func! Test_ExecuteInDir() abort
+  let g:go_gopls_enabled = 0
   let l:tmp = gotest#write_file('a/a.go', ['package a'])
   try
     let l:cwd = go#util#Exec(['pwd'])
@@ -15,6 +16,7 @@ func! Test_ExecuteInDir() abort
 endfunc
 
 func! Test_ExecuteInDir_nodir() abort
+  let g:go_gopls_enabled = 0
   let l:tmp = go#util#tempdir("executeindir")
   exe ':e ' . l:tmp . '/new-dir/a'
 

--- a/autoload/gotest.vim
+++ b/autoload/gotest.vim
@@ -88,11 +88,11 @@ endfun
 " If a:skipHeader is true we won't bother with the package and import
 " declarations; so e.g.:
 "
-"     let l:diff = s:diff_buffer(1, ['_ = mail.Address{}'])
+"     let l:diff = s:assert_buffer(1, ['_ = mail.Address{}'])
 "
 " will pass, whereas otherwise you'd have to:
 "
-"     let l:diff = s:diff_buffer(0, ['package main', 'import "net/mail", '_ = mail.Address{}'])
+"     let l:diff = s:assert_buffer(0, ['package main', 'import "net/mail", '_ = mail.Address{}'])
 fun! gotest#assert_buffer(skipHeader, want) abort
   let l:buffer = go#util#GetLines()
 
@@ -117,7 +117,7 @@ fun! gotest#assert_buffer(skipHeader, want) abort
     call writefile(l:want, l:tmp . '/want')
     call go#fmt#run('gofmt', l:tmp . '/have', l:tmp . '/have')
     call go#fmt#run('gofmt', l:tmp . '/want', l:tmp . '/want')
-    let [l:out, l:err] = go#util#Exec(["diff", "-u", l:tmp . '/have', l:tmp . '/want'])
+    let [l:out, l:err] = go#util#Exec(["diff", "-u", l:tmp . '/want', l:tmp . '/have'])
   finally
     call delete(l:tmp . '/have')
     call delete(l:tmp . '/want')

--- a/scripts/runtest.vim
+++ b/scripts/runtest.vim
@@ -88,8 +88,6 @@ for s:test in sort(s:tests)
     sleep 50m
   catch
     call assert_report(printf('at %s: %s', v:throwpoint, v:exception))
-  finally
-    call s:clearOptions()
   endtry
 
   let s:elapsed_time = substitute(reltimestr(reltime(s:started)), '^\s*\(.\{-}\)\s*$', '\1', '')
@@ -104,6 +102,8 @@ for s:test in sort(s:tests)
     call go#lsp#Exit()
   catch /^Vim(call):E900: Invalid channel id/
     " do nothing - gopls has stopped
+  finally
+    call s:clearOptions()
   endtry
 
   let s:done += 1


### PR DESCRIPTION
##### tests: disable gopls when a test doesn't need it

Disable gopls in many tests that don't need it.

Move the clearing of options to after the the call to go#lsp#Exit in
scripts/runtest to that calling go#lsp#Exit doesn't trigger a new gopls
process to be started in case the test disabled gopls.

Remove unlet g:go_* statements in individual tests, because the runtest
scripts clears them all.


##### gotest: transpose diff arguments

Transpose the diff arguments so that the output is more similar to
"github.com/golang/go-cmp".Diff examples (i.e. '(-want, +got)') to
describe what's wrong instead of how to fix it.


##### fillstruct: remove spin waits in tests

go#fillstruct#FillStruct awaits async results from gopls, so there's no
need to spin wait.


