### PR TITLE
cmd: make :GoRun async

### DIFF
--- a/autoload/go/cmd.vim
+++ b/autoload/go/cmd.vim
@@ -138,20 +138,6 @@ function! go#cmd#Run(bang, ...) abort
     return
   endif
 
-  if go#util#has_job()
-    " NOTE(arslan): 'term': 'open' case is not implement for +jobs. This means
-    " executions waiting for stdin will not work. That's why we don't do
-    " anything. Once this is implemented we're going to make :GoRun async
-  endif
-
-  let l:status = {
-        \ 'desc': 'current status',
-        \ 'type': 'run',
-        \ 'state': "started",
-        \ }
-
-  call go#statusline#Update(expand('%:p:h'), l:status)
-
   let l:cmd = ['go', 'run']
   let l:tags = go#config#BuildTags()
   if len(l:tags) > 0
@@ -165,6 +151,25 @@ function! go#cmd#Run(bang, ...) abort
   endif
 
   let l:cmd = l:cmd + l:files
+  " NOTE(arslan): 'term': 'open' case is not implement for +jobs. This means
+  " executions waiting for stdin will not work.
+  if go#util#has_job()
+    call s:cmd_job({
+        \ 'cmd': l:cmd,
+        \ 'bang': a:bang,
+        \ 'for': 'GoRun',
+        \ 'statustype': 'run',
+        \ 'errorformat': s:runerrorformat()
+        \})
+    return
+  endif
+
+  let l:status = {
+        \ 'desc': 'current status',
+        \ 'type': 'run',
+        \ 'state': "started",
+        \ }
+  call go#statusline#Update(expand('%:p:h'), l:status)
 
   if go#util#IsWin()
     if go#util#HasDebug('shell-commands')


### PR DESCRIPTION
Make go#cmd#Run execute `go run` asynchronously. This will slightly depart from the previous handling of stderr output. With the :make approach, any output to stderr will populate the quickfix window. When run as a job, though, the output will only be parsed as an error if the program being run exits non-zero. See
https://github.com/fatih/vim-go/issues/3085#issuecomment-725197402 for more information.

This is #3086 again. It needs more work before being merged in order to make sure the output is provided to the user to avoid #3523.