### PR TITLE
debug: handle error conditions

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -653,6 +653,9 @@ function! s:sync_breakpoints()
     let l:promise = go#promise#New(function('s:rpc_response'), 20000, {})
     call s:call_jsonrpc(l:promise.wrapper, 'RPCServer.ListBreakpoints', {'All': v:true})
     let l:res = l:promise.await()
+    if type(l:res) != v:t_dict || !has_key(l:res, 'result') || type(l:res.result) != v:t_dict || !has_key(l:res.result, 'Breakpoints')
+      call go#util#EchoError('could not list breakpoints')
+    endif
     let l:breakpoints = l:res.result.Breakpoints
 
     let l:signs = s:list_breakpointsigns()
@@ -798,7 +801,7 @@ function! s:handleRPCResult(resp) abort
     " response.
     call call(s:state.resultHandlers[l:id], [function('s:check_errors', [a:resp]), a:resp])
   catch
-    throw v:exception
+    throw substitute(v:exception, '^Vim', '', '')
   finally
     if has_key(s:state.resultHandlers, l:id)
       call remove(s:state.resultHandlers, l:id)
@@ -1446,7 +1449,7 @@ function! s:handleNextInProgress(res)
       endif
     endwhile
   catch
-    throw v:exception
+    throw substitute(v:exception, '^Vim', '', '')
   endtry
 endfunction
 


### PR DESCRIPTION
Rethrow Vim exceptions by stripping the Vim prefix.

Handle cases where ListBreakpoints response does not have the expected structure.

Relates to #3543