### PR TITLE
lsp: log more efficiently

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -200,6 +200,10 @@ function! go#config#Debug() abort
   return get(g:, 'go_debug', [])
 endfunction
 
+function! go#config#DebugLogDelay() abort
+  return get(g:, 'go_debug_log_delay', 10)
+endfunction
+
 function! go#config#DebugWindows() abort
   return get(g:, 'go_debug_windows', {
             \ 'vars':  'leftabove 30vnew',

--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -1374,7 +1374,7 @@ function! s:debugasync(timer) abort
     " completion, because the window can not be changed while completion is in
     " progress.
     if len(s:log) != 0
-      let s:logtimer = timer_start(10, function('s:debugasync', []))
+      let s:logtimer = timer_start(go#config#DebugLogDelay(), function('s:debugasync', []))
     endif
   endtry
 endfunction
@@ -1384,7 +1384,7 @@ function! s:debug(event, data) abort
   let s:log = add(s:log, [a:event, a:data])
 
   if l:shouldStart
-    let s:logtimer = timer_start(10, function('s:debugasync', []))
+    let s:logtimer = timer_start(go#config#DebugLogDelay(), function('s:debugasync', []))
   endif
 endfunction
 


### PR DESCRIPTION
##### lsp: log more efficiently

* Do not log when in visual mode, select mode, or while waiting on
  completion. This keeps the screen from being cleared or from
  generating an exception when logging would otherwise change to the log
  window to scroll.
* Do not change to the log window merely to write to it. The only
  operation that is now required to change to the log window is to
  scroll it, so limit the time that it's the active window to that
  single operation.


