### PR TITLE
fix: don't use GOBIN env var if not defined

### DIFF
--- a/autoload/go/path.vim
+++ b/autoload/go/path.vim
@@ -80,7 +80,11 @@ function! go#path#BinPath() abort
   " we can use it, otherwise use default GOPATH
   let l:bin_path = go#util#env('gobin')
   if l:bin_path isnot ''
-    let l:bin_path = $GOBIN
+    if $GOBIN isnot ''
+      return $GOBIN
+    else
+      return l:bin_path
+    endif
   else
     let l:go_paths = split(go#path#Default(), go#util#PathListSep())
     if len(l:go_paths) == 0
@@ -88,7 +92,6 @@ function! go#path#BinPath() abort
     endif
     let l:bin_path = expand(l:go_paths[0] . '/bin/')
   endif
-
   return l:bin_path
 endfunction
 


### PR DESCRIPTION
This commit works around an issue I encountered wherein `gopls` fails to
load despite `:GoInstallBinaries` downloading and installing it. This
happened because I was using `asdf` to manage my Go version and `asdf`
does not set `$GOBIN` in the environment by default.

All that's being done here is getting `g:go_bin` to `$GOBIN` if its
defined in the environment (usually the case when you install `go` with
Homebrew or something like that) and sets it to the output of `go env
GOBIN` otherwise.

Signed-off-by: Carlos Nunez <13461447+carlosonunez@users.noreply.github.com>
