### PR TITLE
Update syntax for version in Go mod file directive

### DIFF
--- a/autoload/go/highlight_test.vim
+++ b/autoload/go/highlight_test.vim
@@ -784,6 +784,50 @@ function! Test_gomodToolchainVersion_invalid_highlight() abort
   endtry
 endfunc
 
+function! Test_gomodGoVersion() abort
+  try
+    syntax on
+
+    let g:go_gopls_enabled = 0
+    let l:wd = getcwd()
+    let l:dir = gotest#write_file('gomodtest/go.mod', [
+          \ 'module github.com/fatih/vim-go',
+          \ '',
+          \ 'go 1.20',
+          \ 'go 1.21',
+          \ 'go 1.21rc2',
+          \ 'go 1.21.1',
+          \ ''])
+
+    let l:lineno = 3
+    let l:lineclose = line('$')
+    while l:lineno < l:lineclose
+      let l:line = getline(l:lineno)
+      let l:split_idx = stridx(l:line, ' ')
+      let l:idx = len(l:line) - 1
+      let l:col = col([l:lineno, '$']) - 1
+
+      while l:idx > l:split_idx
+        call cursor(l:lineno, l:col)
+        let l:synname = synIDattr(synID(l:lineno, l:col, 1), 'name')
+        let l:errlen = len(v:errors)
+
+        call assert_equal('gomodGoVersion', l:synname, 'version on line ' . l:lineno . ' and col ' . l:col)
+        if l:errlen < len(v:errors)
+          break
+        endif
+
+        let l:col -= 1
+        let l:idx -= 1
+      endwhile
+      let l:lineno += 1
+    endwhile
+
+  finally
+    call go#util#Chdir(l:wd)
+    call delete(l:dir, 'rf')
+  endtry
+endfunc
 
 " restore Vi compatibility settings
 let &cpo = s:cpo_save

--- a/syntax/gomod.vim
+++ b/syntax/gomod.vim
@@ -61,7 +61,7 @@ syntax match gomodToolchainVersion "go1\(.\d\+\)\{,2\}\(rc\d\+\)\?\([ \t-].*\)\?
 highlight default link gomodToolchainVersion Identifier
 
 " match go versions
-syntax match gomodGoVersion "1\.\d\+" contained
+syntax match gomodGoVersion "\(1.\d\+\)\(\(.\d\+\)\|\(rc\d\+\)\)\?" contained
 highlight default link gomodGoVersion Identifier
 
 " highlight versions:


### PR DESCRIPTION
Since go1.21 this directive supports the same version format as the `toolchain` directive[1] (though it doesn't support any suffixes). Specifically it supports formats such as:

* `1.20` (this was supported previously)
* `1.21.0`
* `1.21rc1`

Note: patch versions do not have release candidates (e.g. `1.21.1rc2` is not valid)

[1] https://go.dev/ref/mod#go-mod-file-go