### PR TITLE
mingw: Add platform checking of GoDocBrowser for Cygwin on windows

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -100,7 +100,7 @@ function! go#config#SnippetEngine() abort
 endfunction
 
 function! go#config#PlayBrowserCommand() abort
-    if go#util#IsWin()
+    if go#util#IsWin() || system('uname') =~ 'MINGW'
         let go_play_browser_command = '!start rundll32 url.dll,FileProtocolHandler %URL%'
     elseif go#util#IsMac()
         let go_play_browser_command = 'open %URL%'

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -100,8 +100,15 @@ function! go#config#SnippetEngine() abort
 endfunction
 
 function! go#config#PlayBrowserCommand() abort
-    if go#util#IsWin() || go#util#IsCygwin()
+    if go#util#IsWin()
         let go_play_browser_command = '!start rundll32 url.dll,FileProtocolHandler %URL%'
+    elseif go#util#IsCygwin()
+      " CYGWIN uses 'cygstart', whereas MSYS2 and GitBash uses 'start'
+      if system('uname') =~ 'CYGWIN'
+        let go_play_browser_command = '!cygstart rundll32 url.dll,FileProtoco          lHandler %URL%'
+      else
+        let go_play_browser_command = '!start rundll32 url.dll,FileProtocolHa          ndler %URL%'
+      endif
     elseif go#util#IsMac()
         let go_play_browser_command = 'open %URL%'
     elseif executable('xdg-open')

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -100,7 +100,7 @@ function! go#config#SnippetEngine() abort
 endfunction
 
 function! go#config#PlayBrowserCommand() abort
-    if go#util#IsWin() || system('uname') =~ 'MINGW'
+    if go#util#IsWin() || system('uname') =~ 'MINGW' || system('uname') =~ 'CYGWIN'
         let go_play_browser_command = '!start rundll32 url.dll,FileProtocolHandler %URL%'
     elseif go#util#IsMac()
         let go_play_browser_command = 'open %URL%'

--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -100,7 +100,7 @@ function! go#config#SnippetEngine() abort
 endfunction
 
 function! go#config#PlayBrowserCommand() abort
-    if go#util#IsWin() || system('uname') =~ 'MINGW' || system('uname') =~ 'CYGWIN'
+    if go#util#IsWin() || go#util#IsCygwin()
         let go_play_browser_command = '!start rundll32 url.dll,FileProtocolHandler %URL%'
     elseif go#util#IsMac()
         let go_play_browser_command = 'open %URL%'

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -37,9 +37,8 @@ endfunction
 
 " IsWin returns 1 if current OS is Windows or 0 otherwise
 " Note that has('win32') is always 1 when has('win64') is 1, so has('win32') is enough.
-" has('win32unix') for Cygwin (MSYS2, GitBash etc.)
 function! go#util#IsWin() abort
-  return has('win32') || has('win32unix')
+  return has('win32')
 endfunction
 
 " IsMac returns 1 if current OS is macOS or 0 otherwise.

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -51,13 +51,7 @@ endfunction
 
 " IsCygwin returns 1 if current OS is Cygwin/MSYS2/GitBash, 0 otherwise
 function! go#util#IsCygwin()
-  return !has('win32') &&
-        \ has('win32unix') &&
-        \ (
-        \ system('uname') =~ 'CYGWIN' ||
-        \ system('uname') =~ 'MINGW' ||
-        \ system('uname') =~ 'MSYS'
-        \ )
+  return has('win32unix')
 endfunction
 
  " Checks if using:

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -37,8 +37,9 @@ endfunction
 
 " IsWin returns 1 if current OS is Windows or 0 otherwise
 " Note that has('win32') is always 1 when has('win64') is 1, so has('win32') is enough.
+" has('win32unix') for GitBash (MSYS2, Cygwin)
 function! go#util#IsWin() abort
-  return has('win32')
+  return has('win32') || has('win32unix')
 endfunction
 
 " IsMac returns 1 if current OS is macOS or 0 otherwise.

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -49,6 +49,17 @@ function! go#util#IsMac() abort
         \ go#util#Exec(['uname'])[0] =~? '^darwin'
 endfunction
 
+" IsCygwin returns 1 if current OS is Cygwin/MSYS2/GitBash, 0 otherwise
+function! go#util#IsCygwin()
+  return !has('win32') &&
+        \ has('win32unix') &&
+        \ (
+        \ system('uname') =~ 'CYGWIN' ||
+        \ system('uname') =~ 'MINGW' ||
+        \ system('uname') =~ 'MSYS'
+        \ )
+endfunction
+
  " Checks if using:
  " 1) Windows system,
  " 2) And has cygpath executable,

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -37,7 +37,7 @@ endfunction
 
 " IsWin returns 1 if current OS is Windows or 0 otherwise
 " Note that has('win32') is always 1 when has('win64') is 1, so has('win32') is enough.
-" has('win32unix') for GitBash (MSYS2, Cygwin)
+" has('win32unix') for Cygwin (MSYS2, GitBash etc.)
 function! go#util#IsWin() abort
   return has('win32') || has('win32unix')
 endfunction

--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -529,6 +529,7 @@ function! go#util#OpenBrowser(url) abort
     if l:cmd =~ '^!'
         let l:cmd = substitute(l:cmd, '%URL%', '\=escape(shellescape(a:url), "#")', 'g')
         silent! exec l:cmd
+        redraw!
     elseif cmd =~ '^:[A-Z]'
         let l:cmd = substitute(l:cmd, '%URL%', '\=escape(a:url,"#")', 'g')
         exec l:cmd


### PR DESCRIPTION
* When using Cygwin/MSYS2 on windows, the `:GoDocBrowser` cannot popup the browser correctly.
   * Added `has('win32unix')` for platform compatibility.
* Also resolved vim screen mess up after using `:silent` with external command
   * refer to `:h :silent`
   * https://vi.stackexchange.com/questions/2809/silent-makes-my-vim-go-blank