### PR TITLE
Dedup tools install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update -y --allow-insecure-repositories && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN pip3 install vim-vint --break-system-packages
+RUN pip3 install setuptools==81.0.0 vim-vint --break-system-packages
 
 RUN useradd -ms /bin/bash -d /vim-go vim-go
 USER vim-go

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,6 @@ RUN scripts/install-vim nvim
 COPY . /vim-go/
 WORKDIR /vim-go
 
-RUN scripts/install-tools vim-8.2
 RUN scripts/install-tools vim-9.1
-RUN scripts/install-tools nvim
 
 ENTRYPOINT ["make"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.26.0
+FROM golang:1.26.0
 
 RUN apt-get update -y --allow-insecure-repositories && \
   apt-get install -y build-essential curl git libncurses5-dev python3-pip && \

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ install:
 	@echo "==> Installing Vims: $(VIMS)"
 	@for vim in $(VIMS); do \
 		./scripts/install-vim $$vim; \
-		./scripts/install-tools $$vim; \
 	done
+	./scripts/install-tools $(firstword $(VIMS));
 
 test:
 	@echo "==> Running tests for $(VIMS)"

--- a/scripts/install-tools
+++ b/scripts/install-tools
@@ -12,26 +12,32 @@ cd "$vimgodir"
 
 vim=${1:-}
 
-installdir="/tmp/vim-go-test/$1-install"
+toolsdir="/tmp/vim-go-test/tools-install"
+
+echo "Installing vim-go"
+mkdir -p "$toolsdir/share/vim/vimgo/pack/vim-go/start"
+ln -s "$vimgodir" "$toolsdir/share/vim/vimgo/pack/vim-go/start/vim-go"
 
 # Make sure all Go tools and other dependencies are installed.
 echo "Installing Go binaries"
-export GOPATH=$installdir
+export GOPATH=$toolsdir
 export GO111MODULE=on
 export PATH="${GOPATH}/bin:$PATH"
 "$vimgodir/scripts/run-vim" $vim +':silent :GoUpdateBinaries' +':qa'
 
 echo "Installing lint tools"
 (
-  mkdir -p "$installdir/share/vim/vimgo/pack/vim-go/start/"
-  cd "$installdir/share/vim/vimgo/pack/vim-go/start/"
+  cd "$toolsdir/share/vim/vimgo/pack/vim-go/start/"
   [ -d "vim-vimhelplint" ] || git clone --depth 1 --quiet https://github.com/machakann/vim-vimhelplint
   [ -d "vim-vimlparser" ]  || git clone --depth 1 --quiet https://github.com/ynkdir/vim-vimlparser
-  [ -d "vim-vimlint" ]     || git clone --depth 1 --quiet https://github.com/syngan/vim-vimlint
-  sed -e 's/^#set -x/set -x/g' -e 's/\<egrep\>/grep -E/g'  vim-vimlint/bin/vimlint.sh > vim-vimlint/bin/vimlint-grep.sh
-  chmod ugo+x vim-vimlint/bin/vimlint-grep.sh
+  [ -d "vim-vimlint" ]     || {
+    git clone --depth 1 --quiet https://github.com/syngan/vim-vimlint  && \
+    sed -e 's/^#set -x/set -x/g' -e 's/\<egrep\>/grep -E/g'  vim-vimlint/bin/vimlint.sh > vim-vimlint/bin/vimlint-grep.sh
+    chmod ugo+x vim-vimlint/bin/vimlint-grep.sh
+  }
+
 )
 
-echo "vim-go tools installed to: $installdir/share/vim/vimgo/pack/vim-go/start"
+echo "vim-go tools installed to: $toolsdir/share/vim/vimgo/pack/vim-go/start"
 
 # vim:ts=2:sts=2:sw=2:et

--- a/scripts/install-vim
+++ b/scripts/install-vim
@@ -9,9 +9,6 @@
 
 set -euC
 
-vimgodir=$(cd -P "$(dirname "$0")/.." > /dev/null && pwd)
-cd "$vimgodir"
-
 vim=${1:-}
 
 case "$vim" in
@@ -54,6 +51,11 @@ esac
 
 srcdir="/tmp/vim-go-test/$1-src"
 installdir="/tmp/vim-go-test/$1-install"
+toolsdir="/tmp/vim-go-test/tools-install"
+
+if [ ! -d "$toolsdir" ]; then
+  mkdir -p "$toolsdir"
+fi
 
 # Use cached installdir.
 if [ -d "$installdir" ]; then
@@ -76,13 +78,9 @@ if [ "$1" = "nvim" ]; then
   curl -Ls https://github.com/neovim/neovim/releases/download/$tag/nvim-linux64.tar.gz |
     tar xzf - -C /tmp/vim-go-test/
   mv /tmp/vim-go-test/nvim-linux64 /tmp/vim-go-test/nvim-install
-  mkdir -p "$installdir/share/nvim/runtime/pack/vim-go/start"
-  ln -s "$vimgodir" "$installdir/share/nvim/runtime/pack/vim-go/start/vim-go"
 
   # Consistent paths makes calling things easier.
   mv "$installdir/bin/nvim" "$installdir/bin/vim"
-  mkdir -p "$installdir/share/vim/vimgo/pack"
-  ln -s "$installdir/share/nvim/runtime/pack/vim-go" "$installdir/share/vim/vimgo/pack/vim-go"
 
 # Build Vim from source.
 else
@@ -95,8 +93,6 @@ else
 
   ./configure --prefix="$installdir" --with-features=huge --disable-gui
   make install
-  mkdir -p "$installdir/share/vim/vimgo/pack/vim-go/start"
-  ln -s "$vimgodir" "$installdir/share/vim/vimgo/pack/vim-go/start/vim-go"
 fi
 
 # Don't really need source after successful install.

--- a/scripts/lint
+++ b/scripts/lint
@@ -17,8 +17,9 @@ fi
 
 vim=$1
 vimdir="/tmp/vim-go-test/$vim-install"
-export GOPATH=$vimdir
-export PATH="${GOPATH}/bin:$PATH"
+toolsdir="/tmp/vim-go-test/tools-install"
+export GOPATH=$toolsdir
+export PATH="${GOPATH}/bin:$vimdir/bin:$PATH"
 
 if [ ! -f "$vimdir/bin/vim" ]; then
   printf "%s/bin/vim doesn't exist; did you install it with the install-vim script?\n" "$vimdir" >&2
@@ -48,9 +49,9 @@ fi
 ###################
 printf "Running vim-vimlint ... " >&2
 set +e
-lint=$(export VIMLINT_VIM='vim +"set maxfuncdepth=200"'; sh "$vimdir/share/vim/vimgo/pack/vim-go/start/vim-vimlint/bin/vimlint-grep.sh" \
-  -p "$vimdir/share/vim/vimgo/pack/vim-go/start/vim-vimlparser" \
-  -l "$vimdir/share/vim/vimgo/pack/vim-go/start/vim-vimlint" \
+lint=$(export VIMLINT_VIM="$vimdir"'/bin/vim +"set maxfuncdepth=200"'; sh "$toolsdir/share/vim/vimgo/pack/vim-go/start/vim-vimlint/bin/vimlint-grep.sh" \
+  -p "$toolsdir/share/vim/vimgo/pack/vim-go/start/vim-vimlparser" \
+  -l "$toolsdir/share/vim/vimgo/pack/vim-go/start/vim-vimlint" \
   -u \
   -c func_abort=1 \
   -e EVL110=1 -e EVL103=1 -e EVL104=1 -e EVL102=1 \
@@ -77,7 +78,7 @@ printf "Running vimhelplint ... " >&2
 
 # set modeline explicitly so that the modeline will be respected when run as root.
 lint=$($vimdir/bin/vim -esNR \
-  --cmd "set rtp+=$vimdir/share/vim/vimgo/pack/vim-go/start/vim-vimhelplint/" \
+  --cmd "set rtp+=$toolsdir/share/vim/vimgo/pack/vim-go/start/vim-vimhelplint/" \
   --cmd 'set modeline' \
   +'filetype plugin on' \
   +"e $vimgodir/doc/vim-go.txt" \

--- a/scripts/lint
+++ b/scripts/lint
@@ -31,9 +31,8 @@ failed=0
 printf "Running vint ... " >&2
 if [ -x "$(command -v vint)" ]; then
   lint=$(vint "$vimgodir" 2>&1 ||:)
-  if [ -n "$lint" ]; then
+  if ! vint "$vimgodir" 1>&2; then
     printf "FAILED\n" >&2
-    printf "$lint" >&2
     printf "\n" >&2
     # set failed to 3, because exit code 2 is used by python to indicate a problem running a command.
     failed=3

--- a/scripts/run-vim
+++ b/scripts/run-vim
@@ -22,7 +22,9 @@ if [ -z "${1:-}" ]; then
 fi
 
 dir="/tmp/vim-go-test/$1-install"
-export GOPATH=$dir
+toolsdir="/tmp/vim-go-test/tools-install"
+
+export GOPATH=$toolsdir
 export GO111MODULE=on
 export PATH="${GOPATH}/bin:$PATH"
 shift
@@ -35,13 +37,13 @@ fi
 if [ $coverage -eq 1 ]; then
   covimerage -q run --report-file /tmp/vim-go-test/cov-profile.txt --append \
     $dir/bin/vim --noplugin -u NONE -i NONE -N -n \
-      +"set shm+=WAFI rtp^=$vimgodir packpath=$dir/share/vim/vimgo" \
+      +"set shm+=WAFI rtp^=$vimgodir packpath=$toolsdir/share/vim/vimgo" \
       +'filetype plugin indent on' \
       +'packloadall!' \
       "$@"
 else
   $dir/bin/vim --noplugin -u NONE -i NONE -N -n \
-    +"set shm+=WAFI rtp^=$vimgodir packpath=$dir/share/vim/vimgo" \
+    +"set shm+=WAFI rtp^=$vimgodir packpath=$toolsdir/share/vim/vimgo" \
     +'filetype plugin indent on' \
     +'packloadall!' \
     "$@"

--- a/scripts/test
+++ b/scripts/test
@@ -49,7 +49,8 @@ fi
 
 vim=$1
 vimdir="/tmp/vim-go-test/$vim-install"
-export GOPATH=$vimdir
+toolsdir="/tmp/vim-go-test/tools-install"
+export GOPATH=$toolsdir
 export PATH="${GOPATH}/bin:$PATH"
 
 if [ ! -f "$vimdir/bin/vim" ]; then


### PR DESCRIPTION
##### omit FROM --platform in the Dockerfile

Remove --platform in the Dockerfile to squash the
FromPlatformFlagConstDisallowed warning and adhere to Docker best
practices (see
https://docs.docker.com/reference/build-checks/from-platform-flag-const-disallowed/).


##### pin Python setuptools version

Pin Python setuptools module version to 81.0.0, because vint has
dependencies on pkg_resources, which was removed in 82. See
https://discuss.python.org/t/pkg-resources-removal-how-to-go-from-there/106079

Update scripts/lint to check vint's exit code, because setuptools 81.0.0
outputs a warning about the deprecated pkg_resources module.


##### install tools only once in docker image

Only install the tools once in the Docker image and share them among all
versions of Vim that are used for testing. This is a big productivity
boost, because each installation of the tools takes several minutes.


