### PR TITLE
mingw: Resolve path issue, make gopls work on GitBash (`:GoDoc`, `:GoInfo` and `:GoDef`)

### DIFF
--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -129,10 +129,8 @@ function! go#def#jump_to_declaration(out, mode, bin_name) abort
     let parts = split(out, '\(^[a-zA-Z]\)\@<!:')
   elseif has('win32unix')
     " remove comma in cygwin path e.g. '/c:/path'
-    if l:out[0:8] != '/cygdrive'
-      if l:out[2:3] is# ':/'
-        let l:out = l:out[0:1] . l:out[3:]
-      endif
+    if l:out[0:8] != '/cygdrive' && l:out[2:3] is# ':/'
+      let l:out = l:out[0:1] . l:out[3:]
     endif
     let parts = split(out, ':')
   else

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -127,7 +127,8 @@ function! go#def#jump_to_declaration(out, mode, bin_name) abort
   if go#util#IsWin()
     let parts = split(out, '\(^[a-zA-Z]\)\@<!:')
   elseif system('uname') =~ 'MINGW' || system('uname') =~ 'CYGWIN'
-    if l:msguri[2:3] is# ':/'
+    " remove comma from path before split. e.g. /c:/path to /c/path
+    if l:out[2:3] is# ':/'
       let l:out = l:out[0:1] . l:out[3:]
     endif
     let parts = split(out, ':')

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -126,8 +126,10 @@ function! go#def#jump_to_declaration(out, mode, bin_name) abort
   let out = split(final_out, go#util#LineEnding())[0]
   if go#util#IsWin()
     let parts = split(out, '\(^[a-zA-Z]\)\@<!:')
-  elseif (system('uname') =~ 'MINGW' || system('uname') =~ 'CYGWIN')
-    let l:out = l:out[0:1] . l:out[3:]
+  elseif system('uname') =~ 'MINGW' || system('uname') =~ 'CYGWIN'
+    if l:msguri[2:3] is# ':/'
+      let l:out = l:out[0:1] . l:out[3:]
+    endif
     let parts = split(out, ':')
   else
     let parts = split(out, ':')

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -124,12 +124,15 @@ function! go#def#jump_to_declaration(out, mode, bin_name) abort
 
   " strip line ending
   let out = split(final_out, go#util#LineEnding())[0]
+
   if go#util#IsWin()
     let parts = split(out, '\(^[a-zA-Z]\)\@<!:')
-  elseif system('uname') =~ 'MINGW' || system('uname') =~ 'CYGWIN'
-    " remove comma from path before split. e.g. /c:/path to /c/path
-    if l:out[2:3] is# ':/'
-      let l:out = l:out[0:1] . l:out[3:]
+  elseif has('win32unix')
+    " remove comma in cygwin path e.g. '/c:/path'
+    if l:out[0:8] != '/cygdrive'
+      if l:out[2:3] is# ':/'
+        let l:out = l:out[0:1] . l:out[3:]
+      endif
     endif
     let parts = split(out, ':')
   else

--- a/autoload/go/def.vim
+++ b/autoload/go/def.vim
@@ -126,6 +126,9 @@ function! go#def#jump_to_declaration(out, mode, bin_name) abort
   let out = split(final_out, go#util#LineEnding())[0]
   if go#util#IsWin()
     let parts = split(out, '\(^[a-zA-Z]\)\@<!:')
+  elseif (system('uname') =~ 'MINGW' || system('uname') =~ 'CYGWIN')
+    let l:out = l:out[0:1] . l:out[3:]
+    let parts = split(out, ':')
   else
     let parts = split(out, ':')
   endif

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -619,7 +619,7 @@ function! s:definitionHandler(next, msg) abort dict
   let l:msguri = go#path#FromURI(l:msg.uri)
   " remove the comma in cygwin unix-like windwos path
   " e.g. '/c:/path' to '/c/path'
-  if system('uname') =~ 'MINGW' || system('uname') =~ 'CYGWIN'
+  if has('win32unix') && (system('uname') =~ 'MINGW' || system('uname') =~ 'CYGWIN')
     if l:msguri[2:3] is# ':/'
       let l:msguri = l:msguri[0:1] . l:msguri[3:]
     endif

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -617,11 +617,16 @@ function! s:definitionHandler(next, msg) abort dict
   let l:msg = a:msg[0]
 
   let l:msguri = go#path#FromURI(l:msg.uri)
-  " remove the comma in cygwin unix-like windwos path
-  " e.g. '/c:/path' to '/c/path'
-  if has('win32unix') && (system('uname') =~ 'MINGW' || system('uname') =~ 'CYGWIN')
+
+  if has('win32unix')
+    " remove comma in cygwin path e.g. '/c:/path'
     if l:msguri[2:3] is# ':/'
       let l:msguri = l:msguri[0:1] . l:msguri[3:]
+    endif
+
+    " add 'cygdrive' for CYGWIN rather than MSYS2/GitBash
+    if system('uname') =~ 'CYGWIN'
+      let l:msguri = '/cygdrive' . l:msguri
     endif
   endif
 
@@ -631,7 +636,7 @@ function! s:definitionHandler(next, msg) abort dict
     return
   endif
 
-  let l:args = [[printf('%s:%d:%d: %s', go#path#FromURI(l:msg.uri), l:msg.range.start.line+1, go#lsp#lsp#PositionOf(l:line, l:msg.range.start.character), 'lsp does not supply a description')]]
+  let l:args = [[printf('%s:%d:%d: %s', l:msguri, l:msg.range.start.line+1, go#lsp#lsp#PositionOf(l:line, l:msg.range.start.character), 'lsp does not supply a description')]]
   call call(a:next, l:args)
 endfunction
 

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -616,7 +616,16 @@ function! s:definitionHandler(next, msg) abort dict
   " gopls returns a []Location; just take the first one.
   let l:msg = a:msg[0]
 
-  let l:line = s:lineinfile(go#path#FromURI(l:msg.uri), l:msg.range.start.line+1)
+  let l:msguri = go#path#FromURI(l:msg.uri)
+  " remove the comma in cygwin unix-like windwos path
+  " e.g. '/c:/path' to '/c/path'
+  if system('uname') =~ 'MINGW' || system('uname') =~ 'CYGWIN'
+    if l:msguri[2:3] is# ':/'
+      let l:msguri = l:msguri[0:1] . l:msguri[3:]
+    endif
+  endif
+
+  let l:line = s:lineinfile(l:msguri, l:msg.range.start.line+1)
   if l:line is -1
     call go#util#Warn('could not find definition')
     return

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -164,6 +164,10 @@ function! go#path#ToURI(path)
     let l:absolute = 1
     let l:prefix = '/' . l:path[0:1]
     let l:path = l:path[2:]
+  elseif (system('uname') =~ 'MINGW' || system('uname') =~ 'CYGWIN')
+    let l:absolute = 1
+    let l:prefix = l:path[0:1] . ':'
+    let l:path = l:path[2:3] is# ':/' ? l:path[3:] : l:path[2:]
   endif
 
   return substitute(

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -166,8 +166,13 @@ function! go#path#ToURI(path)
     let l:path = l:path[2:]
   elseif system('uname') =~ 'MINGW' || system('uname') =~ 'CYGWIN'
     let l:absolute = 1
-    let l:prefix = l:path[0:1] . ':'
-    let l:path = l:path[2:3] is# ':/' ? l:path[3:] : l:path[2:]
+    if l:path[0:8] == '/cygdrive'
+      let l:prefix = l:path[9:10] . ':'
+      let l:path = l:path[11:]
+    else
+      let l:prefix = l:path[0:1] . ':'
+      let l:path = l:path[2:3] is# ':/' ? l:path[3:] : l:path[2:]
+    endif
   endif
 
   return substitute(

--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -164,7 +164,7 @@ function! go#path#ToURI(path)
     let l:absolute = 1
     let l:prefix = '/' . l:path[0:1]
     let l:path = l:path[2:]
-  elseif (system('uname') =~ 'MINGW' || system('uname') =~ 'CYGWIN')
+  elseif system('uname') =~ 'MINGW' || system('uname') =~ 'CYGWIN'
     let l:absolute = 1
     let l:prefix = l:path[0:1] . ':'
     let l:path = l:path[2:3] is# ':/' ? l:path[3:] : l:path[2:]


### PR DESCRIPTION
This patch can resolve the following issues:

* #3602 
* #3447 

The root cause is that `gopls` cannot identify the correct path sent from `vim-go`.

GitBash mixed the 2 path systems (Win & Unix) which benefit from two world, but also brought some problem. The path like `/c/mypath` is used to represent the corresponding windows path `c:\mypath`. However, when communicating with `gopls`, the path `/c:/mypath` (please note there is a `:`) is used. It is probably because the GitBash parse the path from/to the `gopls` with a forward slash prefix `/`.

I didn't modify the logic of `go#util#IsWin()` because it is called by many places in the program, to prevent other issues happen. Instead, I treated the Cygwin (including MSYS2 and GitBash) system as another system (Neither Windows, nor Unix). 

Vim provide a cygwin checking `has('win32unix')` and it should be enough. Refer to the [bhcleek's reply](https://github.com/fatih/vim-go/pull/3611#discussion_r1435775625)

I have only tested `:GoDoc`, `:GoInfo` and `:GoDef`, which I think are the most popular functions for `GitBash` users.