### PR TITLE
scripts: handle egrep deprecation notice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.0
+FROM --platform=linux/amd64 golang:1.22.3
 
 RUN apt-get update -y --allow-insecure-repositories && \
   apt-get install -y build-essential curl git libncurses5-dev python3-pip && \

--- a/scripts/lint
+++ b/scripts/lint
@@ -54,9 +54,9 @@ lint=$(sh "$vimdir/share/vim/vimgo/pack/vim-go/start/vim-vimlint/bin/vimlint.sh"
   -c func_abort=1 \
   -e EVL110=1 -e EVL103=1 -e EVL104=1 -e EVL102=1 \
   "$vimgodir" \
-  2>&1 ||:)
-if [ -n "$lint" ]; then
-  echo "FAILED"
+  2>&1)
+result="$?"
+if [ "$result" -eq "2" ]; then
   echo "$lint"
   echo
   failed=6


### PR DESCRIPTION
Change scripts/lint to handle the deprecation warning about egrep that's reported on recent non-Debian systems by checking the exit code explicitly instead of merely checking for the presence of output.

Fixes #3635