### PR TITLE
lint: uncomment tests

### DIFF
--- a/autoload/go/complete.vim
+++ b/autoload/go/complete.vim
@@ -43,7 +43,6 @@ function! go#complete#Complete(findstart, base) abort
     let s:completions = l:state.matches
 
     return go#lsp#lsp#PositionOf(getline(l:line+1), l:state.start-1)
-
   else "findstart = 0 when we need to return the list of completions
     return s:completions
   endif

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -512,25 +512,25 @@ func! Test_Lint() abort
   call s:testLint()
 endfunc
 
-"func! Test_Lint_GOPATH() abort
-"  let g:go_gopls_enabled = 0
-"  let RestoreGO111MODULE = go#util#SetEnv('GO111MODULE', 'off')
-"  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
-"
-"  call s:testLint()
-"
-"  call call(RestoreGOPATH, [])
-"  call call(RestoreGO111MODULE, [])
-"endfunc
+func! Test_Lint_GOPATH() abort
+  let g:go_gopls_enabled = 0
+  let RestoreGO111MODULE = go#util#SetEnv('GO111MODULE', 'off')
+  let RestoreGOPATH = go#util#SetEnv('GOPATH', fnameescape(fnamemodify(getcwd(), ':p')) . 'test-fixtures/lint')
 
-"func! Test_Lint_NullModule() abort
-"  let g:go_gopls_enabled = 0
-"  let RestoreGO111MODULE = go#util#SetEnv('GO111MODULE', 'off')
-"
-"  call s:testLint()
-"
-"  call call(RestoreGO111MODULE, [])
-"endfunc
+  call s:testLint()
+
+  call call(RestoreGOPATH, [])
+  call call(RestoreGO111MODULE, [])
+endfunc
+
+func! Test_Lint_NullModule() abort
+  let g:go_gopls_enabled = 0
+  let RestoreGO111MODULE = go#util#SetEnv('GO111MODULE', 'off')
+
+  call s:testLint()
+
+  call call(RestoreGO111MODULE, [])
+endfunc
 
 func! Test_Errcheck() abort
   let g:go_gopls_enabled = 0


### PR DESCRIPTION
Uncomment tests that were previously disabled due to a breaking change in revive.

This effectively reverts 15ae65272d46bdeae40fabebd5bab261966880c8.