### PR TITLE
mingw: Add platform checking of GoDocBrowser for Cygwin on windows

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -37,8 +37,9 @@ endfunction
 
 " IsWin returns 1 if current OS is Windows or 0 otherwise
 " Note that has('win32') is always 1 when has('win64') is 1, so has('win32') is enough.
+" has('win32unix') for GitBash (MSYS2, Cygwin)
 function! go#util#IsWin() abort
-  return has('win32')
+  return has('win32') || has('win32unix')
 endfunction
 
 " IsMac returns 1 if current OS is macOS or 0 otherwise.

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -37,7 +37,7 @@ endfunction
 
 " IsWin returns 1 if current OS is Windows or 0 otherwise
 " Note that has('win32') is always 1 when has('win64') is 1, so has('win32') is enough.
-" has('win32unix') for GitBash (MSYS2, Cygwin)
+" has('win32unix') for Cygwin (MSYS2, GitBash etc.)
 function! go#util#IsWin() abort
   return has('win32') || has('win32unix')
 endfunction


### PR DESCRIPTION
When using Cygwin/MSYS2 on windows, the `:GoDocBrowser` cannot popup the browser correctly.

Added `has('win32unix')` for platform compatibility.