### PR TITLE
issue.vim: fix template filename

### DIFF
--- a/autoload/go/issue.vim
+++ b/autoload/go/issue.vim
@@ -2,7 +2,7 @@
 let s:cpo_save = &cpo
 set cpo&vim
 
-let s:templatepath = go#util#Join(resolve(expand('<sfile>:p:h:h:h')), '.github', 'ISSUE_TEMPLATE.md')
+let s:templatepath = go#util#Join(resolve(expand('<sfile>:p:h:h:h')), '.github', 'issue_template.md')
 
 function! go#issue#New() abort
   let body = go#uri#Encode(s:issuebody())


### PR DESCRIPTION
Fix the template filename so that it is correct on case-sensitive file systems, too.

Fixes #3724