### PR TITLE
debug: halt on connect

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -634,7 +634,7 @@ function! s:connect(addr) abort
   let s:state['ready'] = 1
 
   " replace all the breakpoints set before delve started so that the ids won't overlap.
-  for l:bt in s:list_breakpoints()
+  for l:bt in s:list_breakpointsigns()
     call s:sign_unplace(l:bt.id, l:bt.file)
     call go#debug#Breakpoint(l:bt.line, l:bt.file)
   endfor
@@ -1308,7 +1308,7 @@ function! go#debug#Stack(name) abort
 
   " Add a breakpoint to the main.Main if the user didn't define any.
   " TODO(bc): actually set the breakpoint in main.Main
-  if len(s:list_breakpoints()) is 0
+  if len(s:list_breakpointsigns()) is 0
     if go#debug#Breakpoint() isnot 0
       let s:state.running = 0
       return
@@ -1453,7 +1453,7 @@ function! go#debug#Breakpoint(...) abort
   try
     " Check if we already have a breakpoint for this line.
     let l:found = {}
-    for l:bt in s:list_breakpoints()
+    for l:bt in s:list_breakpointsigns()
       if l:bt.file is# l:filename && l:bt.line is# l:linenr
         let l:found = l:bt
         break
@@ -1476,7 +1476,7 @@ function! go#debug#Breakpoint(...) abort
         let l:bt = l:res.result.Breakpoint
         call s:sign_place(l:bt.id, s:substituteRemotePath(l:bt.file), l:bt.line)
       else
-        let l:id = len(s:list_breakpoints()) + 1
+        let l:id = len(s:list_breakpointsigns()) + 1
         call s:sign_place(l:id, l:filename, l:linenr)
       endif
     endif
@@ -1506,7 +1506,7 @@ function! s:sign_place(id, expr, lnum) abort
   call sign_place(a:id, 'vim-go-debug', 'godebugbreakpoint', a:expr, {'lnum': a:lnum})
 endfunction
 
-function! s:list_breakpoints()
+function! s:list_breakpointsigns()
   let l:breakpoints = []
   let l:signs = s:sign_getplaced()
   for l:item in l:signs

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -1113,6 +1113,7 @@ function! s:show_goroutines(currentGoroutineID, res) abort
       return
     endif
 
+    let l:currentGoroutine = []
     for l:idx in range(len(l:goroutines))
       let l:goroutine = l:goroutines[l:idx]
       let l:goroutineType = ""

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -35,10 +35,9 @@ function! s:goroutineID() abort
 endfunction
 
 function! s:complete(job, exit_status, data) abort
-  let l:gotready = get(s:state, 'ready', 0)
   " copy messages to a:data _only_ when dlv exited non-zero and it was never
   " detected as ready (e.g. there was a compiler error).
-  if a:exit_status > 0 && !l:gotready
+  if a:exit_status > 0 && !s:isReady()
       " copy messages to data so that vim-go's usual handling of errors from
       " async jobs will occur.
       call extend(a:data, s:state['message'])
@@ -570,7 +569,7 @@ function! s:continue()
 endfunction
 
 function! s:err_cb(ch, msg) abort
-  if get(s:state, 'ready', 0) != 0
+  if s:isReady()
     call s:logger('ERR: ', a:ch, a:msg)
     return
   endif
@@ -579,7 +578,7 @@ function! s:err_cb(ch, msg) abort
 endfunction
 
 function! s:out_cb(ch, msg) abort
-  if get(s:state, 'ready', 0) != 0
+  if s:isReady()
     call s:logger('OUT: ', a:ch, a:msg)
     return
   endif


### PR DESCRIPTION
##### debug: use s:isReady() consistently


##### debug: set default value for current goroutine indicator

Sometimes execution will be halted at a time when there is no current
goroutine (e.g. the process is sleeping). Default the current goroutine
indicator so that trying to prepend the current goroutine to the list
does not cause an error.


##### debug: halt on connect

Always halt on connect so that :GoDebugConnect will halt the
application and set up breakpoints even when delve was started with
--continue.

It is safe to halt multiple times, so it won't matter what state the
debugger is in when halt is called.


##### debug: change function names for readability

Change function names for readability so that it is easier to reason
about what the code is doing.
* start_cb() -> create_layout()
* stack_cb() -> update_windows()


##### debug: s:list_breakpoints -> s:list_breakpointsigns

Rename s:list_breakpoints to s:list_breakpointsigns to disambiguate
whether the breakpoints as understood by the debugger, dlv, or or the
signs placed in the editor are returned.


##### debug: add breakpoint synchronization

Synchronize breakpoints whenever connecting to the debugger in case it
was started in multiclient mode and already has breakpoints set.


Fixes #3508