### PR TITLE
config: change default g:go_gorename_prefill value

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -393,8 +393,8 @@ endfunction
 
 function! go#config#GorenamePrefill() abort
   return get(g:, "go_gorename_prefill", 'expand("<cword>") =~# "^[A-Z]"' .
-          \ '? go#util#pascalcase(expand("<cword>"))' .
-          \ ': go#util#camelcase(expand("<cword>"))')
+          \ '? go#util#camelcase(expand("<cword>"))' .
+          \ ': go#util#pascalcase(expand("<cword>"))')
 endfunction
 
 function! go#config#TextobjIncludeFunctionDoc() abort


### PR DESCRIPTION
Change the default value of `g:go_gorename_prefill` so that the default value will be the other of camelCase or PascalCase than what the word under the cursor is.

Perhaps this shouldn't be merged. The [original rationale](https://github.com/fatih/vim-go/pull/1465#issuecomment-336641007) for preserving the case where the current behavior was introduced is worth considering. #3509 is an argument in favor of changing which casing is used by default.

With this change, it's relatively simple to use the `(go-rename)` map to change an identifier from exported to unexported and vice versa (e.g. `map <leader>r <Plug>(go-rename)`)