### PR TITLE
compiler: detect `GNUmakefile`

### DIFF
--- a/compiler/go.vim
+++ b/compiler/go.vim
@@ -19,7 +19,7 @@ endif
 
 let s:save_cpo = &cpo
 set cpo-=C
-if filereadable("makefile") || filereadable("Makefile")
+if filereadable("GNUmakefile") || filereadable("makefile") || filereadable("Makefile")
   CompilerSet makeprg=make
 else
   CompilerSet makeprg=go\ build


### PR DESCRIPTION
From `make(1)`:

If no -f option is present, make will look for the makefiles GNUmakefile, makefile, and Makefile, in that order.