### PR TITLE
syntax: link goPredefinedIdentifiers to Constant

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -53,8 +53,11 @@ syn keyword     goBoolean                  true false
 syn keyword     goPredefinedIdentifiers    nil iota
 
 hi def link     goBuiltins                 Identifier
+hi def link     goPredefinedIdentifiers    Constant
+" Boolean links to Constant by default by vim: goBoolean and goPredefinedIdentifiers
+" will be highlighted the same, but having the separate allows users to have
+" separate highlighting for them if they desire.
 hi def link     goBoolean                  Boolean
-hi def link     goPredefinedIdentifiers    goBoolean
 
 " Comments; their contents
 syn keyword     goTodo              contained TODO FIXME XXX BUG


### PR DESCRIPTION
Link goPredefinedIdentifiers to Constant. This is a non-functional change, because goPredefinedIdentifier was previously linked to goBoolean, which in turn is linked to Boolean, which is linked to Constant by default by Vim. This change effectively spells goBoolean differently. The highlighting for goPredefinedIdentiifers remains the same as it was and users can still vary the highlighting of goBoolean and goPredefinedIdentifiers if they wish.