### PR TITLE
extract: add :GoExtract command and related mappings

### DIFF
--- a/autoload/go/extract.vim
+++ b/autoload/go/extract.vim
@@ -1,0 +1,25 @@
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+function! go#extract#Extract(selected) abort
+  if !go#config#GoplsEnabled()
+    call go#util#EchoError('GoExtract requires gopls, but gopls is disabled')
+    return
+  endif
+
+  " Extract requires a selection
+  if a:selected == -1
+    call go#util#EchoError('GoExtract requires a selection (range) of code')
+    return
+  endif
+
+  call go#lsp#Extract(a:selected)
+  return
+endfunction
+
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/extract_test.vim
+++ b/autoload/go/extract_test.vim
@@ -1,0 +1,47 @@
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+func! Test_Extract() abort
+  try
+    let l:tmp = gotest#write_file('a/a.go', [
+          \ 'package a',
+          \ '',
+          \ 'func f(v int) {',
+          \ '	for i := 0; i < v; i++ {',
+          \ "		p\x1f" . 'rintln("outputting something")',
+          \ '		println("i is ", i+1)',
+          \ '	}',
+          \ '}'])
+
+    silent! execute "normal vj$\<Esc>"
+
+    call go#extract#Extract(line('.'))
+
+    let start = reltime()
+    while &modified == 0 && reltimefloat(reltime(start)) < 10
+      sleep 100m
+    endwhile
+
+    call gotest#assert_buffer(1, [
+          \ 'func f(v int) {',
+          \ '	for i := 0; i < v; i++ {',
+          \ '		newFunction(i)',
+          \ '	}',
+          \ '}',
+          \ '',
+          \ 'func newFunction(i int) {',
+          \ '	println("outputting something")',
+          \ '	println("i is ", i+1)',
+          \ '}'])
+
+  finally
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et

--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -32,7 +32,7 @@ function! go#lsp#message#Initialize(wd) abort
                 \ 'codeAction': {
                 \   'codeActionLiteralSupport': {
                 \     'codeActionKind': {
-                \       'valueSet': ['source.organizeImports', 'refactor.rewrite'],
+                \       'valueSet': ['source.organizeImports', 'refactor.rewrite', 'refactor.extract'],
                 \     },
                 \   },
                 \ },
@@ -78,14 +78,18 @@ function! go#lsp#message#CodeActionImports(file) abort
 endfunction
 
 function! go#lsp#message#CodeActionFillStruct(file, line, col) abort
-  return go#lsp#message#CodeActionRefactorRewrite(a:file, a:line, a:col, a:line, a:col)
+  return go#lsp#message#CodeActionRefactor('rewrite', a:file, a:line, a:col, a:line, a:col)
 endfunction
 
-function! go#lsp#message#CodeActionRefactorRewrite(file, startline, startcol, endline, endcol) abort
+function! go#lsp#message#CodeActionRefactorExtract(file, startline, startcol, endline, endcol) abort
+  return go#lsp#message#CodeActionRefactor('extract', a:file, a:startline, a:startcol, a:endline, a:endcol)
+endfunction
+
+function! go#lsp#message#CodeActionRefactor(action, file, startline, startcol, endline, endcol) abort
   let l:startpos = s:position(a:startline, a:startcol)
   let l:endpos = s:position(a:endline, a:endcol)
 
-  let l:request = s:codeAction('refactor.rewrite', a:file)
+  let l:request = s:codeAction(printf('refactor.%s', a:action), a:file)
 
   let l:request.params = extend(l:request.params,
         \ {

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -942,6 +942,12 @@ CTRL-t
 :GoLSPDebugBrowser
 
     Open a browser to see gopls debugging information.
+                                                                 *:GoExtract*
+:GoExtract
+
+    Extract the code fragment in the selected range to a new function and
+    replace the fragment with call to the function.
+
 
 ==============================================================================
 MAPPINGS                                                        *go-mappings*
@@ -1197,6 +1203,9 @@ Calls `:GoDiagnostics`
                                                              *(go-fillstruct)*
                                                             *(go-fill-struct)*
 Calls `:GoFillStruct`
+
+                                                                *(go-extract)*
+Calls `:GoExtract`
 
 ==============================================================================
 TEXT OBJECTS                                                 *go-text-objects*

--- a/ftplugin/go/commands.vim
+++ b/ftplugin/go/commands.vim
@@ -137,4 +137,7 @@ command! -nargs=? GoModReload call go#lsp#ModReload()
 " -- term
 command! GoToggleTermCloseOnExit call go#term#ToggleCloseOnExit()
 
+" -- extract
+command! -range=% GoExtract call go#extract#Extract(<count>)
+
 " vim: sw=2 ts=2 et

--- a/ftplugin/go/mappings.vim
+++ b/ftplugin/go/mappings.vim
@@ -93,4 +93,6 @@ nnoremap <silent> <Plug>(go-diagnostics) :<C-u>call go#lint#Diagnostics(!g:go_ju
 
 nnoremap <silent> <Plug>(go-fill-struct) :<C-u>call go#fillstruct#FillStruct()<CR>
 
+xnoremap <silent> <Plug>(go-extract) :<C-u>call go#extract#Extract(0)<CR>
+
 " vim: sw=2 ts=2 et


### PR DESCRIPTION
Add GoExtract command and the go-extract mapping. It relies on gopls, which seems to be very finnicky regarding what can be extracted: it is very sensitive to leading and trailing spaces.