### PR TITLE
lsp: fix text edit handling

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -1942,15 +1942,15 @@ function s:applyTextEdits(bufnr, msg) abort
     let l:startcontent = ''
     if l:msg.range.start.character > 0
       let l:startcontent = getline(l:startline)
-      let l:preSliceEnd = go#lsp#lsp#PositionOf(l:startcontent, l:msg.range.start.character-1) - 1
-      let l:startcontent = l:startcontent[:l:preSliceEnd]
+      let l:preSliceEnd = go#lsp#lsp#PositionOf(l:startcontent, l:msg.range.start.character-1)
+      let l:startcontent = strcharpart(l:startcontent, 0, l:preSliceEnd) "l:startcontent[:l:preSliceEnd]
     endif
 
     let l:endcontent = getline(l:endline)
     let l:postSliceStart = 0
     if l:msg.range.end.character > 0
       let l:postSliceStart = go#lsp#lsp#PositionOf(l:endcontent, l:msg.range.end.character-1)
-      let l:endcontent = l:endcontent[(l:postSliceStart):]
+      let l:endcontent = strcharpart(l:endcontent, l:postSliceStart) "l:endcontent[(l:postSliceStart):]
     endif
 
     " There isn't an easy way to replace the text in a byte or character

--- a/autoload/go/lsp/lsp_test.vim
+++ b/autoload/go/lsp/lsp_test.vim
@@ -13,8 +13,8 @@ function! Test_PositionOf_Start()
   let l:str = 'abcd'
   let l:actual = go#lsp#lsp#PositionOf(l:str, 0)
   call assert_equal(l:actual, 1)
-  " subtract one, because PositionOf returns a one-based cursor position and
-  " while string indices are zero based.
+  " subtract one, because PositionOf returns a one-based cursor position while
+  " string indices are zero based.
   call assert_equal(l:str[l:actual-1], 'a')
 endfunc
 

--- a/autoload/go/lsp_test.vim
+++ b/autoload/go/lsp_test.vim
@@ -79,6 +79,24 @@ func! Test_Format_SingleNewline() abort
   endtry
 endfunc
 
+func! Test_Format_Multibyte() abort
+  let l:wd = getcwd()
+  try
+    let expected = join(readfile("test-fixtures/lsp/fmt/multibyte_golden.go"), "\n")
+    let l:tmp = gotest#load_fixture('lsp/fmt/multibyte.go')
+
+    call go#lsp#Format()
+
+    " this should now contain the formatted code
+    let actual = join(go#util#GetLines(), "\n")
+
+    call assert_equal(expected, actual)
+  finally
+    call go#util#Chdir(l:wd)
+    call delete(l:tmp, 'rf')
+  endtry
+endfunc
+
 func! Test_Imports() abort
   let l:wd = getcwd()
   try

--- a/autoload/go/test-fixtures/lsp/fmt/multibyte.go
+++ b/autoload/go/test-fixtures/lsp/fmt/multibyte.go
@@ -1,0 +1,29 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("vim-go") // 中      asdfasdf
+	fmt.Println("vim-go") // 中 
+	fmt.Println("vim-go") // 中a
+	fmt.Println("vim-go") // 中 	a
+	fmt.Println("vim-go") // 中
+
+	fmt.Println("vim-go") // ⌘      asdfasdf
+	fmt.Println("vim-go") // ⌘  
+	fmt.Println("vim-go") // ⌘ a
+	fmt.Println("vim-go") // ⌘  	a
+	fmt.Println("vim-go") // ⌘
+
+	fmt.Println("vim-go") // é      asdfasdf
+	fmt.Println("vim-go") // é 
+	fmt.Println("vim-go") // é a
+	fmt.Println("vim-go") // é  	a
+	fmt.Println("vim-go") // é
+
+
+
+
+
+
+}

--- a/autoload/go/test-fixtures/lsp/fmt/multibyte_golden.go
+++ b/autoload/go/test-fixtures/lsp/fmt/multibyte_golden.go
@@ -1,0 +1,24 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("vim-go") // 中      asdfasdf
+	fmt.Println("vim-go") // 中
+	fmt.Println("vim-go") // 中a
+	fmt.Println("vim-go") // 中 	a
+	fmt.Println("vim-go") // 中
+
+	fmt.Println("vim-go") // ⌘      asdfasdf
+	fmt.Println("vim-go") // ⌘
+	fmt.Println("vim-go") // ⌘ a
+	fmt.Println("vim-go") // ⌘  	a
+	fmt.Println("vim-go") // ⌘
+
+	fmt.Println("vim-go") // é      asdfasdf
+	fmt.Println("vim-go") // é
+	fmt.Println("vim-go") // é a
+	fmt.Println("vim-go") // é  	a
+	fmt.Println("vim-go") // é
+
+}


### PR DESCRIPTION
Fix text edit handling when multi-byte characters are involved. Use strcharpart() instead of treating the text to be modified as a slice of bytes, because the output of go#lsp#PositionOf is character position, not byte position.

Fixes #3641