### PR TITLE
rename: do not attempt to install gorename

### DIFF
--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -601,7 +601,7 @@ CTRL-t
     Changes the build tags for various commands. If you have any file that
     uses a custom build tag, such as `// +build integration`, this command
     can be used to pass it to all tools that accepts tags, such as gopls,
-    gorename, etc.
+    go test, etc.
 
     The build tags is cleared (unset) if `""` is given. If no arguments are
     given it prints the current build tags.

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -51,7 +51,6 @@ let s:packages = {
       \ 'golangci-lint': ['github.com/golangci/golangci-lint/cmd/golangci-lint@latest'],
       \ 'staticcheck':   ['honnef.co/go/tools/cmd/staticcheck@latest'],
       \ 'gomodifytags':  ['github.com/fatih/gomodifytags@latest'],
-      \ 'gorename':      ['golang.org/x/tools/cmd/gorename@master'],
       \ 'gotags':        ['github.com/jstemmer/gotags@master'],
       \ 'impl':          ['github.com/josharian/impl@main'],
       \ 'motion':        ['github.com/fatih/motion@latest'],


### PR DESCRIPTION
gorename has been removed from golang.org/x/tools/cmd, so remove it from the set of tools installed by vim-go.