### PR TITLE
Error window height depends on every error length

### DIFF
--- a/autoload/go/job.vim
+++ b/autoload/go/job.vim
@@ -228,7 +228,13 @@ function! go#job#Options(args)
     " only open the error window if user was still in the window from which
     " the job was started.
     if self.winid == l:winid
-      call go#list#Window(l:listtype, len(errors))
+      " height equal to sum of every error length divided by window width
+      let l:height = 0
+      for error in errors
+        let l:height += len(error.text) / winwidth(l:winid) + 1
+      endfor
+
+      call go#list#Window(l:listtype, l:height)
       if self.bang
         call win_gotoid(l:winid)
       else


### PR DESCRIPTION
When I have got long length errors it has been difficult to read in a window with not enough width.

I have tried to set wrap over quickfix but it didn't work because the height of the window depends on the number of errors and it does not depend on the error length.

Until now it has been the best option for me.

any other option to read long-length errors inside of the window with not enough width?

Thanks