### PR TITLE
lint: fix golangci-lint tests

### DIFF
--- a/autoload/go/lint_test.vim
+++ b/autoload/go/lint_test.vim
@@ -54,7 +54,10 @@ func! s:gometa(metalinter) abort
 
     call gotest#assert_quickfix(actual, expected)
   finally
-      call call(RestoreGOPATH, [])
+    if a:metalinter == 'golangci-lint'
+      call go#util#Exec(['golangci-lint', 'cache', 'clean'])
+    endif
+    call call(RestoreGOPATH, [])
   endtry
 endfunc
 
@@ -173,6 +176,9 @@ func! s:gometaautosave(metalinter, withList) abort
 
     call gotest#assert_quickfix(l:actual, l:expected)
   finally
+    if a:metalinter == 'golangci-lint'
+      call go#util#Exec(['golangci-lint', 'cache', 'clean'])
+    endif
     call go#util#Chdir(l:wd)
     call delete(l:tmp, 'rf')
   endtry


### PR DESCRIPTION
Fix the golangci-lint tests that were failing for the metalinter autosave tests. This is a workaround for
https://github.com/golangci/golangci-lint/issues/3502.