### PR TITLE
Modify GoDoc split window key binding for GitBash compatibility

### DIFF
--- a/autoload/go/doc.vim
+++ b/autoload/go/doc.vim
@@ -208,7 +208,10 @@ function! s:GodocView(newposition, position, content, package) abort
   noremap <buffer> <silent> <Esc> :<C-U>close<CR>
   " make sure any key that sends an escape as a prefix (e.g. the arrow keys)
   " don't cause the window to close.
-  nnoremap <buffer> <silent> <Esc>[ <Esc>[
+  " exception on GitBash: https://stackoverflow.com/a/20458579
+  if system('uname') !~ 'MINGW'
+    nnoremap <buffer> <silent> <Esc>[ <Esc>[
+  endif
 endfunction
 
 " returns the package and exported name. exported name might be empty.


### PR DESCRIPTION
The following keybinding resolved leading escape as a prefix (e.g. arrow keys),
But on `GitBash`, as there is no escape when press arraw keys, the first key-press will have no response.

```vim
nnoremap <buffer> <silent> <Esc>[ <Esc[
```

Thus, I made a GitBash platform checking to skip the key binding.