### PR TITLE
Adds an option to disable gohtmltmpl

### DIFF
--- a/ftdetect/gofiletype.vim
+++ b/ftdetect/gofiletype.vim
@@ -7,7 +7,6 @@ set cpo&vim
 " Note: should not use augroup in ftdetect (see :help ftdetect)
 au BufRead,BufNewFile *.go setfiletype go
 au BufRead,BufNewFile *.s setfiletype asm
-au BufRead,BufNewFile *.tmpl set filetype=gohtmltmpl
 au BufRead,BufNewFile go.sum set filetype=gosum
 au BufRead,BufNewFile go.work.sum set filetype=gosum
 au BufRead,BufNewFile go.work set filetype=gowork


### PR DESCRIPTION
Added an option to disable automatic syntax highlighting for `gohtmltmpl`.

I wanted this behaviour because it conflicts with `.tmpl` files generated by [chezmoi](https://www.chezmoi.io/user-guide/templating/))