### PR TITLE
plugin: pin revive at v1.3.4

### DIFF
--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -46,7 +46,7 @@ let s:packages = {
       \ 'fillstruct':    ['github.com/davidrjenni/reftools/cmd/fillstruct@master'],
       \ 'godef':         ['github.com/rogpeppe/godef@latest'],
       \ 'goimports':     ['golang.org/x/tools/cmd/goimports@master'],
-      \ 'revive':        ['github.com/mgechev/revive@latest'],
+      \ 'revive':        ['github.com/mgechev/revive@v1.3.4'],
       \ 'gopls':         ['golang.org/x/tools/gopls@latest', {}, {'after': function('go#lsp#Restart', [])}],
       \ 'golangci-lint': ['github.com/golangci/golangci-lint/cmd/golangci-lint@latest'],
       \ 'staticcheck':   ['honnef.co/go/tools/cmd/staticcheck@latest'],


### PR DESCRIPTION
Pin revive at v1.3.4 until v1.3.6 is released, because v1.3.5 has a replace directive in its go.mod file, preventing revive from being installed via go install.