### PR TITLE
Add installation instructions for packer.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ for popular package managers:
   * `Plug 'fatih/vim-go', { 'do': ':GoUpdateBinaries' }`
 * [Vundle](https://github.com/VundleVim/Vundle.vim)
   * `Plugin 'fatih/vim-go'`
+* [Packer](https://github.com/wbthomason/packer.nvim)
+  * `use('fatih/vim-go', {run = ':GoUpdateBinaries'})`
 
 You will also need to install all the necessary binaries. vim-go makes it easy
 to install all of them by providing a command, `:GoInstallBinaries`, which will

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -114,6 +114,11 @@ manager's install command.
 *  https://github.com/gmarik/vundle >
 
     Plugin 'fatih/vim-go'
+
+*  https://github.com/wbthomason/packer.nvim
+
+    use('fatih/vim-go', {run = ':GoUpdateBinaries'})
+<
 <
 *  Manual (not recommended) >
 


### PR DESCRIPTION
Add installation section for [packer.nvim](https://github.com/wbthomason/packer.nvim). Since the user will want to run the post-install hook for `:GoUpdateBinaries`, I believe it would be nice to have a copy/paste statement for this.