### PR TITLE
debug: fix double substitution for paths in goto_file from stacktrace window

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -362,7 +362,7 @@ function! s:goto_file() abort
     return
   endif
   call win_gotoid(win_getid(bufs[0][0]))
-  let filename = s:substituteLocalPath(m[1])
+  let filename = m[1]
   let linenr = m[2]
   let oldfile = fnamemodify(expand('%'), ':p:gs!\\!/!')
   if oldfile != filename


### PR DESCRIPTION
When the content of the stacktrace window is computed in s:show_stacktrace(), s:substituteRemotePath() is already used to map remote paths to local paths. goto_file() is intended to jump to the desired location in the source code which resides on the local machine. Thus it should use the _local_ path and not translate the path back to the remote version.