### PR TITLE
update supported versions of Vim

### DIFF
--- a/.github/workflows/git.yml
+++ b/.github/workflows/git.yml
@@ -3,7 +3,7 @@ on: [pull_request]
 
 jobs:
   autosquash-commits-integrated:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,11 @@ jobs:
     - name: checkout
       uses: actions/checkout@v2.1.0
     - name: install vim
-      run: $GITHUB_WORKSPACE/scripts/install-vim vim-8.2
+      run: $GITHUB_WORKSPACE/scripts/install-vim vim-9.1
     - name: install tools
-      run: $GITHUB_WORKSPACE/scripts/install-tools vim-8.2
+      run: $GITHUB_WORKSPACE/scripts/install-tools vim-9.1
     - name: lint
-      run: $GITHUB_WORKSPACE/scripts/lint vim-8.2
+      run: $GITHUB_WORKSPACE/scripts/lint vim-9.1
   test:
     name: test
     runs-on: ubuntu-22.04
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         go: ['1.23','1.24']
-        vim: ['vim-8.1', 'vim-8.2', 'nvim']
+        vim: ['vim-8.2', 'vim-9.1', 'nvim']
     steps:
     - name: setup Go
       uses: actions/setup-go@v2.1.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: set up python
-      uses: actions/setup-python@v2.1.4
+      uses: actions/setup-python@v5.5.0
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: install vim-vint
       run: |
         python -m pip install --upgrade pip
@@ -35,9 +35,9 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
     - name: set up python
-      uses: actions/setup-python@v2.1.4
+      uses: actions/setup-python@v5.5.0
       with:
-        python-version: 3.6
+        python-version: 3.7
     - name: install covimerage
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
   lint:
     name: lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - name: set up python
       uses: actions/setup-python@v2.1.4
@@ -23,7 +23,7 @@ jobs:
       run: $GITHUB_WORKSPACE/scripts/lint vim-8.2
   test:
     name: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,15 @@ USER vim-go
 COPY scripts/install-vim /vim-go/scripts/install-vim
 WORKDIR /vim-go
 
-RUN scripts/install-vim vim-8.1
 RUN scripts/install-vim vim-8.2
+RUN scripts/install-vim vim-9.1
 RUN scripts/install-vim nvim
 
 COPY . /vim-go/
 WORKDIR /vim-go
 
-RUN scripts/install-tools vim-8.1
 RUN scripts/install-tools vim-8.2
+RUN scripts/install-tools vim-9.1
 RUN scripts/install-tools nvim
 
 ENTRYPOINT ["make"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VIMS ?= vim-8.1 vim-8.2 nvim
+VIMS ?= vim-8.2 vim-9.1 nvim
 TEST_FLAGS ?=
 
 all: install lint test
@@ -18,7 +18,7 @@ test:
 
 lint:
 	@echo "==> Running linting tools"
-	@./scripts/lint vim-8.2
+	@./scripts/lint vim-9.1
 
 docker:
 	@echo "==> Building/starting Docker container"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This plugin adds Go language support for Vim, with the following main features:
 
 ## Install
 
-vim-go requires at least Vim 8.1.2269 or Neovim 0.4.0.
+vim-go requires at least Vim 8.2.5072 or Neovim 0.4.0.
 
 The [**latest stable release**](https://github.com/fatih/vim-go/releases/latest) is the
 recommended version to use. If you choose to use the master branch instead,

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -771,7 +771,7 @@ function! s:message(buf, data) abort
     " and
     "     for every list you receive in a callback, all items except the first
     "     represent newlines.
-
+    call s:logger('DATA: ', '', printf('%s', a:data))
     let l:data = printf('%s%s', a:buf, a:data[0])
     for l:msg in a:data[1:]
       let l:data = printf("%s\n%s", l:data, l:msg)

--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -602,11 +602,11 @@ func! Test_Errcheck_compilererror() abort
 endfunc
 
 func! s:vimdir()
-  let l:vim = "vim-8.2"
+  let l:vim = "vim-9.1"
   if has('nvim')
     let l:vim = 'nvim'
-  elseif v:version == 810
-    let l:vim = 'vim-8.1'
+  elseif v:version == 820
+    let l:vim = 'vim-8.2'
   endif
 
   return l:vim

--- a/doc/vim-go.txt
+++ b/doc/vim-go.txt
@@ -75,7 +75,7 @@ experience.
 ==============================================================================
 INSTALL                                                           *go-install*
 
-vim-go requires at least Vim 8.1.2269 or Neovim 0.4.0. On macOS, if you are
+vim-go requires at least Vim 8.2.5072 or Neovim 0.4.0. On macOS, if you are
 still using your system version of vim, you can use homebrew to keep your
 version of Vim up-to-date with the following terminal command:
 >

--- a/plugin/go.vim
+++ b/plugin/go.vim
@@ -14,17 +14,17 @@ function! s:checkVersion() abort
     if has('nvim')
       let l:unsupported = !has('nvim-0.4.0')
     else
-      let l:unsupported = !has('patch-8.1.2269')
+      let l:unsupported = !has('patch-8.2.5072')
     endif
 
     if l:unsupported == 1
       echohl Error
-      echom "vim-go requires at least Vim 8.1.2269 or Neovim 0.4.0, but you're using an older version."
+      echom "vim-go requires at least Vim 8.2.5072 or Neovim 0.4.0, but you're using an older version."
       echom "Please update your Vim for the best vim-go experience."
       echom "If you really want to continue you can set this to make the error go away:"
       echom "    let g:go_version_warning = 0"
       echom "Note that some features may error out or behave incorrectly."
-      echom "Please do not report bugs unless you're using at least Vim 8.1.2269 or Neovim 0.4.0."
+      echom "Please do not report bugs unless you're using at least Vim 8.2.5072 or Neovim 0.4.0."
       echohl None
 
       " Make sure people see this.

--- a/scripts/bench-syntax
+++ b/scripts/bench-syntax
@@ -13,7 +13,7 @@ cd "$vimgodir"
 
 if [ -z "${1:-}" ]; then
   echo "unknown version: '${1:-}'"
-  echo "First argument must be 'vim-8.1', 'vim-8.2', or 'nvim'."
+  echo "First argument must be 'vim-8.2', 'vim-9.1', or 'nvim'."
   exit 1
 fi
 

--- a/scripts/install-vim
+++ b/scripts/install-vim
@@ -15,27 +15,27 @@ cd "$vimgodir"
 vim=${1:-}
 
 case "$vim" in
-  "vim-8.1")
+  "vim-8.2")
     # This follows the version in Ubuntu LTS. Vim's master branch isn't always
     # stable, and we don't want to have the build fail because Vim introduced a
     # bug.
