### PR TITLE
debug: record commands as objects

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -120,7 +120,7 @@ function! s:call_jsonrpc(handle_result, method, ...) abort
 
     if go#util#HasDebug('debugger-commands')
       let g:go_debug_commands = add(go#config#DebugCommands(), {
-            \ 'request':  l:req_json,
+            \ 'request':  json_decode(l:req_json)
       \ })
     endif
 
@@ -662,7 +662,7 @@ function! s:on_data(ch, data, ...) dict abort
 
     if go#util#HasDebug('debugger-commands')
       let g:go_debug_commands = add(go#config#DebugCommands(), {
-            \ 'response': l:data,
+            \ 'response': l:res,
       \ })
     endif
     call s:handleRPCResult(l:res)


### PR DESCRIPTION
Record debugger commands as objects instead of as strings. This makes it much easier to paste them into another window with `"=json_decode(g:go_debug_commands)p` and then format that window with jq to see a more readable json representation.