### PR TITLE
doc: add support for navigating doc from the doc window

### DIFF
--- a/ftplugin/godoc.vim
+++ b/ftplugin/godoc.vim
@@ -1,0 +1,25 @@
+" Copyright 2013 The Go Authors. All rights reserved.
+" Use of this source code is governed by a BSD-style
+" license that can be found in the LICENSE file.
+"
+" go.vim: Vim filetype plugin for Go.
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+" don't spam the user when Vim is started in Vi compatibility mode
+let s:cpo_save = &cpo
+set cpo&vim
+
+if get(g:, "go_doc_keywordprg_enabled", 1)
+  " keywordprg doesn't allow to use vim commands, override it
+  nnoremap <buffer> <silent> K :GoDoc<cr>
+endif
+
+" restore Vi compatibility settings
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: sw=2 ts=2 et

--- a/ftplugin/godoc/commands.vim
+++ b/ftplugin/godoc/commands.vim
@@ -1,0 +1,3 @@
+" -- doc
+command! -nargs=* -range -complete=customlist,go#package#Complete GoDoc call go#doc#Open('new', 'split', <f-args>)
+command! -nargs=* -range -complete=customlist,go#package#Complete GoDocBrowser call go#doc#OpenBrowser(<f-args>)

--- a/ftplugin/godoc/mappings.vim
+++ b/ftplugin/godoc/mappings.vim
@@ -1,0 +1,7 @@
+nnoremap <silent> <Plug>(go-doc) :<C-u>call go#doc#Open("new", "split")<CR>
+nnoremap <silent> <Plug>(go-doc-tab) :<C-u>call go#doc#Open("tabnew", "tabe")<CR>
+nnoremap <silent> <Plug>(go-doc-vertical) :<C-u>call go#doc#Open("vnew", "vsplit")<CR>
+nnoremap <silent> <Plug>(go-doc-split) :<C-u>call go#doc#Open("new", "split")<CR>
+nnoremap <silent> <Plug>(go-doc-browser) :<C-u>call go#doc#OpenBrowser()<CR>
+
+" vim: sw=2 ts=2 et


### PR DESCRIPTION
Add commands and mappings for godoc filetypes so that all the relevant commands from the go file type for doc are also available on the godoc filetype.

Resolves #3519