### PR TITLE
debug: fix mappings

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -630,8 +630,8 @@ function! s:connect(addr) abort
 
   let s:state['ch'] = l:ch
 
-  " Set running because so that the next go#debug#Stack call doesn't change
-  " operation to continue.
+  " Set running so that the next go#debug#Stack call doesn't change operation
+  " to continue.
   let s:state['running'] = 0
 
   " It is ok to halt whether whether delve was started with connect, debug, or
@@ -1370,9 +1370,9 @@ function! go#debug#Stack(name) abort
   if s:state.running is 0
     if l:name != 'halt'
       let l:name = 'continue'
+      let s:state.running = 1
+      call s:continue()
     endif
-    let s:state.running = 1
-    call s:continue()
   endif
 
   " Add a breakpoint to the main.Main if the user didn't define any.


### PR DESCRIPTION
Apply mappings in correct order.

s:create_layout configures only breakpoint and continue mappings. s:continue configures all the the debug related mappings. s:create_layout is called in s:connect after it calls go#debug#Stack('halt'), which in turn calls s:continue, so be sure to only call s:continue in go#debug#Stack when its single argument is not 'halt'.

Fixes #3568