### PR TITLE
Fix highlighting import string followed by some comment

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -107,7 +107,7 @@ else
   syn region      goRawString         start=+`+ end=+`+
 endif
 
-syn match       goImportString      /^\%(\s\+\|import \)\(\h\w* \)\?\zs"[^"]\+"$/ contained containedin=goImport
+syn match       goImportString      /^\%(\s\+\|import \)\(\h\w* \)\?\zs"[^"]\+"/ contained containedin=goImport
 
 if go#config#HighlightFormatStrings()
   " [n] notation is valid for specifying explicit argument indexes


### PR DESCRIPTION
Fix #3656

Screenshot:

<img width="430" alt="image" src="https://github.com/fatih/vim-go/assets/823277/ce2a0e33-a398-41d5-b3ac-7335257ed417">
