### PR TITLE
guarding s:sign_place function to avoid exception.

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -1567,6 +1567,11 @@ function! s:sign_unplace(id, file) abort
 endfunction
 
 function! s:sign_place(id, expr, lnum) abort
+  " Check if lnum is less than 1 or expr is empty or null
+  if a:lnum < 1 || empty(a:expr)
+    return
+  endif
+
   if !exists('*sign_place')
     exe 'sign place ' . a:id . ' line=' . a:lnum . ' name=godebugbreakpoint file=' . a:expr
     return


### PR DESCRIPTION
when dlv started, there will be some default breakpoints created, some of them may have no line and file information, like "runtime-fatal-throw" breakpoint. check a:lnum and a:expr to avoid vim excption when sync breakpoints.