### PR TITLE
fix fatih/vim-go/issues/3690: set `noshellslash` only on win32

### DIFF
--- a/autoload/go/util.vim
+++ b/autoload/go/util.vim
@@ -314,7 +314,9 @@ function! go#util#Shelljoin(arglist, ...) abort
     endif
 
     let ssl_save = &shellslash
-    set noshellslash
+    if has("win32")
+      set noshellslash
+    endif
     if a:0
       return join(map(copy(a:arglist), 'shellescape(v:val, ' . a:1 . ')'), ' ')
     endif
@@ -332,7 +334,9 @@ endfunction
 function! go#util#Shelllist(arglist, ...) abort
   try
     let ssl_save = &shellslash
-    set noshellslash
+    if has("win32")
+      set noshellslash
+    endif
     if a:0
       return map(copy(a:arglist), 'go#util#Shelljoin(v:val, ' . a:1 . ')')
     endif
@@ -779,7 +783,7 @@ function! go#util#TestNamesInFile() abort
     call cursor(l:line-1, 1)
     let l:line = go#util#testLine()
   endwhile
- 
+
   call setpos('.', l:startpos)
 
   let l:tests = []


### PR DESCRIPTION
In neovim nightly, neovim/neovim/pull/28400 was merged:

> The value of shellslash should show true now outside of Windows.
> set shellslash should work on POSIX while set noshellslash will fail

This PR for vim-go wraps `set noshellslash` between a `if has("win32")` conditional to ensure that the functions no longer error in POSIX environments.