### PR TITLE
debug: make local variables load config configurable

### DIFF
--- a/autoload/go/config.vim
+++ b/autoload/go/config.vim
@@ -217,6 +217,10 @@ function! go#config#LspLog() abort
   return g:go_lsp_log
 endfunction
 
+function! go#config#DebugLocalVariablesLoadConfig() abort
+  return get(g:, 'go_debug_local_variables_load_config', {'MaxStringLen': 20, 'MaxArrayValues': 20, 'MaxVariableRecurse': 10})
+endfunction
+
 function! go#config#SetDebugDiag(value) abort
   let g:go_debug_diag = a:value
 endfunction

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -1305,7 +1305,7 @@ function! s:update_variables() abort
   " MaxStructFields is the maximum number of fields read from a struct, -1 will read all fields.
   let l:cfg = {
         \ 'scope': {'GoroutineID': s:goroutineID()},
-        \ 'cfg':   {'MaxStringLen': 20, 'MaxArrayValues': 20, 'MaxVariableRecurse': 10}
+        \ 'cfg':   go#config#DebugLocalVariablesLoadConfig()
         \ }
 
   try

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -2461,7 +2461,7 @@ will suppress logging entirely.  Default: `'debugger,rpc'`:
   let g:go_debug_log_output = 'debugger,rpc'
 <
 
-                                                     *'g:go_highlight_debug'*
+                                                      *'g:go_highlight_debug'*
 
 Highlight the current line and breakpoints in the debugger.
 
@@ -2469,12 +2469,26 @@ Highlight the current line and breakpoints in the debugger.
   let g:go_highlight_debug = 1
 <
 
-                                         *'go:go_debug_breakpoint_sign_text'*
+                                           *'g:go_debug_breakpoint_sign_text'*
 
 Set the sign text used for breakpoints in the debugger. By default it's '>'.
 
 >
   let g:go_debug_breakpoint_sign_text = '>'
+<
+
+                                    *'g:go_debug_local_variables_load_config'*
+
+Set load configuration that is used to retrieve and display local variables in
+the variable window. For details about the values, refer to
+https://pkg.go.dev/github.com/go-delve/delve/service/api#LoadConfig .
+
+>
+  let g:go_debug_local_variables_load_config = {
+    \ 'MaxStringLen':       20,
+    \ 'MaxArrayValues':     20,
+    \ 'MaxVariableRecurse': 10,
+  \ }
 <
 
 ==============================================================================


### PR DESCRIPTION
Note though that usage of a `LoadConfig` is not consistent:
* If `debug.vim:s:eval()` is called directly, most notably from `s:expand_vars()` (i.e., when the user tries to expand a variable in the variable window), [`RPCServer.Eval()`](https://pkg.go.dev/github.com/go-delve/delve@v1.23.0/service/rpc2#RPCServer.Eval) is used which currently (i.e., delve@v1.23.0) does not allow to specify a `LoadConfig`.
* If `debug.vim:s:eval()` is called from `go#debug#Print()` (e.g., via `:GoDebugPrint`), [`RPCServer.Command()`](https://pkg.go.dev/github.com/go-delve/delve@v1.23.0/service/rpc2#RPCServer.Command) is used and [`DebuggerCommand`](https://pkg.go.dev/github.com/go-delve/delve@v1.23.0/service/api#DebuggerCommand) is provided with a `ReturnInfoLoadConfig`. However, those values and the values used in the variables window differ.