-    tag="v8.1.2269"
+    tag="v8.2.5072"
     giturl="https://github.com/vim/vim"
 
     ;;
 
-  "vim-8.2")
+  "vim-9.1")
     # This is the version that's installed by homebrew currently. It doesn't
     # have to stay up to date with homebrew, and is only chosen here because
     # that's what homebrew was using at the the time and we need a version to
     # vimlint with.
-    tag="v8.2.0200"
+    tag="v9.1.1300"
     giturl="https://github.com/vim/vim"
     ;;
 
   "nvim")
     # Use latest stable version.
-    tag="v0.9.0"
+    tag="v0.9.1"
     giturl="https://github.com/neovim/neovim"
     ;;
 

--- a/scripts/lint
+++ b/scripts/lint
@@ -11,7 +11,7 @@ cd "$vimgodir"
 #####################################
 if [ -z "${1:-}" ]; then
   echo "unknown version: '${1:-}'"
-  echo "First argument must be 'vim-8.1', 'vim-8.2' or 'nvim'."
+  echo "First argument must be 'vim-8.2', 'vim-9.1' or 'nvim'."
 	exit 1
 fi
 

--- a/scripts/run-vim
+++ b/scripts/run-vim
@@ -17,7 +17,7 @@ shift $((OPTIND - 1))
 
 if [ -z "${1:-}" ]; then
   echo "unknown version: '${1:-}'"
-  echo "First argument must be 'vim-8.1', 'vim-8.2', or 'nvim'."
+  echo "First argument must be 'vim-8.2', 'vim-9.1', or 'nvim'."
   exit 1
 fi
 

--- a/scripts/test
+++ b/scripts/test
@@ -43,7 +43,7 @@ shift $((OPTIND - 1))
 #####################################
 if [ -z "${1:-}" ]; then
   echo "unknown version: '${1:-}'"
-  echo "First argument must be 'vim-8.1', 'vim-8.2', or 'nvim'."
+  echo "First argument must be 'vim-8.2', 'vim-9.1', or 'nvim'."
   exit 1
 fi
 


### PR DESCRIPTION
##### require at least Vim 8.2

Require at least Vim 8.2, which is what ships with the oldest Ubuntu LTS
that is still supported.


##### update supported vim versions

Update supported versions of vim and expected versions in tests. All
that was 8.1 becomes 8.2 and all that was 8.2 becomes 9.1.


##### use Python 3.7 for tests

* Use Python 3.7 for tests, because 3.6 is not available for Ubuntu
  22.04.
* Update setup-python from 2.1.4 to the latest, 5.5.0.


