### PR TITLE
lsp: set clientInfo in Initialize

### DIFF
--- a/autoload/go/lsp/message.vim
+++ b/autoload/go/lsp/message.vim
@@ -8,6 +8,9 @@ function! go#lsp#message#Initialize(wd) abort
           \ 'method': 'initialize',
           \ 'params': {
             \ 'processId': getpid(),
+            \ 'clientInfo': {
+              \ 'name': 'vim-go',
+            \ },
             \ 'rootUri': go#path#ToURI(a:wd),
             \ 'capabilities': {
               \ 'workspace': {


### PR DESCRIPTION
Set clientInfo to allow telemetry to be used.

Relates to https://github.com/golang/go/issues/61038.

ref: https://go-review.googlesource.com/c/tools/+/506635