### PR TITLE
def: only use native tagstack when the t action is supported

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -214,7 +214,7 @@ function! go#def#jump_to_declaration(out, mode, bin_name) abort
   " also align the line to middle of the view
   normal! zz
 
-  if exists('*settagstack')
+  if exists('*settagstack') && has('patch-8.2.0077')
     " Jump was successful, write previous location to tag stack.
     let l:winid = win_getid()
     let l:stack = gettagstack(l:winid)


### PR DESCRIPTION
The action to support replacing the current stack from the current
position was only added in 8.0.0077, so check for that before trying to
use `settagstack`.

ref:
https://github.com/vim/vim/commit/271fa08a35b8d320d3a40db4ddae83b698fdd4fb