### PR TITLE
debug: do not change to a non-existent file

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -151,13 +151,16 @@ function! s:update_breakpoint(res) abort
   endif
 
   let s:state['currentThread'] = state.currentThread
+  let filename = s:substituteRemotePath(state.currentThread.file)
+  if filename == ''
+    return
+  endif
   let bufs = filter(map(range(1, winnr('$')), '[v:val,bufname(winbufnr(v:val))]'), 'v:val[1]=~"\.go$"')
   if len(bufs) == 0
     return
   endif
 
   call win_gotoid(win_getid(bufs[0][0]))
-  let filename = s:substituteRemotePath(state.currentThread.file)
   let linenr = state.currentThread.line
   let oldfile = fnamemodify(expand('%'), ':p:gs!\\!/!')
   if oldfile != filename


### PR DESCRIPTION
Do not try to change to a non-existent file in update_breakpoint. Trying to change to a non-existent file causes the file to not be changed, and s:sync_breakpoints to try to add a breakpoint for any missing signs twice.

Fixes #3518