### PR TITLE
lsp: improve debug logging

### DIFF
--- a/autoload/go/lsp.vim
+++ b/autoload/go/lsp.vim
@@ -1363,6 +1363,7 @@ function! s:debugasync(timer) abort
       silent file `='__GOLSP_LOG__'`
       setlocal buftype=nofile bufhidden=wipe nomodified nobuflisted noswapfile nowrap nonumber nocursorline
       setlocal filetype=golsplog
+      setlocal fileencoding=utf-8
       call win_gotoid(l:winid)
     endif
 
@@ -1380,11 +1381,8 @@ function! s:debugasync(timer) abort
         call appendbufline(l:name, '$', split(l:data, "\r\n"))
       endfor
 
-      " TODO(bc): how to move the window's cursor position without switching
-      " to the window?
-      call win_gotoid(l:logwinid)
-      normal! G
-      call win_gotoid(l:winid)
+      " Move the window's cursor position without switching to the window
+      call win_execute(l:logwinid, 'normal! G')
       call setbufvar(l:name, '&modifiable', 0)
     finally
     endtry


### PR DESCRIPTION
* Use win_execute instead of win_gotoid when possible to avoid problems with textlock that can occur when completion is in progress. This isn't a full solution, so the retry has to remain in case the debug window is being created for the first time while completion is in progress. However, in nearly all other cases, the debug window will be able to be changed without making it the active window.
* Set the log's fileencoding to utf-8 so that multibyte characters will be displayed correctly.