### PR TITLE
debug: improve some logging bits

### DIFF
--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -72,6 +72,9 @@ function! s:logasync(timer) abort
     let l:name = '__GODEBUG_OUTPUT__'
     let l:log_winid = bufwinid(l:name)
     if l:log_winid == -1
+      if !s:isReady() && !has_key(s:state, 'job')
+        return
+      endif
       let s:logtimer = timer_start(go#config#DebugLogDelay(), function('s:logasync', []))
       return
     endif

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -6,7 +6,7 @@ scriptencoding utf-8
 
 if !exists('s:state')
   let s:state = {
-        \ 'rpcid': 1,
+        \ 'rpcid': 0,
         \ 'running': 0,
         \ 'currentThread': {},
         \ 'localVars': {},
@@ -1493,7 +1493,7 @@ function! go#debug#Restart() abort
     call s:stop()
 
     let s:state = {
-          \ 'rpcid': 1,
+          \ 'rpcid': 0,
           \ 'running': 0,
           \ 'currentThread': {},
           \ 'localVars': {},

--- a/autoload/go/debug.vim
+++ b/autoload/go/debug.vim
@@ -320,7 +320,13 @@ endfunction
 function! go#debug#Stop() abort
   " Remove all commands and add back the default commands.
   for k in map(split(execute('command GoDebug'), "\n")[1:], 'matchstr(v:val, "^\\s*\\zs\\S\\+")')
-    exe 'delcommand' k
+    try
+      if k is 'Name'
+        continue
+      endif
+      execute(printf('delcommand %s', k))
+    catch
+    endtry
   endfor
   command! -nargs=* -complete=customlist,go#package#Complete GoDebugStart call go#debug#Start('debug', <f-args>)
   command! -nargs=* -complete=customlist,go#package#Complete GoDebugTest  call go#debug#Start('test', <f-args>)
@@ -334,7 +340,10 @@ function! go#debug#Stop() abort
 
   " remove plug mappings
   for k in map(split(execute('nmap <Plug>(go-debug-'), "\n"), 'matchstr(v:val, "^n\\s\\+\\zs\\S\\+")')
-    execute(printf('nunmap %s', k))
+    try
+      execute(printf('nunmap %s', k))
+    catch
+    endtry
   endfor
 
   call s:stop()


### PR DESCRIPTION
##### debug: refactor logging

Refactor logging to support logging all messages, even those that
precede availability for the __GODEBUG_OUTPUT__ window.

Use functions instead of normal mode commands to manage the log window.


##### debug: fix off by one error in request ids

Start tracking the id on requests start at 1 instead of 2 by
initializing the value to 0; it's incremented before set on outgoing
requests.


##### debug: avoid cleanup errors

Do not attempt to delete a command based on the first line of output
from ":command GoDebug" trying to stop debugging. The error was causing
the function to be aborted, which was in turn causing Neovim to hang
when trying to quit.

Similarly, swallow exceptions when removing commands and mappings.


##### debug: do not reschedule log timer when stopping


