### PR TITLE
Fix `goPackageComment` highlighting too broad

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -448,12 +448,12 @@ if go#config#HighlightBuildConstraints() || go#config#FoldEnable('package_commen
   " matched as comments to avoid looking like working build constraints.
   " The he, me, and re options let the "package" itself be highlighted by
   " the usual rules.
-  exe 'syn region  goPackageComment    start=/\v(\/\/.*\n)+\s*package/'
-        \ . ' end=/\v\n\s*package/he=e-7,me=e-7,re=e-7'
+  exe 'syn region  goPackageComment    start=/\v(\/\/.*\n)+\s*package\s/'
+        \ . ' end=/\v\n\s*package\s/he=e-8,me=e-8,re=e-8'
         \ . ' contains=@goCommentGroup,@Spell'
         \ . (go#config#FoldEnable('package_comment') ? ' fold' : '')
-  exe 'syn region  goPackageComment    start=/\v^\s*\/\*.*\n(.*\n)*\s*\*\/\npackage/'
-        \ . ' end=/\v\*\/\n\s*package/he=e-7,me=e-7,re=e-7'
+  exe 'syn region  goPackageComment    start=/\v^\s*\/\*.*\n(.*\n)*\s*\*\/\npackage\s/'
+        \ . ' end=/\v\*\/\n\s*package\s/he=e-8,me=e-8,re=e-8'
         \ . ' contains=@goCommentGroup,@Spell'
         \ . (go#config#FoldEnable('package_comment') ? ' fold' : '')
   hi def link goPackageComment    Comment


### PR DESCRIPTION
Previously this would highlight any comment before a line starting `package`, for example

    var (
      // This comment would be highlighted as a goPackageComment
      packages []string
    )

The package clause is only valid when followed by a space[1], so include this restriction

[1] https://go.dev/ref/spec#Package_clause