### PR TITLE
Add syntax support for toolchain directive

### DIFF
--- a/syntax/gomod.vim
+++ b/syntax/gomod.vim
@@ -11,12 +11,13 @@ syntax case match
 " https://golang.org/ref/mod#go-mod-file-grammar
 
 " match keywords
-syntax keyword gomodModule  module
-syntax keyword gomodGo      go      contained
-syntax keyword gomodRequire require
-syntax keyword gomodExclude exclude
-syntax keyword gomodReplace replace
-syntax keyword gomodRetract retract
+syntax keyword gomodModule     module
+syntax keyword gomodGo         go        contained
+syntax keyword gomodToolchain  toolchain contained
+syntax keyword gomodRequire    require
+syntax keyword gomodExclude    exclude
+syntax keyword gomodReplace    replace
+syntax keyword gomodRetract    retract
 
 " require, exclude, replace, and go can be also grouped into block
 syntax region gomodRequire start='require (' end=')' transparent contains=gomodRequire,gomodVersion
@@ -24,14 +25,16 @@ syntax region gomodExclude start='exclude (' end=')' transparent contains=gomodE
 syntax region gomodReplace start='replace (' end=')' transparent contains=gomodReplace,gomodVersion
 syntax region gomodRetract start='retract (' end=')' transparent contains=gomodVersionRange,gomodVersion
 syntax match  gomodGo            '^go .*$'           transparent contains=gomodGo,gomodGoVersion
+syntax match  gomodToolchain     '^toolchain .*$'    transparent contains=gomodToolchain,gomodToolchainVersion
 
 " set highlights
-highlight default link gomodModule  Keyword
-highlight default link gomodGo      Keyword
-highlight default link gomodRequire Keyword
-highlight default link gomodExclude Keyword
-highlight default link gomodReplace Keyword
-highlight default link gomodRetract Keyword
+highlight default link gomodModule     Keyword
+highlight default link gomodGo         Keyword
+highlight default link gomodToolchain  Keyword
+highlight default link gomodRequire    Keyword
+highlight default link gomodExclude    Keyword
+highlight default link gomodReplace    Keyword
+highlight default link gomodRetract    Keyword
 
 " comments are always in form of // ...
 syntax region gomodComment  start="//" end="$" contains=@Spell
@@ -44,6 +47,18 @@ highlight default link gomodString  String
 " replace operator is in the form of '=>'
 syntax match gomodReplaceOperator "\v\=\>"
 highlight default link gomodReplaceOperator Operator
+
+" match toolchain versions, based on https://go.dev/doc/toolchain#version,
+"  * default
+"  * go1
+"  * go1.X.Y
+"  * go1.X
+"  * go1.XrcN
+"  * go1.XrcN-somesuffix
+"  * go1.X.Y-somesuffix
+syntax match gomodToolchainVersion "default$" contained
+syntax match gomodToolchainVersion "go1\(.\d\+\)\{,2\}\(rc\d\+\)\?\([ \t-].*\)\?" contained
+highlight default link gomodToolchainVersion Identifier
 
 " match go versions
 syntax match gomodGoVersion "1\.\d\+" contained


### PR DESCRIPTION
This directive was added to `go.mod` with Go 1.21[1] So that this
directive can be highlighted in `go.mod`.

It's not entirely clear exactly what the fully supported syntax is. The
docs[1] suggests any Go release version, e.g.

* `go1.20`
* `go1.21.1`
* `go1.21.1rc1`

`golang.org/x/mod` gives a much more relaxed definition, requiring just
that things match against the regex `^default$|^go1($|\.)`[2]

Finally there's `FromToolchain` from the stdlib's internals for
processing versions[3] which is broader than that from[1] but more
limited than that from[2], supporting arbitrary suffixes (after any of
`" \t-"`) appended to the version, e.g.

* go1.21.3-somesuffix
* go1.21rc2-somesuffix
* go1.21 some-suffix

The approach taken for the syntax matching here is closest to this final
condition, and will not include some toolchain verison's that would be
supported by the `modfile` regex, e.g.

* go1.21.1blah
* go1.21!some-suffix

Since these would be rejected by the `go` tool itself with an error like

> go: invalid toolchain "go1.21.1blah" in go.mod