### PR TITLE
syntax: fix goVar and goConst highlighting bug

### DIFF
--- a/autoload/go/highlight_test.vim
+++ b/autoload/go/highlight_test.vim
@@ -900,6 +900,39 @@ function! Test_goPackageComment_highlight() abort
   endtry
 endfunc
 
+function! Test_goStringEscapedQuotesInVarBlockHighlight() abort
+  syntax on
+  let g:go_gopls_enabled = 0
+
+  let l:wd = getcwd()
+  let l:dir = gotest#write_file('highlight/escaped_quotes_var.go', [
+        \ 'package main',
+        \ '',
+        \ 'var (',
+        \ printf('%shost string', "\t"),
+        \ printf('%susage string = "" +', "\t"),
+        \ printf('%s"\"\""', "\t\t"),
+        \ ')',
+        \ '',
+        \ 'func main() {}',
+        \ ])
+
+  try
+    " Ensure string with escaped quotes inside var () is matched as goString (not goImportString)
+    call cursor(6, 3)
+    let l:str_syntax = synIDattr(synID(6, 3, 1), 'name')
+    call assert_equal('goString', l:str_syntax)
+
+    " Ensure subsequent function declaration syntax is not broken
+    call cursor(9, 1)
+    let l:func_syntax = synIDattr(synID(9, 1, 1), 'name')
+    call assert_equal('goDeclaration', l:func_syntax)
+  finally
+    call go#util#Chdir(l:wd)
+    call delete(l:dir, 'rf')
+  endtry
+endfunc
+
 " restore Vi compatibility settings
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -156,23 +156,24 @@ endif
 " var, const
 if go#config#FoldEnable('varconst')
   syn region    goVar               start='var ('   end='^\s*)$' transparent fold
-                                  \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+                                  \ contains=ALLBUT,goImport,goImportString,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
   syn match     goVar               /var ()/ transparent fold
                                   \ contains=goVar
   syn region    goConst             start='const (' end='^\s*)$' transparent fold
-                                  \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+                                  \ contains=ALLBUT,goImport,goImportString,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
   syn match     goConst             /const ()/ transparent fold
                                   \ contains=goConst
 else
   syn region    goVar               start='var ('   end='^\s*)$' transparent
-                                  \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+                                  \ contains=ALLBUT,goImport,goImportString,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
   syn match     goVar               /var ()/ transparent
                                   \ contains=goVar
   syn region    goConst             start='const (' end='^\s*)$' transparent
-                                  \ contains=ALLBUT,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
+                                  \ contains=ALLBUT,goImport,goImportString,goParen,goBlock,goFunction,goTypeName,goReceiverType,goReceiverVar,goParamName,goParamType,goSimpleParams,goPointerOperator
   syn match     goConst             /const ()/ transparent
                                   \ contains=goConst
 endif
+
 
 " Single-line var, const, and import.
 syn match       goSingleDecl        /\%(import\|var\|const\) [^(]\@=/ contains=goImport,goVar,goConst


### PR DESCRIPTION
Fix `goVar` and `goConst` hightlighting bug by excluding `goImportString` from `goVar` and `goConst` blocks.

Fixes https://github.com/fatih/vim-go/issues/3699