### PR TITLE
util: Fix method not found `go#util#Warn` and `go#util#EchoWarn`

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -812,7 +812,7 @@ endfunction
 function! go#debug#TestFunc(...) abort
   let l:test = go#util#TestName()
   if l:test is ''
-    call go#util#Warn("vim-go: [debug] no test found immediate to cursor")
+    call go#util#EchoWarning("vim-go: [debug] no test found immediate to cursor")
     return
   endif
   call call('go#debug#Start', extend(['test', '.', '-test.run', printf('%s$', l:test)], a:000))

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -618,7 +618,7 @@ function! s:definitionHandler(next, msg) abort dict
 
   let l:line = s:lineinfile(go#path#FromURI(l:msg.uri), l:msg.range.start.line+1)
   if l:line is -1
-    call go#util#Warn('could not find definition')
+    call go#util#EchoWarning('could not find definition')
     return
   endif
 
@@ -651,7 +651,7 @@ function! s:typeDefinitionHandler(next, msg) abort dict
 
   let l:line = s:lineinfile(go#path#FromURI(l:msg.uri), l:msg.range.start.line+1)
   if l:line is -1
-    call go#util#Warn('could not find definition')
+    call go#util#EchoWarning('could not find definition')
     return
   endif
 
@@ -1866,7 +1866,7 @@ function s:applyDocumentChanges(changes)
 
       let l:editbufnr = bufnr(l:bufname)
       if l:editbufnr == -1
-        call go#util#EchoWarn(printf('could not apply changes to %s', l:fname))
+        call go#util#EchoWarning(printf('could not apply changes to %s', l:fname))
         continue
       endif
 


### PR DESCRIPTION
As captioned.

No method `go#util#Warn` and `go#util#EchoWarn` defined in `util.vim`.